### PR TITLE
refactor: move image save to IPC for security

### DIFF
--- a/src/main/ipc/inferenceHandlers.ts
+++ b/src/main/ipc/inferenceHandlers.ts
@@ -1,7 +1,8 @@
-import { ipcMain } from 'electron';
+import { ipcMain, dialog, BrowserWindow } from 'electron';
 import { InferenceDispatcher } from '../services/inference/InferenceDispatcher';
 import type { InferenceCall } from '../../types/inference';
 import { getLogger } from '../services/logging';
+import * as fs from 'fs/promises';
 
 const logger = getLogger();
 
@@ -107,6 +108,54 @@ export function setupInferenceHandlers() {
       return {
         success: false,
         error: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  });
+
+  // Save image to disk with native dialog
+  ipcMain.removeHandler('levante/inference/save-image');
+  ipcMain.handle('levante/inference/save-image', async (event, dataUrl: string, defaultFilename: string) => {
+    try {
+      // Get the window that sent the request
+      const win = BrowserWindow.fromWebContents(event.sender);
+
+      const { filePath, canceled } = await dialog.showSaveDialog(win || {}, {
+        defaultPath: defaultFilename,
+        filters: [
+          { name: 'PNG Image', extensions: ['png'] },
+          { name: 'JPEG Image', extensions: ['jpg', 'jpeg'] },
+          { name: 'WebP Image', extensions: ['webp'] },
+          { name: 'All Images', extensions: ['png', 'jpg', 'jpeg', 'webp'] }
+        ]
+      });
+
+      if (canceled || !filePath) {
+        return { success: false, error: 'Save cancelled by user' };
+      }
+
+      // Extract base64 data from dataUrl
+      const matches = dataUrl.match(/^data:image\/(\w+);base64,(.+)$/);
+      if (!matches) {
+        throw new Error('Invalid image data URL format');
+      }
+
+      const base64Data = matches[2];
+      const buffer = Buffer.from(base64Data, 'base64');
+
+      // Write file to disk
+      await fs.writeFile(filePath, buffer);
+
+      logger.ipc.info('Image saved to disk', { filePath, size: buffer.length });
+
+      return {
+        success: true,
+        data: filePath
+      };
+    } catch (error) {
+      logger.ipc.error('Failed to save image', { error: error instanceof Error ? error.message : error });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error saving image'
       };
     }
   });

--- a/src/preload/api/inference.ts
+++ b/src/preload/api/inference.ts
@@ -25,4 +25,10 @@ export const inferenceApi = {
    */
   asr: (apiKey: string, model: string, audioBuffer: ArrayBuffer, options?: any) =>
     ipcRenderer.invoke('levante/inference/asr', apiKey, model, audioBuffer, options),
+
+  /**
+   * Save image to disk with native save dialog
+   */
+  saveImage: (dataUrl: string, defaultFilename: string) =>
+    ipcRenderer.invoke('levante/inference/save-image', dataUrl, defaultFilename),
 };

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -102,6 +102,7 @@ export interface LevanteAPI {
     textToImage: (apiKey: string, model: string, prompt: string, options?: any) => Promise<{ success: boolean; data?: any; error?: string }>;
     imageToText: (apiKey: string, model: string, imageBuffer: ArrayBuffer, options?: any) => Promise<{ success: boolean; data?: any; error?: string }>;
     asr: (apiKey: string, model: string, audioBuffer: ArrayBuffer, options?: any) => Promise<{ success: boolean; data?: any; error?: string }>;
+    saveImage: (dataUrl: string, defaultFilename: string) => Promise<{ success: boolean; data?: string; error?: string }>;
   };
 
   // Database functionality

--- a/src/renderer/components/inference/TextToImagePanel.tsx
+++ b/src/renderer/components/inference/TextToImagePanel.tsx
@@ -68,15 +68,15 @@ export function TextToImagePanel() {
     await textToImage(selectedModel, prompt, options);
   };
 
-  const handleDownload = () => {
+  const handleDownload = async () => {
     if (!result || result.kind !== 'image') return;
 
-    const link = document.createElement('a');
-    link.href = result.dataUrl;
-    link.download = `generated-${Date.now()}.png`;
-    document.body.appendChild(link);
-    link.click();
-    document.body.removeChild(link);
+    const defaultFilename = `generated-${Date.now()}.png`;
+    const response = await window.levante.inference.saveImage(result.dataUrl, defaultFilename);
+
+    if (!response.success && response.error !== 'Save cancelled by user') {
+      console.error('Failed to save image:', response.error);
+    }
   };
 
   const handleKeyDown = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {


### PR DESCRIPTION
## Summary
- Replace direct DOM-based file download with IPC handler using Electron's native save dialog
- Ensures disk writes are controlled by the main process for better security
- Uses `dialog.showSaveDialog` for native OS file picker experience

## Test plan
- [ ] Generate an image using text-to-image
- [ ] Click "Download Image" button
- [ ] Verify native save dialog appears
- [ ] Confirm file is saved correctly to selected location

🤖 Generated with [Claude Code](https://claude.com/claude-code)