### PR TITLE
feat(mcp): improve configuration import/export and UI

### DIFF
--- a/src/renderer/components/mcp/config/import-export.tsx
+++ b/src/renderer/components/mcp/config/import-export.tsx
@@ -109,11 +109,16 @@ export function ImportExport({ variant = 'dropdown', onRefresh, isRefreshing = f
     if (!importPreview) return;
 
     setIsImporting(true);
-    
+
     try {
       await importConfiguration(importPreview);
       toast.success(t('import_export.import_success'));
       handleCloseImportDialog();
+
+      // Trigger parent refresh if available
+      if (onRefresh) {
+        onRefresh();
+      }
     } catch (error) {
       logger.mcp.error('MCP configuration import failed', { serverCount: getImportServerCount(), error: error instanceof Error ? error.message : error });
       toast.error(t('import_export.import_error'));

--- a/src/renderer/components/mcp/store-page/store-layout.tsx
+++ b/src/renderer/components/mcp/store-page/store-layout.tsx
@@ -248,11 +248,29 @@ export function StoreLayout({ mode }: StoreLayoutProps) {
               </div>
             </>
           ) : (
-            <div className="text-center py-12">
-              <p className="text-muted-foreground mb-4">{t('active.no_servers')}</p>
-              <p className="text-sm text-muted-foreground">
-                {t('active.switch_to_store')}
-              </p>
+            <div className="space-y-6">
+              <div className="text-center py-8">
+                <p className="text-muted-foreground mb-2">{t('active.no_servers')}</p>
+                <p className="text-sm text-muted-foreground">
+                  {t('active.switch_to_store')}
+                </p>
+              </div>
+
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {/* Add New Card - shown even when no servers */}
+                <Card className="p-6 border-dashed border-2 hover:border-primary/50 transition-colors cursor-pointer">
+                  <div
+                    className="flex flex-col items-center justify-center text-center h-full min-h-[200px]"
+                    onClick={() => setIsFullJSONEditorOpen(true)}
+                  >
+                    <Plus className="w-12 h-12 text-muted-foreground mb-4" />
+                    <h3 className="font-semibold mb-2">{t('active.add_custom')}</h3>
+                    <p className="text-sm text-muted-foreground">
+                      {t('active.edit_json')}
+                    </p>
+                  </div>
+                </Card>
+              </div>
             </div>
           )}
         </section>


### PR DESCRIPTION
- Add transport type normalization in mcpConfigManager (type <-> transport conversion)
- Auto-detect transport type on import (stdio for commands, http for URLs)
- Improve logging for configuration imports
- Trigger refresh after successful configuration import
- Show "Add Custom" card in store layout even when no servers are configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)