### PR TITLE
feat(ui): implement multi-provider model selector with auto-switching

### DIFF
--- a/src/renderer/components/ai-elements/model-searchable-select.tsx
+++ b/src/renderer/components/ai-elements/model-searchable-select.tsx
@@ -23,16 +23,18 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { cn } from '@/lib/utils';
-import { Check, ChevronsUpDown, Loader2, Filter, X } from 'lucide-react';
-import { useState, useMemo } from 'react';
-import type { Model } from '../../../types/models';
+import { Check, ChevronsUpDown, Loader2, Filter, X, ChevronRight, ChevronDown } from 'lucide-react';
+import { useState, useMemo, useEffect } from 'react';
+import type { Model, GroupedModelsByProvider } from '../../../types/models';
 import type { ModelCategory } from '../../../types/modelCategories';
 import { useTranslation } from 'react-i18next';
 
 export interface ModelSearchableSelectProps {
   value?: string;
   onValueChange?: (value: string) => void;
+
   models: Model[];
+  groupedModels?: GroupedModelsByProvider;
   loading?: boolean;
   placeholder?: string;
   className?: string;
@@ -42,6 +44,7 @@ export const ModelSearchableSelect = ({
   value,
   onValueChange,
   models,
+  groupedModels,
   loading = false,
   placeholder,
   className,
@@ -50,6 +53,19 @@ export const ModelSearchableSelect = ({
   const [open, setOpen] = useState(false);
   const [search, setSearch] = useState('');
   const [selectedCategory, setSelectedCategory] = useState<ModelCategory | null>(null);
+  const [collapsedProviders, setCollapsedProviders] = useState<Set<string>>(new Set());
+
+  // Toggle provider collapse
+  const toggleProviderCollapse = (providerId: string, e?: React.MouseEvent) => {
+    e?.stopPropagation();
+    const newCollapsed = new Set(collapsedProviders);
+    if (newCollapsed.has(providerId)) {
+      newCollapsed.delete(providerId);
+    } else {
+      newCollapsed.add(providerId);
+    }
+    setCollapsedProviders(newCollapsed);
+  };
 
   // Get category display name
   const getCategoryDisplayName = (category: ModelCategory): string => {
@@ -63,11 +79,19 @@ export const ModelSearchableSelect = ({
     return displayNames[category] || category;
   };
 
+  // Determine effective models list for categories: use all models from all providers if grouped
+  const effectiveModelsForCategories = useMemo(() => {
+    if (groupedModels) {
+      return groupedModels.providers.flatMap(p => p.models);
+    }
+    return models;
+  }, [models, groupedModels]);
+
   // Calculate available categories with counts
   const availableCategories = useMemo(() => {
     const counts = new Map<ModelCategory, number>();
 
-    models.forEach(model => {
+    effectiveModelsForCategories.forEach(model => {
       if (model.category) {
         counts.set(model.category, (counts.get(model.category) || 0) + 1);
       }
@@ -78,7 +102,7 @@ export const ModelSearchableSelect = ({
       count,
       label: getCategoryDisplayName(category)
     })).sort((a, b) => a.label.localeCompare(b.label));
-  }, [models]);
+  }, [effectiveModelsForCategories]);
 
   // Simple fuzzy search function
   const fuzzyMatch = (text: string, query: string): boolean => {
@@ -102,31 +126,95 @@ export const ModelSearchableSelect = ({
     return queryIndex === normalizedQuery.length;
   };
 
-  // Filter models based on category and search
-  const filteredModels = models
-    .filter(model => {
-      // Filter by category
-      if (selectedCategory && model.category !== selectedCategory) {
-        return false;
-      }
-      return true;
-    })
-    .filter(model =>
-      // Fuzzy search
-      fuzzyMatch(model.name, search) || fuzzyMatch(model.provider, search)
-    );
+  // Prepare display groups (supporting both legacy 'models' and new 'groupedModels')
+  const displayGroups = useMemo(() => {
+    // Helper to filter a list of models
+    const filterModels = (list: Model[]) => {
+      return list
+        .filter(model => {
+          // Filter by category
+          if (selectedCategory && model.category !== selectedCategory) {
+            return false;
+          }
+          return true;
+        })
+        .filter(model =>
+          // Fuzzy search
+          fuzzyMatch(model.name, search) || fuzzyMatch(model.provider, search)
+        );
+    };
 
-  // Group models by provider
-  const groupedModels = filteredModels.reduce((groups, model) => {
-    const provider = model.provider || 'Other';
-    if (!groups[provider]) {
-      groups[provider] = [];
+    if (groupedModels && groupedModels.providers.length > 0) {
+      // Use grouped models from service
+      return groupedModels.providers
+        .map(group => ({
+          id: group.provider.id,
+          name: group.provider.name,
+          models: filterModels(group.models),
+          originalCount: group.modelCount,
+          active: group.provider.isActive // For highlighting
+        }))
+        .filter(group => group.models.length > 0);
+    } else {
+      // Legacy fallback: group the 'models' prop manually
+      const filtered = filterModels(models);
+
+      const groups: Record<string, Model[]> = {};
+      filtered.forEach(model => {
+        const providerName = model.provider || 'Other';
+        if (!groups[providerName]) {
+          groups[providerName] = [];
+        }
+        groups[providerName].push(model);
+      });
+
+      return Object.entries(groups).map(([name, models]) => ({
+        id: name,
+        name: name.charAt(0).toUpperCase() + name.slice(1),
+        models,
+        originalCount: models.length,
+        active: false // Can't detect active in legacy mode easily without prop
+      }));
     }
-    groups[provider].push(model);
-    return groups;
-  }, {} as Record<string, Model[]>);
+  }, [models, groupedModels, selectedCategory, search]);
 
-  const selectedModel = models.find(model => model.id === value);
+  // Auto-expand active provider group initially
+  useEffect(() => {
+    if (groupedModels && !open) {
+      // Reset collapse state when closed? 
+      // User requirement: "Providers displayed as collapsible groups (closed by default)."
+      // Maybe we want to keep them closed by default except the one with the selected model?
+      // Or simply default all to closed? 
+      // Let's default to closed, but user might want to see the selected model.
+
+      const shouldCollapse = new Set<string>();
+      groupedModels.providers.forEach(p => {
+        // If this provider does NOT contain the selected model, collapse it?
+        // Or collapse everything by default except active provider?
+        // Requirement: "Active provider highlighted".
+        // Let's start with all expanded or all collapsed? 
+        // "Providers displayed as collapsible groups (closed by default)" -> This suggests all closed?
+        // But that hides the models. Usually "closed by default" means non-active ones.
+        // Let's implement logic: collapse all groups that do NOT contain the currently selected model.
+
+        const hasSelectedModel = p.models.some(m => m.id === value);
+        if (!hasSelectedModel) {
+          shouldCollapse.add(p.provider.id);
+        }
+      });
+      setCollapsedProviders(shouldCollapse);
+    }
+  }, [groupedModels, open, value]); // Re-run when opening
+
+  const selectedModel = useMemo(() => {
+    if (groupedModels) {
+      for (const group of groupedModels.providers) {
+        const found = group.models.find(m => m.id === value);
+        if (found) return found;
+      }
+    }
+    return models.find(model => model.id === value);
+  }, [models, groupedModels, value]);
 
   return (
     <Popover open={open} onOpenChange={setOpen}>
@@ -156,7 +244,7 @@ export const ModelSearchableSelect = ({
         </Button>
       </PopoverTrigger>
       <PopoverContent className="w-[300px] p-0" align="start">
-        <Command>
+        <Command shouldFilter={false}>
           <div className="flex items-center border-b px-3">
             <CommandInput
               placeholder={t('model_selector.search_placeholder')}
@@ -226,45 +314,74 @@ export const ModelSearchableSelect = ({
             )}
           </div>
           <CommandList>
-            <CommandEmpty>
-              {selectedCategory
-                ? `No models found in "${getCategoryDisplayName(selectedCategory)}" category`
-                : t('model_selector.no_models_found')
-              }
-            </CommandEmpty>
-            {Object.entries(groupedModels).map(([provider, providerModels]) => (
-              <CommandGroup key={provider} heading={provider.charAt(0).toUpperCase() + provider.slice(1)}>
-                {providerModels.map((model) => (
-                  <CommandItem
-                    key={model.id}
-                    value={model.id}
-                    onSelect={() => {
-                      onValueChange?.(model.id);
-                      setOpen(false);
-                      setSearch('');
-                    }}
-                  >
-                    <Check
-                      className={cn(
-                        "mr-2 h-4 w-4",
-                        value === model.id ? "opacity-100" : "opacity-0"
+            {displayGroups.length === 0 && (
+              <div className="py-6 text-center text-sm">
+                {selectedCategory
+                  ? `No models found in "${getCategoryDisplayName(selectedCategory)}" category`
+                  : t('model_selector.no_models_found')
+                }
+              </div>
+            )}
+            {displayGroups.map((group) => {
+              const isCollapsed = collapsedProviders.has(group.id);
+
+              return (
+                <CommandGroup
+                  key={group.id}
+                  heading={
+                    <div
+                      className="flex items-center cursor-pointer hover:bg-accent/50 rounded px-1 -mx-1 py-0.5 select-none"
+                      onClick={(e) => toggleProviderCollapse(group.id, e)}
+                    >
+                      {isCollapsed ? (
+                        <ChevronRight className="h-3 w-3 mr-1 opacity-70" />
+                      ) : (
+                        <ChevronDown className="h-3 w-3 mr-1 opacity-70" />
                       )}
-                    />
-                    <div className="flex flex-col flex-1">
-                      <span>{model.name}</span>
-                      {model.contextLength && (
-                        <span className="text-xs text-muted-foreground">
-                          {model.contextLength >= 1000
-                            ? t('model_selector.context_k', { count: Math.round(model.contextLength / 1000) })
-                            : t('model_selector.context', { count: model.contextLength })
-                          }
+                      <span className={cn(
+                        "font-medium flex-1",
+                        group.active && "text-primary font-bold"
+                      )}>
+                        {group.name}
+                        <span className="ml-1.5 text-xs text-muted-foreground font-normal opacity-70">
+                          ({group.models.length})
                         </span>
-                      )}
+                      </span>
                     </div>
-                  </CommandItem>
-                ))}
-              </CommandGroup>
-            ))}
+                  }
+                >
+                  {!isCollapsed && group.models.map((model) => (
+                    <CommandItem
+                      key={model.id}
+                      value={model.id}
+                      onSelect={() => {
+                        onValueChange?.(model.id);
+                        setOpen(false);
+                        setSearch('');
+                      }}
+                    >
+                      <Check
+                        className={cn(
+                          "mr-2 h-4 w-4",
+                          value === model.id ? "opacity-100" : "opacity-0"
+                        )}
+                      />
+                      <div className="flex flex-col flex-1">
+                        <span>{model.name}</span>
+                        {model.contextLength > 0 && (
+                          <span className="text-xs text-muted-foreground">
+                            {model.contextLength >= 1000
+                              ? t('model_selector.context_k', { count: Math.round(model.contextLength / 1000) })
+                              : t('model_selector.context', { count: model.contextLength })
+                            }
+                          </span>
+                        )}
+                      </div>
+                    </CommandItem>
+                  ))}
+                </CommandGroup>
+              );
+            })}
           </CommandList>
         </Command>
       </PopoverContent>

--- a/src/renderer/components/chat/ChatPromptInput.tsx
+++ b/src/renderer/components/chat/ChatPromptInput.tsx
@@ -11,7 +11,7 @@ import { ContextPreview } from '@/components/chat/ContextPreview';
 import { AddContextMenu } from '@/components/chat/AddContextMenu';
 import { useTranslation } from 'react-i18next';
 import { getRendererLogger } from '@/services/logger';
-import type { Model } from '../../../types/models';
+import type { Model, GroupedModelsByProvider } from '../../../types/models';
 import type { ChatStatus } from 'ai';
 import type { SelectedResource, SelectedPrompt, MCPResource, MCPPrompt } from '@/hooks/useMCPResources';
 
@@ -26,6 +26,7 @@ interface ChatPromptInputProps {
   model: string;
   onModelChange: (modelId: string) => void;
   availableModels: Model[];
+  groupedModelsByProvider?: GroupedModelsByProvider;
   modelsLoading: boolean;
   status?: ChatStatus;
   // File attachment props
@@ -53,6 +54,7 @@ export function ChatPromptInput({
   model,
   onModelChange,
   availableModels,
+  groupedModelsByProvider,
   modelsLoading,
   status,
   attachedFiles = [],
@@ -196,6 +198,7 @@ export function ChatPromptInput({
             value={model}
             onValueChange={onModelChange}
             models={availableModels}
+            groupedModels={groupedModelsByProvider}
             loading={modelsLoading}
             placeholder={availableModels.length === 0 ? t('model_selector.no_models') : t('model_selector.label')}
           />

--- a/src/renderer/hooks/useModelSelection.ts
+++ b/src/renderer/hooks/useModelSelection.ts
@@ -10,7 +10,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { modelService } from '@/services/modelService';
 import { getRendererLogger } from '@/services/logger';
-import type { Model } from '../../types/models';
+import type { Model, GroupedModelsByProvider } from '../../types/models';
 
 const logger = getRendererLogger();
 
@@ -34,6 +34,7 @@ interface UseModelSelectionReturn {
   setModel: (model: string) => void;
   availableModels: Model[];
   filteredAvailableModels: Model[];
+  groupedModelsByProvider: GroupedModelsByProvider | null;
   modelsLoading: boolean;
   currentModelInfo: Model | undefined;
   modelTaskType: string | undefined;
@@ -107,10 +108,24 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
 
   const [model, setModel] = useState<string>('');
   const [availableModels, setAvailableModels] = useState<Model[]>([]);
+  const [groupedModelsByProvider, setGroupedModelsByProvider] = useState<GroupedModelsByProvider | null>(null);
   const [modelsLoading, setModelsLoading] = useState(true);
 
-  // Get current model info
-  const currentModelInfo = availableModels.find((m) => m.id === model);
+  // Get current model info - search in grouped models if available, otherwise availableModels
+  const currentModelInfo = useMemo(() => {
+    // First try to find in available models (active provider)
+    let info = availableModels.find((m) => m.id === model);
+
+    // If not found, search in grouped models (other providers)
+    if (!info && groupedModelsByProvider) {
+      for (const group of groupedModelsByProvider.providers) {
+        info = group.models.find(m => m.id === model);
+        if (info) break;
+      }
+    }
+    return info;
+  }, [model, availableModels, groupedModelsByProvider]);
+
   const modelTaskType = currentModelInfo?.taskType;
 
   // Filter available models based on current session type
@@ -125,12 +140,21 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
       try {
         // Ensure model service is initialized
         await modelService.initialize();
-        const models = await modelService.getAvailableModels();
+
+        // Load legacy single-provider models AND grouped multi-provider models
+        const [models, grouped] = await Promise.all([
+          modelService.getAvailableModels(),
+          modelService.getAllProvidersWithSelectedModels()
+        ]);
+
         setAvailableModels(models);
+        setGroupedModelsByProvider(grouped);
 
         // Log available models for debugging
-        logger.models.debug(`Loaded ${models.length} available models`, {
-          models: models.map(m => ({ id: m.id, name: m.name, provider: m.provider }))
+        logger.models.debug(`Loaded models`, {
+          count: models.length,
+          groupedCount: grouped.totalModelCount,
+          providerCount: grouped.providers.length
         });
       } catch (error) {
         logger.models.error('Failed to load models', {
@@ -143,11 +167,39 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
 
     loadModels();
 
+
     // Also load user name if callback provided
     if (onLoadUserName) {
       onLoadUserName();
     }
   }, [onLoadUserName]);
+
+  // Auto-select model if only one is available and no model is selected
+  useEffect(() => {
+    if (!modelsLoading && !model && !currentSession) {
+      // Logic:
+      // 1. If groupedModels exists, check total count.
+      // 2. If availableModels exists (legacy/active), check that.
+
+      let candidateModel = '';
+
+      if (groupedModelsByProvider && groupedModelsByProvider.totalModelCount === 1) {
+        // Only 1 model across all providers
+        const provider = groupedModelsByProvider.providers[0];
+        if (provider && provider.models.length === 1) {
+          candidateModel = provider.models[0].id;
+        }
+      } else if (availableModels.length === 1) {
+        // Fallback or specific scope
+        candidateModel = availableModels[0].id;
+      }
+
+      if (candidateModel) {
+        logger.models.info('Auto-selecting single available model', { model: candidateModel });
+        setModel(candidateModel);
+      }
+    }
+  }, [availableModels, groupedModelsByProvider, modelsLoading, model, currentSession]);
 
   // Sync model with current session when session changes
   useEffect(() => {
@@ -161,15 +213,53 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
   }, [currentSession?.id, currentSession?.model]);
 
   // Handle model change with session type validation
-  const handleModelChange = useCallback((newModelId: string) => {
+  const handleModelChange = useCallback(async (newModelId: string) => {
+    // Keep internal sync with new model logic (async wrapper)
+
+    // Find model info across all providers
+    let newModelInfo = availableModels.find((m) => m.id === newModelId);
+    if (!newModelInfo && groupedModelsByProvider) {
+      for (const group of groupedModelsByProvider.providers) {
+        newModelInfo = group.models.find(m => m.id === newModelId);
+        if (newModelInfo) break;
+      }
+    }
+
+    // If still not found (rare edge case), we can't validate
+    if (!newModelInfo) {
+      logger.models.warn('Model not found for selection', { newModelId });
+      // If no current session, proceed blindly, otherwise block safe
+      if (currentSession) return;
+    }
+
     // If no current session, allow any model (it will determine session type on creation)
     if (!currentSession) {
+      // Check if we need to switch provider
+      try {
+        const newProviderId = await modelService.getProviderForModel(newModelId);
+        const activeProvider = await modelService.getActiveProvider();
+
+        if (newProviderId && activeProvider && newProviderId !== activeProvider.id) {
+          logger.models.info('Auto-switching provider for new session', {
+            from: activeProvider.id,
+            to: newProviderId,
+            model: newModelId
+          });
+          await modelService.setActiveProvider(newProviderId);
+          // Refresh available models for the new active provider
+          const models = await modelService.getAvailableModels();
+          setAvailableModels(models);
+        }
+      } catch (err) {
+        logger.models.error('Failed to auto-switch provider', {
+          error: err instanceof Error ? err.message : String(err)
+        });
+      }
+
       setModel(newModelId);
       return;
     }
 
-    // Get the new model's info
-    const newModelInfo = availableModels.find((m) => m.id === newModelId);
     const newTaskType = newModelInfo?.taskType;
     const isNewModelInference = isInferenceModel(newTaskType);
 
@@ -204,7 +294,33 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
       return;
     }
 
-    // Valid change - update model
+    // Valid change - check provider switch
+    try {
+      const newProviderId = await modelService.getProviderForModel(newModelId);
+      const activeProvider = await modelService.getActiveProvider();
+
+      if (newProviderId && activeProvider && newProviderId !== activeProvider.id) {
+        logger.models.info('Auto-switching provider for existing session', {
+          from: activeProvider.id,
+          to: newProviderId,
+          model: newModelId
+        });
+        await modelService.setActiveProvider(newProviderId);
+
+        // Refresh available models (active provider changed)
+        const models = await modelService.getAvailableModels();
+        setAvailableModels(models);
+
+        // Also refresh grouped models to update order (active logic)
+        const grouped = await modelService.getAllProvidersWithSelectedModels();
+        setGroupedModelsByProvider(grouped);
+      }
+    } catch (err) {
+      logger.models.error('Failed to auto-switch provider', {
+        error: err instanceof Error ? err.message : String(err)
+      });
+    }
+
     logger.core.info('Model changed', {
       oldModel: model,
       newModel: newModelId,
@@ -212,13 +328,14 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
       compatible: true
     });
     setModel(newModelId);
-  }, [currentSession, availableModels, model]);
+  }, [currentSession, availableModels, model, groupedModelsByProvider]);
 
   return {
     model,
     setModel,
     availableModels,
     filteredAvailableModels,
+    groupedModelsByProvider,
     modelsLoading,
     currentModelInfo,
     modelTaskType,

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -98,6 +98,7 @@ const ChatPage = () => {
     setModel,
     availableModels,
     filteredAvailableModels,
+    groupedModelsByProvider,
     modelsLoading,
     currentModelInfo,
     modelTaskType,
@@ -725,6 +726,7 @@ const ChatPage = () => {
                 model={model}
                 onModelChange={handleModelChange}
                 availableModels={filteredAvailableModels}
+                groupedModelsByProvider={groupedModelsByProvider || undefined}
                 modelsLoading={modelsLoading}
                 status={status}
                 attachedFiles={attachedFiles}
@@ -779,6 +781,7 @@ const ChatPage = () => {
               model={model}
               onModelChange={handleModelChange}
               availableModels={filteredAvailableModels}
+              groupedModelsByProvider={groupedModelsByProvider || undefined}
               modelsLoading={modelsLoading}
               status={status}
               attachedFiles={attachedFiles}

--- a/src/renderer/services/modelService.ts
+++ b/src/renderer/services/modelService.ts
@@ -1,4 +1,4 @@
-import type { Model, ProviderConfig } from '../../types/models';
+import type { Model, ProviderConfig, GroupedModelsByProvider, ProviderWithModels } from '../../types/models';
 import type { ModelCategory, SessionType } from '../../types/modelCategories';
 import { getRendererLogger } from '@/services/logger';
 import { migrateCloudProvider, migrateCloudProvidersToDynamic } from './model/migrations';
@@ -210,6 +210,81 @@ class ModelServiceImpl {
     }
 
     return activeProvider.models.filter(m => m.isAvailable);
+  }
+
+  // Get all providers with their selected models (for multi-provider selector)
+  async getAllProvidersWithSelectedModels(): Promise<GroupedModelsByProvider> {
+    const groupedResult: GroupedModelsByProvider = {
+      providers: [],
+      totalModelCount: 0
+    };
+
+    // 1. Refresh dynamic providers if needed (smart sync)
+    // We don't want to block UI, so we trust cache but trigger background sync if very old
+    const now = Date.now();
+    this.providers.forEach(provider => {
+      if (provider.modelSource === 'dynamic' &&
+        (!provider.lastModelSync || (now - provider.lastModelSync > 1000 * 60 * 5))) {
+        // Trigger sync but don't await it to keep UI snappy
+        // If it's critical, the user can refresh or we can await
+        this.syncProviderModels(provider.id).catch(err => {
+          logger.models.warn(`Background sync failed for ${provider.name}`, err);
+        });
+      }
+    });
+
+    // 2. Iterate through all providers
+    for (const provider of this.providers) {
+      if (!provider.models) continue;
+
+      let selectedModels: Model[] = [];
+
+      // Filter available and selected models
+      if (provider.modelSource === 'dynamic') {
+        const selectedIds = new Set(provider.selectedModelIds || []);
+        // Also check isSelected flag as fallback/redundancy
+        selectedModels = provider.models.filter(m =>
+          m.isAvailable &&
+          (selectedIds.has(m.id) || m.isSelected)
+        );
+      } else {
+        // User defined providers
+        selectedModels = provider.models.filter(m =>
+          m.isAvailable &&
+          m.isSelected !== false // Default to true if undefined
+        );
+      }
+
+      if (selectedModels.length > 0) {
+        groupedResult.providers.push({
+          provider,
+          models: selectedModels,
+          modelCount: selectedModels.length
+        });
+        groupedResult.totalModelCount += selectedModels.length;
+      }
+    }
+
+    // 3. Sort providers: Active first, then alphabetically
+    groupedResult.providers.sort((a, b) => {
+      if (a.provider.id === this.activeProviderId) return -1;
+      if (b.provider.id === this.activeProviderId) return 1;
+      return a.provider.name.localeCompare(b.provider.name);
+    });
+
+    return groupedResult;
+  }
+
+  // Find which provider owns a model
+  async getProviderForModel(modelId: string): Promise<string | null> {
+    for (const provider of this.providers) {
+      // Check if model exists in provider
+      const model = provider.models.find(m => m.id === modelId);
+      if (model) {
+        return provider.id;
+      }
+    }
+    return null;
   }
 
   // Toggle model selection

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -47,6 +47,17 @@ export interface ProviderConfig {
   region?: string; // For AWS Bedrock (future)
 }
 
+export interface ProviderWithModels {
+  provider: ProviderConfig;
+  models: Model[];
+  modelCount: number;
+}
+
+export interface GroupedModelsByProvider {
+  providers: ProviderWithModels[];
+  totalModelCount: number;
+}
+
 export interface ModelService {
   fetchOpenRouterModels(apiKey?: string): Promise<Model[]>;
   fetchGatewayModels(apiKey: string, baseUrl: string): Promise<Model[]>;
@@ -54,5 +65,7 @@ export interface ModelService {
   getUserDefinedModels(providerId: string): Promise<Model[]>;
   syncProviderModels(providerId: string): Promise<Model[]>;
   getAvailableModels(): Promise<Model[]>;
+  getAllProvidersWithSelectedModels(): Promise<GroupedModelsByProvider>;
+  getProviderForModel(modelId: string): Promise<string | null>;
   getActiveProvider(): Promise<ProviderConfig | null>;
 }


### PR DESCRIPTION
- Update ModelSearchableSelect to support grouped models and collapsible provider sections - Implement provider auto-switching in useModelSelection when selecting cross-provider models - Add logic to aggregate models from all providers in modelService - Auto-select model if only one is available to reduce friction - Fix no models found state when provider groups are collapsed - Ensure backward compatibility with single-provider view