### PR TITLE
feat(mcp): add discovery tool with shop integration and UI controls

### DIFF
--- a/docs/MCP_DISCOVERY.md
+++ b/docs/MCP_DISCOVERY.md
@@ -1,0 +1,302 @@
+# MCP Discovery Tool
+
+The MCP Discovery tool enables the AI to proactively suggest relevant MCP servers when a user's request cannot be fulfilled with currently configured tools. This bridges the gap between user intent and available capabilities.
+
+## Overview
+
+When a user asks for something that requires an MCP server they haven't configured (e.g., "Can you access my GitHub?"), the AI can:
+
+1. Search the MCP Shop for relevant servers
+2. Present matching options with configure buttons
+3. Allow one-click configuration without leaving the chat
+4. Continue helping once the server is configured
+
+## User Flow
+
+```
+┌─────────────────────────────────────────────────────────────────┐
+│ User: "Can you access my GitHub repositories?"                  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ AI: Checks available tools                                      │
+│     → No GitHub tools found                                     │
+│     → Calls mcp_discovery tool with query "github"              │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ mcp_discovery: Searches MCP Shop API                            │
+│     → Finds matching servers                                    │
+│     → Filters out already-configured servers                    │
+│     → Returns results with deep links                           │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ AI Response:                                                    │
+│                                                                 │
+│ "To access GitHub, I found this MCP server you can configure:  │
+│                                                                 │
+│ **GitHub** - Access repositories, issues, and pull requests    │
+│                                                                 │
+│ [Configure GitHub]  ← Rendered as a button                     │
+│                                                                 │
+│ *Requires: GitHub Personal Access Token*                       │
+│                                                                 │
+│ Click the button to add it."                                   │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ User: Clicks configure button                                   │
+│       → Modal opens over the chat                               │
+│       → User enters API key                                     │
+│       → Server connects                                         │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│ User: "Now list my repositories"                                │
+│ AI: Uses the newly configured GitHub tools                      │
+└─────────────────────────────────────────────────────────────────┘
+```
+
+## Tool Definition
+
+### `mcp_discovery`
+
+**Description:** Search for MCP servers in the Levante MCP Shop.
+
+**Parameters:**
+
+| Parameter | Type | Required | Default | Description |
+|-----------|------|----------|---------|-------------|
+| `query` | string | Yes | - | Search query (e.g., "github", "database", "email") |
+| `limit` | number | No | 5 | Maximum results to return (1-10) |
+
+**Response:**
+
+```typescript
+interface MCPDiscoveryToolResponse {
+  results: MCPDiscoveryResult[];
+  totalMatches: number;
+  message: string;
+}
+
+interface MCPDiscoveryResult {
+  id: string;                    // Server identifier
+  name: string;                  // Display name
+  description: string;           // What the server does
+  category: string;              // e.g., "development", "database"
+  icon?: string;                 // Emoji or icon
+  transport: string;             // "stdio" | "http" | "sse"
+  configureUrl: string;          // Deep link URL
+  hasApiKeyRequirement: boolean; // Requires credentials
+}
+```
+
+**Example Response:**
+
+```json
+{
+  "results": [
+    {
+      "id": "github",
+      "name": "GitHub",
+      "description": "Access GitHub repositories, issues, and pull requests",
+      "category": "development",
+      "icon": "🐙",
+      "transport": "stdio",
+      "configureUrl": "levante://mcp/configure/github",
+      "hasApiKeyRequirement": true
+    }
+  ],
+  "totalMatches": 1,
+  "message": "Found 1 MCP server(s) matching \"github\"."
+}
+```
+
+## Deep Link Format
+
+The discovery tool generates deep links in the format:
+
+```
+levante://mcp/configure/{server-id}
+```
+
+When clicked:
+1. The app fetches the server configuration from the MCP Shop registry
+2. Opens the configuration modal with pre-filled settings
+3. User provides any required credentials
+4. Server is added and connected
+
+## Button Rendering
+
+Configure links in AI responses are automatically rendered as buttons:
+
+**Markdown Input:**
+```markdown
+[Configure GitHub](levante://mcp/configure/github)
+```
+
+**Rendered Output:**
+A styled button with:
+- Primary theme colors
+- Settings icon
+- Hover and focus states
+- Click triggers the configuration modal
+
+## Search Algorithm
+
+The discovery tool uses a scoring algorithm to rank results:
+
+| Match Type | Score |
+|------------|-------|
+| Name contains query | +10 |
+| ID contains query | +8 |
+| Category matches query | +5 |
+| Description contains term | +1 per term |
+
+Results are:
+1. Filtered to exclude already-configured servers
+2. Sorted by score (highest first)
+3. Limited to the requested count
+
+## Configuration
+
+The discovery tool is enabled by default. It can be disabled via preferences:
+
+```typescript
+// In ui-preferences.json
+{
+  "ai": {
+    "mcpDiscovery": false  // Set to false to disable
+  }
+}
+```
+
+## System Prompt Integration
+
+When enabled, the AI receives these instructions:
+
+```
+MCP DISCOVERY:
+You have access to the `mcp_discovery` tool to search for MCP servers.
+
+Use this tool when:
+- Users ask about adding capabilities or tools you don't have
+- Users want to connect to external services
+- Users ask "Can you access X?" or "Is there a tool for Y?"
+- You cannot fulfill a request with current tools
+
+When presenting results:
+1. Show each server with its name and description
+2. Include the configure URL as a markdown link (renders as button)
+3. Mention if API keys are required
+4. Offer to help once configured
+```
+
+## Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `src/main/services/ai/builtInTools.ts` | Tool definition and search logic |
+| `src/main/services/ai/systemPromptBuilder.ts` | AI instructions |
+| `src/main/services/deepLinkService.ts` | Deep link parsing |
+| `src/main/lifecycle/window.ts` | Handle clicks on levante:// links |
+| `src/main/ipc/mcpHandlers/providers.ts` | Registry entry lookup |
+| `src/renderer/App.tsx` | Modal opening logic |
+| `src/renderer/components/ai-elements/response.tsx` | Button rendering |
+
+## API Endpoints
+
+The tool uses the MCP Shop API:
+
+**Registry Fetch:**
+```
+GET https://services.levanteapp.com/api/mcps.json
+```
+
+**Entry Lookup (IPC):**
+```typescript
+window.levante.mcp.providers.getEntry(serverId)
+```
+
+## Security Considerations
+
+1. **Server Validation**: All servers come from the curated MCP Shop registry
+2. **User Confirmation**: Configuration requires explicit user action via modal
+3. **Credential Protection**: API keys are stored encrypted via electron-store
+4. **Protocol Isolation**: Only `levante://` links are handled internally; others open externally
+
+## Examples
+
+### Example 1: Database Access
+
+**User:** "Can you query my PostgreSQL database?"
+
+**AI Response:**
+```
+I don't have database access configured. I found this MCP server:
+
+**PostgreSQL** - Query and manage PostgreSQL databases
+
+[Configure PostgreSQL](levante://mcp/configure/postgresql)
+
+*Requires: Database connection string*
+
+Click to add it, then I can help with your queries.
+```
+
+### Example 2: File System
+
+**User:** "Read the files in my project folder"
+
+**AI Response:**
+```
+I found a file system server you can configure:
+
+**Filesystem** - Read and write files on your computer
+
+[Configure Filesystem](levante://mcp/configure/filesystem)
+
+This server needs access to specific directories. Click to configure.
+```
+
+### Example 3: No Results
+
+**User:** "Can you control my smart home?"
+
+**AI Response:**
+```
+I searched for smart home MCP servers but didn't find any matches.
+Try searching the MCP Shop manually, or check if there's a
+community server available for your smart home platform.
+```
+
+## Troubleshooting
+
+### Button not appearing
+
+- Ensure the AI is using the correct markdown format: `[Label](levante://...)`
+- Check that `mcpDiscovery` is not disabled in preferences
+
+### Modal not opening
+
+- Check the browser console for errors
+- Verify the server ID exists in the registry
+- Ensure the deep link service is properly initialized
+
+### Server not found
+
+- The server may have been removed from the registry
+- Try searching with different terms
+- Check if the server requires a different provider
+
+## Related Documentation
+
+- [Deep Linking](./DEEP_LINKING.md) - Full deep link protocol documentation
+- [MCP Deep Link Security](./MCP_DEEP_LINK_SECURITY.md) - Security considerations
+- [Architecture](./ARCHITECTURE.md) - System architecture overview

