### PR TITLE
fix(google): use v1beta API endpoint for model listing

### DIFF
--- a/src/main/services/apiValidation/providers/google.ts
+++ b/src/main/services/apiValidation/providers/google.ts
@@ -17,7 +17,7 @@ export async function validateGoogle(apiKey: string): Promise<ValidationResult> 
     }
 
     const response = await fetch(
-      `https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`,
+      `https://generativelanguage.googleapis.com/v1beta/models?key=${apiKey}`,
       {
         headers: {
           'Content-Type': 'application/json',

--- a/src/main/services/modelFetchService.ts
+++ b/src/main/services/modelFetchService.ts
@@ -229,7 +229,7 @@ export class ModelFetchService {
       // Security: API key in Authorization header instead of URL query string
       // This prevents API key exposure in logs, browser history, and network monitoring
       const response = await safeFetch(
-        "https://generativelanguage.googleapis.com/v1/models",
+        "https://generativelanguage.googleapis.com/v1beta/models",
         {
           headers: {
             "x-goog-api-key": apiKey,


### PR DESCRIPTION
## Summary
- Changes Google AI API endpoint from `v1` to `v1beta` to access newer models
- Updates both model fetching and API validation endpoints

## Test plan
- [x] Configure Google AI API key in Settings > Providers
- [x] Sync Google models and verify new Gemini models appear
- [x] Verify API key validation still works

Fixes #139

🤖 Generated with [Claude Code](https://claude.com/claude-code)