### PR TITLE
feat: remove chat/inference session type restrictions

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,36 +1,7 @@
 {
-  "permissions": {
-    "allow": [
-      "Bash(gh issue:*)",
-      "Bash(gh api:*)",
-      "WebFetch(domain:www.reddit.com)",
-      "Bash(pnpm install:*)",
-      "Bash(pnpm dev:*)",
-      "WebFetch(domain:www.electronjs.org)",
-      "WebFetch(domain:ui.shadcn.com)",
-      "WebFetch(domain:www.npmjs.com)",
-      "WebFetch(domain:ai-sdk.dev)",
-      "Bash(pnpm update:*)",
-      "Bash(pnpm:*)",
-      "WebSearch",
-      "WebFetch(domain:electron-vite.org)",
-      "Bash(pkill:*)",
-      "mcp__sequential-thinking__sequentialthinking",
-      "mcp__context7__resolve-library-id",
-      "mcp__context7__get-library-docs",
-      "Bash(source:*)",
-      "Bash(find:*)",
-      "Bash(grep:*)",
-      "WebFetch(domain:docs.turso.tech)",
-      "WebFetch(domain:openrouter.ai)"
-    ],
-    "deny": [],
-    "ask": []
-  },
   "enabledMcpjsonServers": [
     "context7",
     "sequential-thinking",
     "time"
-  ],
-  "enableAllProjectMcpServers": true
+  ]
 }

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -414,6 +414,33 @@ export class AIService {
   }
 
   /**
+   * Build context from full message history for inference models.
+   * Concatenates all user and assistant messages to provide conversation context.
+   * This allows inference models to understand the full conversation when generating outputs.
+   */
+  private buildInferenceContext(messages: UIMessage[]): string {
+    const contextParts: string[] = [];
+
+    for (const message of messages) {
+      if (message.role !== 'user' && message.role !== 'assistant') {
+        continue;
+      }
+
+      // Extract text from message parts
+      const textParts = message.parts?.filter((p: any) => p.type === 'text') || [];
+      const text = textParts.map((p: any) => p.text).join('\n').trim();
+
+      if (text) {
+        const prefix = message.role === 'user' ? 'User' : 'Assistant';
+        contextParts.push(`${prefix}: ${text}`);
+      }
+    }
+
+    return contextParts.join('\n');
+  }
+
+
+  /**
    * Parse a JSON block embedded in markdown fences
    */
   private extractJsonBlock(
@@ -1036,17 +1063,38 @@ export class AIService {
           inferenceInput = { messages: chatMessages };
           break;
 
-        case "text-to-image":
-          inferenceInput = { prompt: inputText };
+        case "text-to-image": {
+          // Build context from FULL conversation history
+          const contextPrompt = this.buildInferenceContext(messages);
+          this.logger.aiSdk.info("text-to-image using full conversation context", {
+            contextLength: contextPrompt.length,
+            messageCount: messages.length
+          });
+          inferenceInput = { prompt: contextPrompt || inputText };
           break;
+        }
 
-        case "text-to-speech":
-          inferenceInput = { text: inputText };
+        case "text-to-speech": {
+          // Build context from FULL conversation history
+          const contextText = this.buildInferenceContext(messages);
+          this.logger.aiSdk.info("text-to-speech using full conversation context", {
+            contextLength: contextText.length,
+            messageCount: messages.length
+          });
+          inferenceInput = { text: contextText || inputText };
           break;
+        }
 
-        case "text-to-video":
-          inferenceInput = { text: inputText };
+        case "text-to-video": {
+          // Build context from FULL conversation history
+          const contextText = this.buildInferenceContext(messages);
+          this.logger.aiSdk.info("text-to-video using full conversation context", {
+            contextLength: contextText.length,
+            messageCount: messages.length
+          });
+          inferenceInput = { text: contextText || inputText };
           break;
+        }
 
         case "image-to-image": {
           // Get image from attachment or fall back to last generated image
@@ -1140,30 +1188,54 @@ export class AIService {
 
         case "visual-question-answering":
         case "document-question-answering": {
-          if (attachments.length === 0) {
-            yield {
-              error:
-                "This model requires an image attachment. Please attach an image.",
-              done: true,
-            };
-            return;
-          }
+          // Get image from attachment or fall back to last generated/attached image
+          let imageData: string | null = null;
+          let imageSource: string = "unknown";
 
+          // First, check if user attached an image
           const qaAttachment = attachments.find((a: any) => a.type === "image");
-          if (!qaAttachment) {
+
+          if (qaAttachment?.data) {
+            imageData = qaAttachment.data;
+            imageSource = "user-attachment";
+            this.logger.aiSdk.debug("Using user-attached image for visual-qa");
+          } else {
+            // No attachment - try to find last image in conversation history
+            this.logger.aiSdk.debug("No attachment provided, searching for previous image in history");
+            const lastImage = await this.findLastGeneratedImage(messages);
+
+            if (lastImage) {
+              imageData = lastImage.data;
+              imageSource = "previous-image";
+              this.logger.aiSdk.info("Using previous image from history for visual-qa", {
+                filename: lastImage.filename,
+              });
+            }
+          }
+
+          // If no image found anywhere, show error
+          if (!imageData) {
             yield {
               error:
-                "No image found in attachments. Please provide an image for the question.",
+                "This model requires an image. Please attach an image or use it in a conversation with existing images.",
               done: true,
             };
             return;
           }
 
-          const qaBlob = await this.dataURLToBlob(qaAttachment.data);
+          const qaBlob = await this.dataURLToBlob(imageData);
+
+          // Build context from full conversation for the question
+          const contextQuestion = this.buildInferenceContext(messages);
+
+          this.logger.aiSdk.info("visual-qa input prepared", {
+            imageSource,
+            questionLength: contextQuestion.length || inputText.length,
+          });
 
           inferenceInput = {
             image: qaBlob,
-            question: inputText || "Describe the image",
+            question: contextQuestion || inputText || "Describe the image",
           };
           break;
         }

--- a/src/renderer/components/chat/ChatPromptInput.tsx
+++ b/src/renderer/components/chat/ChatPromptInput.tsx
@@ -17,6 +17,32 @@ import type { SelectedResource, SelectedPrompt, MCPResource, MCPPrompt } from '@
 
 const logger = getRendererLogger();
 
+/**
+ * Get smart placeholder text based on current model type
+ */
+function getPlaceholderText(taskType?: string): string {
+  if (!taskType || taskType === 'chat' || taskType === 'image-text-to-text') {
+    return 'Type a message...';
+  }
+
+  switch (taskType) {
+    case 'text-to-image':
+      return 'Describe the image you want to generate...';
+    case 'image-to-image':
+      return 'Describe the changes or attach an image...';
+    case 'text-to-speech':
+    case 'text-to-video':
+      return 'Enter text to synthesize...';
+    case 'automatic-speech-recognition':
+      return 'Attach an audio file...';
+    case 'visual-question-answering':
+    case 'document-question-answering':
+      return 'Ask a question about the image...';
+    default:
+      return 'Type a message...';
+  }
+}
+
 interface ChatPromptInputProps {
   input: string;
   onInputChange: (value: string) => void;
@@ -29,6 +55,7 @@ interface ChatPromptInputProps {
   groupedModelsByProvider?: GroupedModelsByProvider;
   modelsLoading: boolean;
   status?: ChatStatus;
+  modelTaskType?: string; // Add task type for smart placeholders
   // File attachment props
   attachedFiles?: File[];
   onFilesSelected?: (files: File[]) => void;
@@ -57,6 +84,7 @@ export function ChatPromptInput({
   groupedModelsByProvider,
   modelsLoading,
   status,
+  modelTaskType,
   attachedFiles = [],
   onFilesSelected,
   onFileRemove,
@@ -70,6 +98,9 @@ export function ChatPromptInput({
   onPromptRemove,
 }: ChatPromptInputProps) {
   const { t } = useTranslation('chat');
+
+  // Get smart placeholder based on model type
+  const placeholder = getPlaceholderText(modelTaskType);
 
   // Check if we have any context to show
   const hasContext = attachedFiles.length > 0 || selectedResources.length > 0 || selectedPrompts.length > 0;
@@ -172,7 +203,7 @@ export function ChatPromptInput({
         value={input}
         rows={1}
         className="p-2 border-none"
-        placeholder={t('input.placeholder')}
+        placeholder={placeholder}
       />
 
       {/* Toolbar */}

--- a/src/renderer/hooks/useModelSelection.ts
+++ b/src/renderer/hooks/useModelSelection.ts
@@ -54,49 +54,16 @@ function isInferenceModel(taskType: string | undefined): boolean {
 
 /**
  * Filter models based on session type
+ * NOTE: Session type filtering has been removed - all models are now shown
+ * regardless of session type. Session type updates dynamically when switching models.
  */
 function filterModelsBySessionType(
   models: Model[],
   session: Session | null
 ): Model[] {
-  if (!session) {
-    return models;
-  }
-
-  const sessionType = session.session_type;
-  let filtered: Model[] = [];
-
-  if (sessionType === 'chat') {
-    // Chat session - only show chat and multimodal chat models
-    filtered = models.filter(m => {
-      const taskType = m.taskType;
-      return !taskType || taskType === 'chat' || taskType === 'image-text-to-text';
-    });
-  } else if (sessionType === 'inference') {
-    // Inference session - only show inference models
-    filtered = models.filter(m => {
-      const taskType = m.taskType;
-      return taskType && taskType !== 'chat' && taskType !== 'image-text-to-text';
-    });
-  } else {
-    // Fallback - show all models
-    filtered = models;
-  }
-
-  // ALWAYS include the session's current model, even if not in filtered list
-  // This allows continuing conversations with the same model
-  if (session.model) {
-    const currentModel = models.find(m => m.id === session.model);
-    if (currentModel && !filtered.find(m => m.id === currentModel.id)) {
-      logger.core.info('Adding session model to filtered list', {
-        model: session.model,
-        sessionType
-      });
-      filtered = [currentModel, ...filtered];
-    }
-  }
-
-  return filtered;
+  // No filtering by session type - show all models
+  // Session type will update automatically when user switches models
+  return models;
 }
 
 // ============================================================================
@@ -263,35 +230,38 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
     const newTaskType = newModelInfo?.taskType;
     const isNewModelInference = isInferenceModel(newTaskType);
 
-    // Check session type compatibility
-    const sessionType = currentSession.session_type;
+    // Determine new session type based on model
+    const newSessionType = isNewModelInference ? 'inference' : 'chat';
+    const currentSessionType = currentSession.session_type;
 
-    if (sessionType === 'chat' && isNewModelInference) {
-      logger.core.warn('Cannot switch to inference model in chat session', {
-        currentSessionType: sessionType,
-        newModel: newModelId,
-        newTaskType
+    // If session type changes, update it dynamically
+    if (currentSessionType !== newSessionType) {
+      logger.core.info('Updating session type for model switch', {
+        sessionId: currentSession.id,
+        oldType: currentSessionType,
+        newType: newSessionType,
+        model: newModelId
       });
-      alert(
-        '❌ No puedes usar modelos de inferencia en sesiones de chat.\n\n' +
-        'Las sesiones de chat están diseñadas para modelos conversacionales. ' +
-        'Para usar modelos de inferencia (text-to-image, image-to-image, etc.), inicia una nueva conversación.'
-      );
-      return;
-    }
 
-    if (sessionType === 'inference' && !isNewModelInference) {
-      logger.core.warn('Cannot switch to chat model in inference session', {
-        currentSessionType: sessionType,
-        newModel: newModelId,
-        newTaskType
-      });
-      alert(
-        '❌ No puedes usar modelos de chat en sesiones de inferencia.\n\n' +
-        'Las sesiones de inferencia están diseñadas para tareas específicas (text-to-image, image-to-image, etc.). ' +
-        'Para usar modelos de chat normales, inicia una nueva conversación.'
-      );
-      return;
+      try {
+        // Update session type in database
+        const result = await window.levante.db.sessions.update({
+          id: currentSession.id,
+          session_type: newSessionType
+        });
+
+        if (!result.success) {
+          logger.core.error('Failed to update session type', {
+            error: result.error
+          });
+          // Continue anyway - the model change will still work
+        }
+      } catch (err) {
+        logger.core.error('Error updating session type', {
+          error: err instanceof Error ? err.message : String(err)
+        });
+        // Continue anyway - the model change will still work
+      }
     }
 
     // Valid change - check provider switch
@@ -324,7 +294,7 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
     logger.core.info('Model changed', {
       oldModel: model,
       newModel: newModelId,
-      sessionType,
+      sessionType: newSessionType,
       compatible: true
     });
     setModel(newModelId);

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -68,6 +68,7 @@ const ChatPage = () => {
   const persistMessage = useChatStore((state) => state.persistMessage);
   const createSession = useChatStore((state) => state.createSession);
   const loadHistoricalMessages = useChatStore((state) => state.loadHistoricalMessages);
+  const updateSessionModel = useChatStore((state) => state.updateSessionModel);
   const pendingPrompt = useChatStore((state) => state.pendingPrompt);
   const setPendingPrompt = useChatStore((state) => state.setPendingPrompt);
 
@@ -514,6 +515,16 @@ const ChatPage = () => {
         };
         await persistMessage(userMessage);
 
+        // Update session model to reflect current model being used
+        if (currentSession.model !== model) {
+          logger.core.info('Updating session model', {
+            sessionId: currentSession.id,
+            oldModel: currentSession.model,
+            newModel: model
+          });
+          await updateSessionModel(currentSession.id, model);
+        }
+
         // Send to AI with attachments in the body
         // The ElectronChatTransport will pass these to the IPC layer
         await sendMessageAI(
@@ -623,6 +634,16 @@ const ChatPage = () => {
 
         await persistMessage(userMessage);
 
+        // Update session model to reflect current model being used
+        if (currentSession.model !== model) {
+          logger.core.info('Updating session model for pending message', {
+            sessionId: currentSession.id,
+            oldModel: currentSession.model,
+            newModel: model
+          });
+          await updateSessionModel(currentSession.id, model);
+        }
+
         await sendMessageAI(
           {
             text: messageText,
@@ -729,6 +750,7 @@ const ChatPage = () => {
                 groupedModelsByProvider={groupedModelsByProvider || undefined}
                 modelsLoading={modelsLoading}
                 status={status}
+                modelTaskType={modelTaskType}
                 attachedFiles={attachedFiles}
                 onFilesSelected={handleFilesSelected}
                 onFileRemove={handleFileRemove}
@@ -784,6 +806,7 @@ const ChatPage = () => {
               groupedModelsByProvider={groupedModelsByProvider || undefined}
               modelsLoading={modelsLoading}
               status={status}
+              modelTaskType={modelTaskType}
               attachedFiles={attachedFiles}
               onFilesSelected={handleFilesSelected}
               onFileRemove={handleFileRemove}

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -36,6 +36,7 @@ interface ChatStore {
   loadSession: (sessionId: string) => Promise<void>;
   deleteSession: (sessionId: string) => Promise<boolean>;
   updateSessionTitle: (sessionId: string, title: string) => Promise<boolean>;
+  updateSessionModel: (sessionId: string, model: string) => Promise<boolean>;
   setCurrentSession: (session: ChatSession | null) => void;
   startNewChat: () => void;
 
@@ -286,6 +287,43 @@ export const useChatStore = create<ChatStore>()(
           const error = err instanceof Error ? err.message : 'Unknown error';
           logger.database.error('Error updating session title', { error });
           set({ error });
+          return false;
+        }
+      },
+
+      updateSessionModel: async (sessionId: string, model: string) => {
+        logger.database.debug('Updating session model', { sessionId, model });
+
+        try {
+          const result = await window.levante.db.sessions.update({
+            id: sessionId,
+            model,
+          });
+
+          if (result.success && result.data) {
+            logger.database.info('Session model updated', { sessionId, model });
+
+            set((state) => ({
+              sessions: state.sessions.map((s) =>
+                s.id === sessionId ? { ...s, model } : s
+              ),
+              currentSession:
+                state.currentSession?.id === sessionId
+                  ? { ...state.currentSession, model }
+                  : state.currentSession,
+            }));
+
+            return true;
+          } else {
+            logger.database.error('Failed to update session model', {
+              sessionId,
+              error: result.error,
+            });
+            return false;
+          }
+        } catch (err) {
+          const error = err instanceof Error ? err.message : 'Unknown error';
+          logger.database.error('Error updating session model', { error });
           return false;
         }
       },

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -144,6 +144,7 @@ export interface UpdateChatSessionInput {
   title?: string;
   model?: string;
   folder_id?: string | null;
+  session_type?: SessionType;
 }
 
 export interface UpdateMessageInput {


### PR DESCRIPTION
Enable seamless switching between conversational and inference models within the same session.

## Key Changes

### Dynamic Session Type Switching
- Remove blocking validation alerts that prevented model type switching
- Implement automatic session_type updates when switching between chat and inference models
- Session type now updates transparently without user notification

### Intelligent Message History for Inference Models
- Add buildInferenceContext() helper to build context from full conversation history
- Update text-to-image models to use complete conversation context
- Update text-to-speech and text-to-video to synthesize entire conversation
- Add auto-detection of last image from history for visual-question-answering tasks
- Enable iterative refinement (e.g., 'show me a cat' → 'make it orange')

### Remove Model Filtering Restrictions
- Simplify filterModelsBySessionType to show all available models
- Remove session type-based filtering from model selector
- Users can now see and select any model regardless of current session type

### UI/UX Improvements
- Add smart placeholder text that changes based on current model type
- Context-aware placeholders guide users on what to input for each model

### Database Updates
- Add session_type field to UpdateChatSessionInput interface
- Leverage existing update infrastructure (no new IPC handlers needed)

## User Experience

Before:
- ❌ Blocking error alerts when switching model types
- ❌ Required new sessions for different model types
- ❌ Inference models only used last message
- ❌ Model selector filtered by session type

After:
- ✅ Seamless model type switching
- ✅ Automatic session type updates
- ✅ Full conversation context for inference
- ✅ Auto-image detection for visual tasks
- ✅ All models visible in selector
- ✅ Smart placeholder text

## Files Modified
- src/types/database.ts
- src/renderer/hooks/useModelSelection.ts
- src/main/services/aiService.ts
- src/renderer/components/chat/ChatPromptInput.tsx
- src/renderer/pages/ChatPage.tsx

## Breaking Changes
None - backward compatible with existing sessions