--- a/src/main/ipc/mcpHandlers/providers.ts
+++ b/src/main/ipc/mcpHandlers/providers.ts
@@ -152,5 +152,35 @@ export function registerProviderHandlers() {
     }
   });
 
+  // Get a specific entry by ID from all providers
+  ipcMain.handle('levante/mcp/providers/get-entry', async (_, serverId: string) => {
+    try {
+      const providers = mcpProvidersData.providers as MCPProvider[];
+      const enabledProviders = providers.filter(p => p.enabled);
+
+      for (const provider of enabledProviders) {
+        let entries = await mcpProviderService.getCachedEntries(provider.id);
+
+        if (!entries) {
+          // Sync if no cache
+          entries = await mcpProviderService.syncProvider(provider);
+        }
+
+        const entry = entries.find(e => e.id === serverId);
+        if (entry) {
+          logger.mcp.debug('Found registry entry', { serverId, providerId: provider.id });
+          return { success: true, data: entry };
+        }
+      }
+
+      logger.mcp.warn('Registry entry not found', { serverId });
+      return { success: false, error: `Server not found: ${serverId}` };
+    } catch (error: unknown) {
+      const message = error instanceof Error ? error.message : 'Unknown error';
+      logger.mcp.error('Failed to get registry entry', { serverId, error: message });
+      return { success: false, error: message };
+    }
+  });
+
   logger.mcp.info('MCP provider handlers registered');
 }

