### PR TITLE
fixed hugging face initial provider bug

### DIFF
--- a/src/renderer/services/model/migrations.ts
+++ b/src/renderer/services/model/migrations.ts
@@ -143,35 +143,3 @@ export async function migrateCloudProvidersToDynamic(
 
   return { migrated, providers: updatedProviders };
 }
-
-/**
- * Add Hugging Face provider if missing (for existing users)
- */
-export async function addHuggingFaceProvider(
-  providers: ProviderConfig[]
-): Promise<{ migrated: boolean; providers: ProviderConfig[] }> {
-  // Check if Hugging Face already exists
-  const hasHuggingFace = providers.some(p => p.id === 'huggingface');
-
-  if (hasHuggingFace) {
-    return { migrated: false, providers };
-  }
-
-  logger.models.info('Adding Hugging Face provider for existing user');
-
-  const huggingFaceProvider: ProviderConfig = {
-    id: 'huggingface',
-    name: 'Hugging Face',
-    type: 'huggingface',
-    models: [],
-    isActive: false,
-    settings: {},
-    modelSource: 'dynamic',
-    baseUrl: 'https://router.huggingface.co/v1'
-  };
-
-  return {
-    migrated: true,
-    providers: [...providers, huggingFaceProvider]
-  };
-}

--- a/src/renderer/services/modelService.ts
+++ b/src/renderer/services/modelService.ts
@@ -1,7 +1,7 @@
 import type { Model, ProviderConfig } from '../../types/models';
 import type { ModelCategory, SessionType } from '../../types/modelCategories';
 import { getRendererLogger } from '@/services/logger';
-import { migrateCloudProvider, migrateCloudProvidersToDynamic, addHuggingFaceProvider } from './model/migrations';
+import { migrateCloudProvider, migrateCloudProvidersToDynamic } from './model/migrations';
 import { fetchOpenRouterModels } from './model/providers/openRouterProvider';
 import { fetchGatewayModels } from './model/providers/gatewayProvider';
 import { discoverLocalModels } from './model/providers/localProvider';
@@ -54,14 +54,6 @@ class ModelServiceImpl {
       if (dynamicMigrationResult.migrated) {
         this.providers = dynamicMigrationResult.providers;
         logger.models.info('Migrated cloud providers to dynamic model source');
-        await this.saveProviders();
-      }
-
-      // Add Hugging Face provider for existing users
-      const huggingFaceMigrationResult = await addHuggingFaceProvider(this.providers);
-      if (huggingFaceMigrationResult.migrated) {
-        this.providers = huggingFaceMigrationResult.providers;
-        logger.models.info('Added Hugging Face provider');
         await this.saveProviders();
       }
 


### PR DESCRIPTION
Resumen: había una migración, que introducía huggingface en la lista de modelos default al  iniciarse la aplicación. Existe una validación que dice que si la lista de proveedores es 0, que se inicie la lista con todos los modelos, pero al meterse huggingface la lista nunca era 0 y no se llegaban a cargar en el wizard del comienzo el resto de proveedores por lo que se rompía el wizard. 


El onboarding se rompía porque el listado de proveedores se inicializaba solo con Hugging Face y nunca se creaban los proveedores por defecto (OpenRouter, Vercel Gateway, Local, etc.).
Consecuencia directa: el paso de proveedor en el wizard no podía sincronizar ni mostrar modelos de OpenRouter; no aparecía el selector de modelos y el botón “Next” quedaba bloqueado.
Por qué ocurría

En modelService.initialize, se cargaban las preferencias guardadas. Si el array providers estaba vacío, se esperaba llamar a initializeDefaultProviders para poblar todos los proveedores.
Sin embargo, la migración addHuggingFaceProvider se ejecutaba incluso cuando providers estaba vacío. Añadía Hugging Face a la lista y hacía que providers.length dejara de ser 0.
Al no ser 0, se saltaba initializeDefaultProviders, dejando el estado solo con Hugging Face y sin OpenRouter.
Efecto

El wizard validaba la API key de OpenRouter pero no podía cargar modelos porque el provider no existía en el store. availableModels quedaba vacío, no se mostraba el selector de modelos y el avance quedaba bloqueado.