### PR TITLE
feat: make MCP provider source badge clickable with homepage link

### DIFF
--- a/src/main/services/mcp/MCPProviderService.ts
+++ b/src/main/services/mcp/MCPProviderService.ts
@@ -14,6 +14,7 @@ export interface MCPProvider {
   type: 'local' | 'github' | 'api';
   endpoint: string;
   enabled: boolean;
+  homepage?: string;
   lastSynced?: string;
   serverCount?: number;
   config?: {

--- a/src/renderer/components/mcp/store-page/integration-card.tsx
+++ b/src/renderer/components/mcp/store-page/integration-card.tsx
@@ -5,13 +5,6 @@ import { Badge } from '@/components/ui/badge';
 import { Switch } from '@/components/ui/switch';
 import {
   Settings,
-  FolderOpen,
-  Search,
-  Github,
-  Database,
-  MessageSquare,
-  Globe,
-  Cloud,
   Trash2,
   Loader2
 } from 'lucide-react';
@@ -28,6 +21,7 @@ import {
 import { MCPRegistryEntry, MCPServerConfig, MCPConnectionStatus } from '@/types/mcp';
 import { ConnectionStatus } from '../connection/connection-status';
 import { useTranslation } from 'react-i18next';
+import { useMCPStore } from '@/stores/mcpStore';
 
 interface IntegrationCardProps {
   mode: 'active' | 'store';
@@ -42,16 +36,6 @@ interface IntegrationCardProps {
   onDelete?: () => void;
 }
 
-const iconMap = {
-  folder: FolderOpen,
-  search: Search,
-  github: Github,
-  database: Database,
-  'message-square': MessageSquare,
-  globe: Globe,
-  cloud: Cloud,
-};
-
 export function IntegrationCard({
   mode,
   entry,
@@ -65,12 +49,14 @@ export function IntegrationCard({
   onDelete
 }: IntegrationCardProps) {
   const { t } = useTranslation('mcp');
+  const { providers } = useMCPStore();
   const displayName = entry?.name || server?.name || server?.id || t('server.unknown');
   const description = entry?.description || t('server.custom_description');
   const category = entry?.category || 'custom';
-  const iconName = entry?.icon || 'folder';
 
-  const IconComponent = iconMap[iconName as keyof typeof iconMap] || FolderOpen;
+  // Get provider homepage if available
+  const provider = providers.find(p => p.id === entry?.source);
+  const providerHomepage = provider?.homepage;
 
   const [showDeleteDialog, setShowDeleteDialog] = React.useState(false);
 
@@ -83,26 +69,32 @@ export function IntegrationCard({
     onDelete?.();
   };
 
+  const handleSourceClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    if (providerHomepage) {
+      window.levante.openExternal(providerHomepage);
+    }
+  };
+
   return (
     <Card className="relative overflow-hidden border-none">
       <CardContent className="p-6">
         <div className="flex items-start justify-between mb-4">
-          <div className="flex items-center gap-3">
-            <div className="p-2 bg-muted rounded-md">
-              <IconComponent className="w-5 h-5" />
-            </div>
-            <div>
-              <h3 className="font-semibold text-lg">{displayName}</h3>
-              <div className="flex items-center gap-1.5">
-                <Badge variant="secondary" className="text-xs">
-                  {category}
+          <div>
+            <h3 className="font-semibold text-lg">{displayName}</h3>
+            <div className="flex items-center gap-1.5">
+              <Badge variant="secondary" className="text-xs">
+                {category}
+              </Badge>
+              {entry?.source && entry.source !== 'levante' && (
+                <Badge
+                  variant="outline"
+                  className={`text-xs ${providerHomepage ? 'cursor-pointer hover:bg-accent transition-colors' : ''}`}
+                  onClick={providerHomepage ? handleSourceClick : undefined}
+                >
+                  {entry.source}
                 </Badge>
-                {entry?.source && entry.source !== 'levante' && (
-                  <Badge variant="outline" className="text-xs">
-                    {entry.source}
-                  </Badge>
-                )}
-              </div>
+              )}
             </div>
           </div>
           {/* Switch solo en modo Active */}

--- a/src/renderer/data/mcpProviders.json
+++ b/src/renderer/data/mcpProviders.json
@@ -9,7 +9,8 @@
       "icon": "home",
       "type": "local",
       "endpoint": "mcpRegistry.json",
-      "enabled": true
+      "enabled": true,
+      "homepage": "https://github.com/levante-hub/levante"
     },
     {
       "id": "aitempl",
@@ -18,7 +19,8 @@
       "icon": "star",
       "type": "api",
       "endpoint": "https://www.aitmpl.com/components.json",
-      "enabled": true
+      "enabled": true,
+      "homepage": "https://www.aitmpl.com"
     }
   ]
 }

--- a/src/renderer/types/mcp.ts
+++ b/src/renderer/types/mcp.ts
@@ -40,6 +40,7 @@ export interface MCPProvider {
   type: 'local' | 'github' | 'api';
   endpoint: string;
   enabled: boolean;
+  homepage?: string;
   lastSynced?: string;
   serverCount?: number;
   // Type-specific configuration


### PR DESCRIPTION
## Summary
- Make MCP provider source badges clickable with homepage links
- Remove icon from integration cards to prevent name overflow
- Add hover effects for better UX

## Changes Made
- **Types**: Added `homepage?: string` field to `MCPProvider` interface in both renderer and main service types
- **Data**: Added homepage URLs to `mcpProviders.json`:
  - Levante → https://github.com/levante-hub/levante
  - AITempl → https://www.aitmpl.com
- **UI/UX Improvements**:
  - Removed icon from integration cards to save space and prevent title overflow
  - Made source badge clickable when homepage is available
  - Added cursor pointer and hover background effect for clickable badges
  - Opens provider homepage in external browser using `window.levante.openExternal()`
- **Code Cleanup**: Removed unused icon imports from IntegrationCard component

## Screenshots
Cards now show more space for the MCP server name, and clicking the source badge (e.g., "aitempl") opens the provider's homepage in the default browser.

## Testing
- [x] Verified badges are clickable when homepage exists
- [x] Verified external links open correctly
- [x] Verified hover effects work as expected
- [x] Verified non-clickable badges (no homepage) remain static

## Related Issues
Fixes issue about card icon taking too much space and makes provider sources more discoverable

🤖 Generated with [Claude Code](https://claude.com/claude-code)