--- a/src/main/lifecycle/window.ts
+++ b/src/main/lifecycle/window.ts
@@ -8,6 +8,7 @@ import { BrowserWindow, nativeTheme } from "electron";
 import { join } from "path";
 import { getLogger } from "../services/logging";
 import { safeOpenExternal } from "../utils/urlSecurity";
+import { deepLinkService } from "../services/deepLinkService";
 
 const logger = getLogger();
 
@@ -102,6 +103,20 @@ export function createMainWindow(): BrowserWindow {
 
   // Security: Handle external links with protocol validation
   mainWindow.webContents.setWindowOpenHandler((details) => {
+    // Handle levante:// deep links internally (e.g., from mcp_discovery tool)
+    try {
+      const parsedUrl = new URL(details.url);
+      if (parsedUrl.protocol === "levante:") {
+        logger.core.info("Handling internal deep link from click", {
+          url: details.url
+        });
+        deepLinkService.handleDeepLink(details.url);
+        return { action: "deny" };
+      }
+    } catch {
+      // Invalid URL, let safeOpenExternal handle the error
+    }
+
     // Validate and open URL with protocol allowlist (http, https, mailto only)
     // Blocks file://, javascript:, and other dangerous protocols
     safeOpenExternal(details.url, "window-open-handler");

--- a/src/main/services/ai/builtInTools.ts
+++ b/src/main/services/ai/builtInTools.ts
@@ -3,11 +3,39 @@ import { tool } from "ai";
 import { z } from "zod";
 import { getLogger } from '../logging';
 import { getMermaidValidator } from './mermaidValidator';
+import { mcpProviderService } from '../mcp/MCPProviderService';
+import { MCPConfigurationManager } from '../mcpConfigManager';
+import type { MCPProvider, MCPRegistryEntry } from '../../../renderer/types/mcp';
+import mcpProvidersData from '../../../renderer/data/mcpProviders.json';
 
 const logger = getLogger();
 
 export interface BuiltInToolsConfig {
     mermaidValidation: boolean;
+    mcpDiscovery: boolean;
+}
+
+/**
+ * Result from MCP discovery search
+ */
+interface MCPDiscoveryResult {
+    id: string;
+    name: string;
+    description: string;
+    category: string;
+    icon?: string;
+    transport: string;
+    configureUrl: string;
+    hasApiKeyRequirement: boolean;
+}
+
+/**
+ * Response from the MCP discovery tool
+ */
+interface MCPDiscoveryToolResponse {
+    results: MCPDiscoveryResult[];
+    totalMatches: number;
+    message: string;
 }
 
 /**
@@ -22,6 +50,14 @@ export async function getBuiltInTools(config?: BuiltInToolsConfig): Promise<Reco
         const mermaidTool = await createMermaidValidationTool();
         if (mermaidTool) {
             tools['builtin_validate_mermaid'] = mermaidTool;
+        }
+    }
+
+    // Add MCP discovery tool if enabled
+    if (config?.mcpDiscovery !== false) {
+        const discoveryTool = await createMCPDiscoveryTool();
+        if (discoveryTool) {
+            tools['mcp_discovery'] = discoveryTool;
         }
     }
 
@@ -71,6 +107,168 @@ If validation fails, fix the syntax and validate again before delivering.`,
                     isValid: false,
                     error: error instanceof Error ? error.message : 'Validation failed',
                     suggestion: 'Check syntax and try again'
+                };
+            }
+        },
+    });
+}
+
+/**
+ * Search and score MCP servers based on query
+ */
+function searchMCPServers(
+    entries: MCPRegistryEntry[],
+    query: string,
+    configuredIds: Set<string>,
+    limit: number
+): MCPDiscoveryResult[] {
+    const queryLower = query.toLowerCase();
+    const terms = queryLower.split(/\s+/).filter(t => t.length > 0);
+
+    // Score each entry
+    const scored = entries
+        .filter(entry => !configuredIds.has(entry.id)) // Exclude configured
+        .map(entry => {
+            let score = 0;
+            const searchableText = [
+                entry.name,
+                entry.description,
+                entry.category,
+                entry.id
+            ].join(' ').toLowerCase();
+
+            // Exact match in name gets highest score
+            if (entry.name.toLowerCase().includes(queryLower)) score += 10;
+
+            // ID match
+            if (entry.id.toLowerCase().includes(queryLower)) score += 8;
+
+            // Category match
+            if (entry.category.toLowerCase().includes(queryLower)) score += 5;
+
+            // Term matches in description
+            terms.forEach(term => {
+                if (searchableText.includes(term)) score += 1;
+            });
+
+            return { entry, score };
+        })
+        .filter(item => item.score > 0)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, Math.min(limit, 10));
+
+    return scored.map(({ entry }) => ({
+        id: entry.id,
+        name: entry.name,
+        description: entry.description,
+        category: entry.category,
+        icon: entry.icon,
+        transport: entry.transport.type,
+        configureUrl: `levante://mcp/configure/${encodeURIComponent(entry.id)}`,
+        hasApiKeyRequirement: entry.configuration.fields.some(
+            f => f.type === 'password' || f.key.toLowerCase().includes('key') || f.key.toLowerCase().includes('token')
+        )
+    }));
+}
+
+/**
+ * Creates the MCP discovery tool that allows AI to search for available MCP servers
+ */
+async function createMCPDiscoveryTool() {
+    const configManager = new MCPConfigurationManager();
+
+    return tool({
+        description: `Search for MCP (Model Context Protocol) servers in the Levante MCP Shop.
+
+Use this tool when:
+- Users ask about adding capabilities, integrations, or tools
+- Users want to connect to external services (GitHub, databases, file systems, etc.)
+- Users ask "Can you access X?" or "Is there a tool for Y?"
+- Current tools cannot fulfill the user's request
+
+The tool returns matching servers that are NOT already configured, with deep links to configure them.
+Each result includes a configureUrl that users can click to add the MCP server.`,
+
+        parameters: z.object({
+            query: z.string().describe('Search query to find MCP servers (e.g., "github", "database", "file system", "email")'),
+            limit: z.number().optional().default(5).describe('Maximum number of results to return (1-10, default: 5)'),
+        }),
+
+        execute: async (args: { query: string; limit?: number }): Promise<MCPDiscoveryToolResponse> => {
+            const { query, limit = 5 } = args;
+
+            try {
+                logger.aiSdk.info('MCP discovery search', {
+                    query,
+                    limit
+                });
+
+                // Get all registry entries from all enabled providers
+                const providers = (mcpProvidersData.providers as MCPProvider[]).filter(p => p.enabled);
+                const allEntries: MCPRegistryEntry[] = [];
+
+                for (const provider of providers) {
+                    try {
+                        // Try cache first
+                        let entries = await mcpProviderService.getCachedEntries(provider.id);
+
+                        if (!entries) {
+                            // Sync if no cache
+                            entries = await mcpProviderService.syncProvider(provider);
+                        }
+
+                        if (entries) {
+                            allEntries.push(...entries);
+                        }
+                    } catch (error) {
+                        logger.aiSdk.warn('Failed to get entries from provider', {
+                            providerId: provider.id,
+                            error: error instanceof Error ? error.message : error
+                        });
+                    }
+                }
+
+                // Get configured server IDs
+                const configuredServers = await configManager.listServers();
+                const configuredIds = new Set(configuredServers.map(s => s.id));
+
+                logger.aiSdk.debug('MCP discovery context', {
+                    totalEntries: allEntries.length,
+                    configuredCount: configuredIds.size
+                });
+
+                // Search and score entries
+                const results = searchMCPServers(allEntries, query, configuredIds, limit);
+
+                logger.aiSdk.info('MCP discovery results', {
+                    query,
+                    totalMatches: results.length,
+                    resultIds: results.map(r => r.id)
+                });
+
+                if (results.length === 0) {
+                    return {
+                        results: [],
+                        totalMatches: 0,
+                        message: `No MCP servers found matching "${query}". Try different search terms like "database", "file", "api", "automation", etc.`
+                    };
+                }
+
+                return {
+                    results,
+                    totalMatches: results.length,
+                    message: `Found ${results.length} MCP server(s) matching "${query}". Show the user these options with their configure URLs.`
+                };
+            } catch (error) {
+                logger.aiSdk.error('MCP discovery failed', {
+                    query,
+                    error: error instanceof Error ? error.message : error
+                });
+
+                return {
+                    results: [],
+                    totalMatches: 0,
+                    message: `Discovery search failed: ${error instanceof Error ? error.message : 'Unknown error'}. The MCP shop may be unavailable.`
                 };
             }
         },

--- a/src/main/services/ai/systemPromptBuilder.ts
+++ b/src/main/services/ai/systemPromptBuilder.ts
@@ -10,7 +10,8 @@ export async function buildSystemPrompt(
   webSearch: boolean,
   enableMCP: boolean,
   toolCount: number,
-  mermaidValidation: boolean = true
+  mermaidValidation: boolean = true,
+  mcpDiscoveryEnabled: boolean = true
 ): Promise<string> {
   // Add current date information
   const currentDate = new Date();
@@ -171,6 +172,38 @@ If you are requested to generate a Mermaid diagram or decide to generate one:
 4. Output the diagram in a markdown code block with the \`mermaid\` language identifier.`;
   }
 
+  // Add MCP Discovery capabilities (if enabled)
+  if (mcpDiscoveryEnabled) {
+    systemPrompt += `
+
+MCP DISCOVERY:
+You have access to the \`mcp_discovery\` tool to search for MCP servers in the Levante MCP Shop.
+
+Use this tool when:
+- Users ask about adding capabilities, integrations, or tools you don't currently have
+- Users want to connect to external services (GitHub, databases, file systems, email, etc.)
+- Users ask "Can you access X?" or "Is there a tool for Y?"
+- You cannot fulfill a user's request with your current tools
+
+When presenting discovery results to users:
+1. Show each server with its name and a brief description
+2. Include the configure URL as a markdown link - it will render as a clickable button
+3. Use this exact format: [Configure ServerName](configureUrl)
+4. Mention if the server requires API keys or authentication
+5. Offer to help once the user has configured the server
+
+Example response format:
+"To access GitHub, I found this MCP server you can configure:
+
+**GitHub** - Access GitHub repositories, issues, and pull requests
+
+[Configure GitHub](levante://mcp/configure/github)
+
+*Requires: GitHub Personal Access Token*
+
+Click the button above to add it. Once configured, I'll be able to help you with GitHub operations."`;
+  }
+
   // Debug log for final system prompt
   logger.aiSdk.debug('Final system prompt generated', {
     enabled: personalization?.enabled || false,
@@ -183,6 +216,7 @@ If you are requested to generate a Mermaid diagram or decide to generate one:
     enableMCP,
     toolCount,
     mermaidValidation,
+    mcpDiscoveryEnabled,
     promptLength: systemPrompt.length,
     fullPrompt: systemPrompt
   });

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -695,15 +695,16 @@ export class AIService {
     }
   }
 
-  private async getBuiltInToolsConfig(): Promise<{ mermaidValidation: boolean }> {
+  private async getBuiltInToolsConfig(): Promise<{ mermaidValidation: boolean; mcpDiscovery: boolean }> {
     try {
       const { preferencesService } = await import("./preferencesService");
       const aiPrefs = preferencesService.get('ai') as any;
       return {
-        mermaidValidation: aiPrefs?.mermaidValidation !== false // Enabled by default
+        mermaidValidation: aiPrefs?.mermaidValidation !== false, // Enabled by default
+        mcpDiscovery: aiPrefs?.mcpDiscovery !== false // Enabled by default
       };
     } catch {
-      return { mermaidValidation: true };
+      return { mermaidValidation: true, mcpDiscovery: true };
     }
   }
 
@@ -893,7 +894,8 @@ export class AIService {
           webSearch,
           enableMCP,
           Object.keys(tools).length,
-          builtInToolsConfig.mermaidValidation
+          builtInToolsConfig.mermaidValidation,
+          builtInToolsConfig.mcpDiscovery
         ),
         // Use stopWhen as recommended in AI SDK v5 (not maxSteps)
         // This allows the model to continue generating after tool results
@@ -1515,7 +1517,8 @@ export class AIService {
           webSearch,
           enableMCP,
           Object.keys(tools).length,
-          builtInToolsConfig.mermaidValidation
+          builtInToolsConfig.mermaidValidation,
+          builtInToolsConfig.mcpDiscovery
         ),
         stopWhen: stepCountIs(await calculateMaxSteps(Object.keys(tools).length)),
       });

--- a/src/main/services/deepLinkService.ts
+++ b/src/main/services/deepLinkService.ts
@@ -14,7 +14,7 @@ export interface InputDefinition {
 }
 
 export interface DeepLinkAction {
-  type: 'mcp-add' | 'chat-new';
+  type: 'mcp-add' | 'mcp-configure' | 'chat-new';
   data: Record<string, unknown>;
 }
 
@@ -59,6 +59,11 @@ export class DeepLinkService {
       // Route to appropriate handler
       if (category === 'mcp' && action === 'add') {
         return this.parseMCPAddLink(params);
+      } else if (category === 'mcp' && action === 'configure') {
+        // Format: levante://mcp/configure/{server-id}
+        // The server ID comes after 'configure/' in the pathname
+        const remainingPath = pathname.replace(/^configure\/?/, '');
+        return this.parseMCPConfigureLink(remainingPath, params);
       } else if (category === 'chat' && action === 'new') {
         return this.parseChatNewLink(params);
       }
@@ -303,6 +308,30 @@ export class DeepLinkService {
       data: {
         prompt: decodeURIComponent(prompt),
         autoSend: autoSend === 'true'
+      }
+    };
+  }
+
+  /**
+   * Parse MCP configuration deep link (from discovery tool)
+   * Format: levante://mcp/configure/{server-id}
+   * The server config will be fetched from the registry in the renderer
+   */
+  private parseMCPConfigureLink(serverId: string, _params: Record<string, string>): DeepLinkAction | null {
+    // Decode the server ID in case it contains URL-encoded characters
+    const decodedServerId = decodeURIComponent(serverId).trim();
+
+    if (!decodedServerId) {
+      logger.core.warn('Missing server ID for MCP configure', { serverId });
+      return null;
+    }
+
+    logger.core.info('Parsed MCP configure deep link', { serverId: decodedServerId });
+
+    return {
+      type: 'mcp-configure',
+      data: {
+        serverId: decodedServerId
       }
     };
   }

--- a/src/preload/api/mcp.ts
+++ b/src/preload/api/mcp.ts
@@ -114,7 +114,10 @@ export const mcpApi = {
       ipcRenderer.invoke('levante/mcp/providers/get-entries', providerId),
 
     getAllEntries: () =>
-      ipcRenderer.invoke('levante/mcp/providers/get-all-entries')
+      ipcRenderer.invoke('levante/mcp/providers/get-all-entries'),
+
+    getEntry: (serverId: string) =>
+      ipcRenderer.invoke('levante/mcp/providers/get-entry', serverId)
   },
 
   // Resource methods

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -438,6 +438,9 @@ export interface LevanteAPI {
         data?: any[];
         error?: string;
       }>;
+      getEntry: (
+        serverId: string
+      ) => Promise<{ success: boolean; data?: any; error?: string }>;
     };
     // Resource methods
     listResources: (

--- a/src/preload/types/index.ts
+++ b/src/preload/types/index.ts
@@ -160,7 +160,7 @@ export interface InputDefinition {
 }
 
 export interface DeepLinkAction {
-  type: 'mcp-add' | 'chat-new';
+  type: 'mcp-add' | 'mcp-configure' | 'chat-new';
   data: Record<string, unknown>;
 }
 

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -230,6 +230,61 @@ function App() {
               duration: 5000
             });
           }
+        } else if (action.type === 'mcp-configure') {
+          // Handle MCP configure deep link (from discovery tool)
+          const { serverId } = action.data as { serverId: string };
+
+          logger.core.info('Handling MCP configure from discovery', { serverId });
+
+          // Fetch the server entry from registry (modal opens in current page context)
+          const result = await window.levante.mcp.providers.getEntry(serverId);
+
+          if (result.success && result.data) {
+            const entry = result.data;
+
+            logger.core.info('Found registry entry for MCP configure', {
+              serverId: entry.id,
+              name: entry.name,
+              transport: entry.transport.type
+            });
+
+            // Build the config from registry entry template
+            const config: Partial<MCPServerConfig> = {
+              id: entry.id,
+              name: entry.name,
+              transport: entry.transport.type,
+              ...(entry.configuration.template || {})
+            };
+
+            // Convert fields to inputs format for the modal
+            const inputs: Record<string, any> = {};
+            if (entry.configuration.fields && entry.configuration.fields.length > 0) {
+              for (const field of entry.configuration.fields) {
+                inputs[field.key] = {
+                  label: field.label,
+                  required: field.required,
+                  type: field.type,
+                  default: field.defaultValue,
+                  description: field.description
+                };
+              }
+            }
+
+            // Open the modal
+            setMcpModalConfig({
+              config,
+              name: entry.name,
+              sourceUrl: entry.metadata?.homepage || entry.metadata?.repository,
+              inputs: Object.keys(inputs).length > 0 ? inputs : undefined
+            });
+            setMcpModalOpen(true);
+          } else {
+            logger.core.error('Failed to find MCP server in registry', { serverId, error: result.error });
+            toast.error('MCP server not found', {
+              description: `Could not find server: ${serverId}`,
+              duration: 5000
+            });
+          }
         } else if (action.type === 'chat-new') {
           const { prompt, autoSend } = action.data as { prompt: string; autoSend: boolean };
 

--- a/src/renderer/components/ai-elements/response.tsx
+++ b/src/renderer/components/ai-elements/response.tsx
@@ -9,6 +9,53 @@ import remarkMath from 'remark-math';
 import rehypeKatex from 'rehype-katex';
 import { Mermaid } from '@/components/ui/mermaid';
 import { useStreamingContext } from '@/contexts/StreamingContext';
+import { Settings2 } from 'lucide-react';
+
+// Deep link button component for levante:// URLs
+const DeepLinkButton = ({ href, children }: { href: string; children: React.ReactNode }) => {
+  const handleClick = (e: React.MouseEvent) => {
+    e.preventDefault();
+    // Use window.open which triggers the setWindowOpenHandler in main process
+    window.open(href, '_blank');
+  };
+
+  return (
+    <button
+      onClick={handleClick}
+      className={cn(
+        "inline-flex items-center gap-2 px-4 py-2 my-2",
+        "bg-primary text-primary-foreground hover:bg-primary/90",
+        "rounded-lg font-medium text-sm transition-colors",
+        "shadow-sm hover:shadow-md",
+        "focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2"
+      )}
+    >
+      <Settings2 className="h-4 w-4" />
+      {children}
+    </button>
+  );
+};
+
+// Custom link component that handles levante:// URLs as buttons
+const CustomLink = ({ href, children, ...props }: any) => {
+  // Check if this is a levante:// deep link
+  if (href?.startsWith('levante://')) {
+    return <DeepLinkButton href={href}>{children}</DeepLinkButton>;
+  }
+
+  // Regular link - open in external browser
+  return (
+    <a
+      href={href}
+      target="_blank"
+      rel="noopener noreferrer"
+      className="text-primary hover:underline"
+      {...props}
+    >
+      {children}
+    </a>
+  );
+};
 
 // Custom components for proper list rendering
 const listComponents = {
@@ -21,6 +68,7 @@ const listComponents = {
   li: ({ className, ...props }: any) => (
     <li className={cn("py-1", className)} {...props} />
   ),
+  a: CustomLink,
 };
 
 type ResponseProps = ComponentProps<typeof Streamdown> & {

--- a/src/renderer/components/settings/AIConfigSection.tsx
+++ b/src/renderer/components/settings/AIConfigSection.tsx
@@ -67,6 +67,18 @@ export const AIConfigSection = () => {
           </div>
         </div>
 
+        <div className="bg-muted/50 p-3 rounded-md text-sm">
+          <p className="font-medium mb-1">{t('settings:ai_config.how_it_works.title')}</p>
+          <ul className="text-muted-foreground space-y-1 text-xs">
+            <li>• {t('settings:ai_config.how_it_works.formula')}</li>
+            <li>• {t('settings:ai_config.how_it_works.example', {
+              baseSteps: config.baseSteps,
+              result: Math.min(Math.max(config.baseSteps + Math.floor(24 / 5) * 2, config.baseSteps), config.maxSteps)
+            })}</li>
+            <li>• {t('settings:ai_config.how_it_works.note')}</li>
+          </ul>
+        </div>
+
         <div className="flex items-center justify-between py-2">
           <div className="space-y-0.5">
             <Label>{t('settings:ai_config.mermaid_validation.label')}</Label>
@@ -79,6 +91,22 @@ export const AIConfigSection = () => {
             onCheckedChange={(checked) => setConfig(prev => ({
               ...prev,
               mermaidValidation: checked
+            }))}
+          />
+        </div>
+
+        <div className="flex items-center justify-between py-2">
+          <div className="space-y-0.5">
+            <Label>{t('settings:ai_config.mcp_discovery.label')}</Label>
+            <p className="text-xs text-muted-foreground">
+              {t('settings:ai_config.mcp_discovery.description')}
+            </p>
+          </div>
+          <Switch
+            checked={config.mcpDiscovery}
+            onCheckedChange={(checked) => setConfig(prev => ({
+              ...prev,
+              mcpDiscovery: checked
             }))}
           />
         </div>
@@ -99,18 +127,6 @@ export const AIConfigSection = () => {
               {t('settings:personalization.saved')}
             </div>
           )}
-        </div>
-
-        <div className="bg-muted/50 p-3 rounded-md text-sm">
-          <p className="font-medium mb-1">{t('settings:ai_config.how_it_works.title')}</p>
-          <ul className="text-muted-foreground space-y-1 text-xs">
-            <li>• {t('settings:ai_config.how_it_works.formula')}</li>
-            <li>• {t('settings:ai_config.how_it_works.example', {
-              baseSteps: config.baseSteps,
-              result: Math.min(Math.max(config.baseSteps + Math.floor(24 / 5) * 2, config.baseSteps), config.maxSteps)
-            })}</li>
-            <li>• {t('settings:ai_config.how_it_works.note')}</li>
-          </ul>
         </div>
       </div>
     </SettingsSection>

--- a/src/renderer/hooks/useAIConfig.ts
+++ b/src/renderer/hooks/useAIConfig.ts
@@ -8,6 +8,7 @@ export const useAIConfig = () => {
     baseSteps: 5,
     maxSteps: 20,
     mermaidValidation: true,
+    mcpDiscovery: true,
   });
 
   const [state, setState] = useState({
@@ -26,7 +27,8 @@ export const useAIConfig = () => {
         ...prev,
         baseSteps: aiConfig?.data?.baseSteps || 5,
         maxSteps: aiConfig?.data?.maxSteps || 20,
-        mermaidValidation: aiConfig?.data?.mermaidValidation !== false
+        mermaidValidation: aiConfig?.data?.mermaidValidation !== false,
+        mcpDiscovery: aiConfig?.data?.mcpDiscovery !== false
       }));
     } catch (error) {
       logger.preferences.error('Error loading AI steps configuration', {
@@ -42,7 +44,8 @@ export const useAIConfig = () => {
       await window.levante.preferences.set('ai', {
         baseSteps: config.baseSteps,
         maxSteps: config.maxSteps,
-        mermaidValidation: config.mermaidValidation
+        mermaidValidation: config.mermaidValidation,
+        mcpDiscovery: config.mcpDiscovery
       });
 
       setState(prev => ({ ...prev, saving: false, saved: true }));

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -119,6 +119,10 @@
     "mermaid_validation": {
       "label": "Mermaid Diagram Generation",
       "description": "Enable AI to generate and validate Mermaid diagrams"
+    },
+    "mcp_discovery": {
+      "label": "MCP Server Discovery",
+      "description": "Allow AI to suggest and recommend MCP servers from the shop when you need additional capabilities"
     }
   },
   "developer_mode": {

--- a/src/renderer/locales/es/settings.json
+++ b/src/renderer/locales/es/settings.json
@@ -119,6 +119,10 @@
     "mermaid_validation": {
       "label": "Generación de Diagramas Mermaid",
       "description": "Permite que la IA genere y valide diagramas Mermaid"
+    },
+    "mcp_discovery": {
+      "label": "Descubrimiento de Servidores MCP",
+      "description": "Permite que la IA sugiera y recomiende servidores MCP de la tienda cuando necesites capacidades adicionales"
     }
   },
   "developer_mode": {


### PR DESCRIPTION
Implements a complete MCP discovery system that allows AI to proactively suggest relevant MCP servers from the shop when users need additional capabilities.

Features:
- Built-in `mcp_discovery` tool for searching MCP Shop registry
- AI can suggest servers when current tools are insufficient
- Deep link integration (levante://mcp/configure/{id}) for one-click configuration
- Automatic button rendering for configure URLs in AI responses
- UI toggle in Settings > AI Configuration to enable/disable discovery
- Bilingual support (English/Spanish) for all UI elements
- Comprehensive documentation in docs/MCP_DISCOVERY.md

Technical changes:
- Added search algorithm with relevance scoring
- Filters out already-configured servers
- Integrates with MCPProviderService for registry access
- Deep link handler opens configuration modal from chat
- System prompt instructions for when to use discovery tool

🤖 Generated with [Claude Code](https://claude.com/claude-code)