### PR TITLE
 fix: seleccionar último modelo usado por defecto en chats nuevos

### DIFF
--- a/src/renderer/components/chat/ChatPromptInput.tsx
+++ b/src/renderer/components/chat/ChatPromptInput.tsx
@@ -234,7 +234,11 @@ export function ChatPromptInput({
             placeholder={availableModels.length === 0 ? t('model_selector.no_models') : t('model_selector.label')}
           />
           <PromptInputSubmit
-            disabled={status !== 'streaming' && !input && attachedFiles.length === 0 && selectedResources.length === 0 && selectedPrompts.length === 0}
+            disabled={
+              !model ||
+              model.trim() === '' ||
+              (status !== 'streaming' && !input && attachedFiles.length === 0 && selectedResources.length === 0 && selectedPrompts.length === 0)
+            }
             status={status}
           />
         </div>

--- a/src/renderer/hooks/useModelSelection.ts
+++ b/src/renderer/hooks/useModelSelection.ts
@@ -10,6 +10,7 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { modelService } from '@/services/modelService';
 import { getRendererLogger } from '@/services/logger';
+import { usePreference } from '@/hooks/usePreferences';
 import type { Model, GroupedModelsByProvider } from '../../types/models';
 
 const logger = getRendererLogger();
@@ -78,6 +79,9 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
   const [groupedModelsByProvider, setGroupedModelsByProvider] = useState<GroupedModelsByProvider | null>(null);
   const [modelsLoading, setModelsLoading] = useState(true);
 
+  // Load and save lastUsedModel from preferences
+  const [lastUsedModel, setLastUsedModel] = usePreference('lastUsedModel');
+
   // Get current model info - search in grouped models if available, otherwise availableModels
   const currentModelInfo = useMemo(() => {
     // First try to find in available models (active provider)
@@ -141,12 +145,13 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
     }
   }, [onLoadUserName]);
 
-  // Auto-select model if only one is available and no model is selected
+  // Auto-select model if only one is available OR use lastUsedModel when no model is selected
   useEffect(() => {
     if (!modelsLoading && !model && !currentSession) {
       // Logic:
       // 1. If groupedModels exists, check total count.
       // 2. If availableModels exists (legacy/active), check that.
+      // 3. If multiple models available, use lastUsedModel if available
 
       let candidateModel = '';
 
@@ -159,14 +164,28 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
       } else if (availableModels.length === 1) {
         // Fallback or specific scope
         candidateModel = availableModels[0].id;
+      } else if (lastUsedModel) {
+        // Multiple models available - use lastUsedModel if it exists in available models
+        // Check if lastUsedModel exists in availableModels or groupedModelsByProvider
+        const modelExists = availableModels.some(m => m.id === lastUsedModel) ||
+          (groupedModelsByProvider?.providers.some(p =>
+            p.models.some(m => m.id === lastUsedModel)
+          ) ?? false);
+
+        if (modelExists) {
+          candidateModel = lastUsedModel;
+          logger.models.info('Using last used model', { model: candidateModel });
+        }
       }
 
       if (candidateModel) {
-        logger.models.info('Auto-selecting single available model', { model: candidateModel });
+        if (candidateModel !== lastUsedModel && availableModels.length === 1) {
+          logger.models.info('Auto-selecting single available model', { model: candidateModel });
+        }
         setModel(candidateModel);
       }
     }
-  }, [availableModels, groupedModelsByProvider, modelsLoading, model, currentSession]);
+  }, [availableModels, groupedModelsByProvider, modelsLoading, model, currentSession, lastUsedModel]);
 
   // Sync model with current session when session changes
   useEffect(() => {
@@ -178,6 +197,18 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
       setModel(currentSession.model);
     }
   }, [currentSession?.id, currentSession?.model]);
+
+  // Save model to preferences when it changes (for default selection in new chats)
+  useEffect(() => {
+    if (model && model !== lastUsedModel) {
+      logger.models.info('Saving last used model to preferences', { model });
+      setLastUsedModel(model).catch((error) => {
+        logger.models.error('Failed to save last used model', {
+          error: error instanceof Error ? error.message : String(error)
+        });
+      });
+    }
+  }, [model, lastUsedModel, setLastUsedModel]);
 
   // Handle model change with session type validation
   const handleModelChange = useCallback(async (newModelId: string) => {

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -446,6 +446,13 @@ const ChatPage = () => {
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
+    // Validate that a model is selected before sending
+    if (!model || model.trim() === '') {
+      logger.core.warn('Cannot send message: no model selected');
+      // Display error or warning to user - for now, just prevent submission
+      return;
+    }
+
     // If currently streaming
     if (status === 'streaming') {
       // If there's input, we want to stop current stream and send the new message


### PR DESCRIPTION
  Problema:
  - No se seleccionaba ningún modelo por defecto al crear chats nuevos
  - El sistema permitía enviar peticiones sin modelo seleccionado
  - Con muchos modelos configurados, el usuario debía seleccionar manualmente cada vez

  Solución:
  - Guardar el último modelo seleccionado en ui-preferences.json (lastUsedModel)
  - Cargar automáticamente lastUsedModel al crear un nuevo chat
  - Prevenir envío de mensajes sin modelo seleccionado:
    * Botón de envío deshabilitado cuando no hay modelo
    * Validación en handleSubmit antes de crear sesión
    * Verificación de existencia del modelo en modelos disponibles

  Beneficios:
  - Mejor experiencia de usuario con modelo pre-seleccionado
  - Previene errores al enviar sin modelo
  - Reduce fricción en el flujo de trabajo

  Archivos modificados:
  - src/renderer/hooks/useModelSelection.ts
  - src/renderer/pages/ChatPage.tsx
  - src/renderer/components/chat/ChatPromptInput.tsx