### PR TITLE
fix: restore MCP configuration panel with test functionality

### DIFF
--- a/src/renderer/components/mcp/config/json-editor-panel.tsx
+++ b/src/renderer/components/mcp/config/json-editor-panel.tsx
@@ -1,7 +1,12 @@
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
-import { AddMCPTabs } from './AddMCPTabs';
+import { useState, useEffect } from 'react';
+import { Sheet, SheetContent, SheetHeader, SheetTitle, SheetFooter } from '@/components/ui/sheet';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Loader2, AlertCircle } from 'lucide-react';
 import { useMCPStore } from '@/stores/mcpStore';
-import { useTranslation } from 'react-i18next';
+import { MCPServerConfig, MCPTool } from '@/types/mcp';
+import { MCPServerPreview } from './mcp-server-preview';
 
 interface JSONEditorPanelProps {
   serverId: string | null;
@@ -10,30 +15,249 @@ interface JSONEditorPanelProps {
 }
 
 export function JSONEditorPanel({ serverId, isOpen, onClose }: JSONEditorPanelProps) {
-  const { t } = useTranslation('mcp');
-  const { getServerById, getRegistryEntryById } = useMCPStore();
+  const { getServerById, getRegistryEntryById, updateServer, addServer } = useMCPStore();
 
-  const isCustomNewServer = serverId === 'new-custom-server';
-  const server = serverId && !isCustomNewServer ? getServerById(serverId) : null;
-  const registryEntry = serverId && !isCustomNewServer ? getRegistryEntryById(serverId) : null;
+  const [jsonText, setJsonText] = useState('');
+  const [jsonError, setJsonError] = useState<string | null>(null);
+  const [isTestingConnection, setIsTestingConnection] = useState(false);
+  const [testResult, setTestResult] = useState<{ success: boolean; message: string } | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [tools, setTools] = useState<MCPTool[]>([]);
+  const [isLoadingTools, setIsLoadingTools] = useState(false);
+
+  const server = serverId ? getServerById(serverId) : null;
+  const registryEntry = serverId ? getRegistryEntryById(serverId) : null;
   const isNewServer = !server;
 
-  const serverName = isCustomNewServer
-    ? t('config.new_server_name')
-    : (registryEntry?.name || serverId || 'MCP Server');
+  useEffect(() => {
+    if (isOpen && serverId) {
+      // Load initial JSON
+      if (server) {
+        // Existing server - load current config
+        const config = {
+          type: server.transport,
+          command: server.command,
+          args: server.args || [],
+          env: server.env || {},
+          ...(server.baseUrl && { baseUrl: server.baseUrl }),
+          ...(server.headers && { headers: server.headers })
+        };
+        setJsonText(JSON.stringify(config, null, 2));
+      } else if (registryEntry?.configuration?.template) {
+        // New server - load template
+        setJsonText(JSON.stringify(registryEntry.configuration.template, null, 2));
+      } else {
+        // Fallback empty template
+        setJsonText(JSON.stringify({
+          type: 'stdio',
+          command: '',
+          args: [],
+          env: {}
+        }, null, 2));
+      }
+      setJsonError(null);
+      setTestResult(null);
+    }
+  }, [isOpen, serverId, server, registryEntry]);
+
+  const validateJSON = (text: string): { valid: boolean; data?: any; error?: string } => {
+    try {
+      const parsed = JSON.parse(text);
+
+      // Validate required fields
+      if (!parsed.type) {
+        return { valid: false, error: 'Missing required field: type' };
+      }
+
+      if (parsed.type === 'stdio' && !parsed.command) {
+        return { valid: false, error: 'Missing required field: command (for stdio transport)' };
+      }
+
+      if ((parsed.type === 'http' || parsed.type === 'sse') && !parsed.baseUrl) {
+        return { valid: false, error: 'Missing required field: baseUrl (for http/sse transport)' };
+      }
+
+      return { valid: true, data: parsed };
+    } catch (error) {
+      return { valid: false, error: 'Invalid JSON syntax' };
+    }
+  };
+
+  const handleJSONChange = (text: string) => {
+    setJsonText(text);
+    const validation = validateJSON(text);
+    setJsonError(validation.error || null);
+  };
+
+  const handleTestConnection = async () => {
+    const validation = validateJSON(jsonText);
+    if (!validation.valid || !validation.data) {
+      setJsonError(validation.error || 'Invalid JSON');
+      return;
+    }
+
+    setIsTestingConnection(true);
+    setIsLoadingTools(true);
+    setTestResult(null);
+    setTools([]);
+
+    try {
+      const testConfig: MCPServerConfig = {
+        id: `test-${Date.now()}`,
+        name: registryEntry?.name || 'Test Server',
+        transport: validation.data.type,
+        command: validation.data.command,
+        args: validation.data.args || [],
+        env: validation.data.env || {},
+        baseUrl: validation.data.baseUrl,
+        headers: validation.data.headers
+      };
+
+      // Call IPC directly to get tools
+      const result = await window.levante.mcp.testConnection(testConfig);
+
+      setTestResult({
+        success: result.success,
+        message: result.success
+          ? 'Connection test successful! Server is responding correctly.'
+          : result.error || 'Connection test failed. Please check your configuration.'
+      });
+
+      // Set tools from the result
+      if (result.success && result.data) {
+        setTools(result.data);
+      }
+    } catch (error) {
+      setTestResult({
+        success: false,
+        message: 'Connection test failed with an unexpected error.'
+      });
+    } finally {
+      setIsTestingConnection(false);
+      setIsLoadingTools(false);
+    }
+  };
+
+  const handleSave = async () => {
+    const validation = validateJSON(jsonText);
+    if (!validation.valid || !validation.data || !serverId) {
+      setJsonError(validation.error || 'Invalid JSON');
+      return;
+    }
+
+    setIsSaving(true);
+
+    try {
+      const serverConfig: MCPServerConfig = {
+        id: serverId,
+        name: registryEntry?.name || serverId,
+        transport: validation.data.type,
+        command: validation.data.command,
+        args: validation.data.args || [],
+        env: validation.data.env || {},
+        baseUrl: validation.data.baseUrl,
+        headers: validation.data.headers
+      };
+
+      if (isNewServer) {
+        await addServer(serverConfig);
+      } else {
+        await updateServer(serverId, {
+          name: serverConfig.name,
+          command: serverConfig.command,
+          args: serverConfig.args,
+          env: serverConfig.env,
+          transport: serverConfig.transport,
+          baseUrl: serverConfig.baseUrl,
+          headers: serverConfig.headers
+        });
+      }
+
+      onClose();
+    } catch (error) {
+      setJsonError('Failed to save server configuration');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const validation = validateJSON(jsonText);
+  const serverName = registryEntry?.name || serverId || 'MCP Server';
 
   return (
     <Sheet open={isOpen} onOpenChange={onClose}>
       <SheetContent side="right" className="w-[900px] sm:max-w-[90vw] overflow-y-auto">
         <SheetHeader>
           <SheetTitle>
-            {isNewServer ? t('config.configure') : t('config.edit')} {serverName}
+            {isNewServer ? 'Configure' : 'Edit'} {serverName}
           </SheetTitle>
         </SheetHeader>
 
         <div className="py-6">
-          <AddMCPTabs serverId={serverId} onClose={onClose} />
+          <div className="grid grid-cols-2 gap-6">
+            {/* Left Column: JSON Editor */}
+            <div className="space-y-4">
+              <div>
+                <label className="text-sm font-medium mb-2 block">
+                  Server Configuration (JSON)
+                </label>
+                <Textarea
+                  value={jsonText}
+                  onChange={(e) => handleJSONChange(e.target.value)}
+                  className="font-mono text-sm min-h-[500px]"
+                  placeholder="Enter JSON configuration..."
+                />
+              </div>
+
+              {/* Validation Error */}
+              {jsonError && (
+                <Alert variant="destructive">
+                  <AlertCircle className="h-4 w-4" />
+                  <AlertDescription>{jsonError}</AlertDescription>
+                </Alert>
+              )}
+            </div>
+
+            {/* Right Column: Server Preview */}
+            <div>
+              <label className="text-sm font-medium mb-2 block">
+                Server Preview
+              </label>
+              <MCPServerPreview
+                serverName={serverName}
+                isValidJSON={validation.valid}
+                testResult={testResult}
+                tools={tools}
+                isTestingConnection={isTestingConnection}
+                isLoadingTools={isLoadingTools}
+                onTestConnection={handleTestConnection}
+              />
+            </div>
+          </div>
         </div>
+
+        <SheetFooter className="gap-2">
+          <Button
+            variant="outline"
+            onClick={onClose}
+            disabled={isSaving}
+          >
+            Cancel
+          </Button>
+          <Button
+            onClick={handleSave}
+            disabled={!!jsonError || isTestingConnection || isSaving}
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="w-4 h-4 animate-spin mr-2" />
+                Saving...
+              </>
+            ) : (
+              'Save'
+            )}
+          </Button>
+        </SheetFooter>
       </SheetContent>
     </Sheet>
   );


### PR DESCRIPTION
## Summary
- Restore the JSON editor panel to its original implementation from commit b0778c4
- Brings back the 2-column layout with MCPServerPreview component
- Re-enables MCP connection testing and tools visualization from the configuration panel

## Changes
- Restored `json-editor-panel.tsx` with the original grid layout
- Re-added MCPServerPreview component with test button
- Tools list now displays available MCP tools with their parameters

## Why
The previous refactor (commit d3399de) removed the ability to test MCP connections and view available tools directly from the configuration panel. This functionality is essential for debugging and validating MCP server configurations.

## Test Plan
- [ ] Open an existing MCP server configuration
- [ ] Verify the JSON editor appears on the left
- [ ] Verify the Server Preview appears on the right
- [ ] Click the "Test" button and verify connection status
- [ ] Verify tools list appears with expandable parameters
- [ ] Edit JSON configuration and save successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)