### PR TITLE
fix: sync message IDs between AI SDK UI state and database

### DIFF
--- a/src/main/services/chatService.ts
+++ b/src/main/services/chatService.ts
@@ -231,11 +231,14 @@ export class ChatService {
       contentLength: input.content.length,
       hasToolCalls: !!input.tool_calls,
       hasAttachments: !!input.attachments,
-      attachmentCount: input.attachments?.length || 0
+      attachmentCount: input.attachments?.length || 0,
+      providedId: !!input.id // Log if frontend supplied an ID
     });
 
     try {
-      const id = this.generateId();
+      // Use frontend-provided ID when present, otherwise generate a new one.
+      // This ensures consistency between AI SDK UI state and database.
+      const id = input.id || this.generateId();
       const now = Date.now();
 
       const attachmentsString = input.attachments ? JSON.stringify(input.attachments) : null;

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -348,8 +348,9 @@ const ChatPage = () => {
       setPendingMessageAfterStop(null);
 
       // Persist user message to database BEFORE sending to AI (to ensure correct order)
+      const messageId = `user-${Date.now()}`;
       const userMessage = {
-        id: `user-${Date.now()}`,
+        id: messageId,
         role: 'user' as const,
         parts: [{ type: 'text' as const, text: messageText }],
         attachments: undefined,
@@ -357,8 +358,12 @@ const ChatPage = () => {
 
       persistMessage(userMessage)
         .then(() => {
-          // Send the message after persisting
-          sendMessageAI({ text: messageText });
+          // Send the message after persisting with the same ID
+          sendMessageAI({
+            id: messageId, // Use the same ID we persisted to DB
+            role: 'user',
+            parts: [{ type: 'text', text: messageText }],
+          });
         })
         .catch((err) => {
           logger.database.error('Failed to persist message after stop', { error: err });
@@ -373,8 +378,9 @@ const ChatPage = () => {
       setPendingWidgetMessage(null);
 
       // Persist user message to database BEFORE sending to AI
+      const messageId = `user-${Date.now()}`;
       const userMessage = {
-        id: `user-${Date.now()}`,
+        id: messageId,
         role: 'user' as const,
         parts: [{ type: 'text' as const, text: messageText }],
         attachments: undefined,
@@ -382,7 +388,11 @@ const ChatPage = () => {
 
       persistMessage(userMessage)
         .then(() => {
-          sendMessageAI({ text: messageText });
+          sendMessageAI({
+            id: messageId, // Use the same ID we persisted to DB
+            role: 'user',
+            parts: [{ type: 'text', text: messageText }],
+          });
         })
         .catch((err) => {
           logger.database.error('Failed to persist widget message', { error: err });
@@ -621,12 +631,18 @@ const ChatPage = () => {
           await updateSessionModel(currentSession.id, model);
         }
 
-        // Send to AI with attachments using AI SDK 6 format: { text, files }
-        // The ElectronChatTransport will pass these to the IPC layer
+        // Send to AI with attachments AND the same ID we persisted to DB
+        // This ensures AI SDK UI state matches database
         await sendMessageAI(
           {
-            text: messageText,
-            files: fileParts.length > 0 ? fileParts : undefined
+            id: messageId, // Use the same ID we persisted to DB
+            role: 'user',
+            parts: fileParts.length > 0
+              ? [
+                  { type: 'text', text: messageText },
+                  ...fileParts
+                ]
+              : [{ type: 'text', text: messageText }]
           },
           {
             body: {
@@ -738,11 +754,17 @@ const ChatPage = () => {
           await updateSessionModel(currentSession.id, model);
         }
 
-        // Send to AI with attachments using AI SDK 6 format: { text, files }
+        // Send to AI with attachments AND the same ID we persisted to DB
         await sendMessageAI(
           {
-            text: messageText,
-            files: fileParts.length > 0 ? fileParts : undefined
+            id: messageId, // Use the same ID we persisted to DB
+            role: 'user',
+            parts: fileParts.length > 0
+              ? [
+                  { type: 'text', text: messageText },
+                  ...fileParts
+                ]
+              : [{ type: 'text', text: messageText }]
           },
           {
             body: {

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -437,6 +437,7 @@ export const useChatStore = create<ChatStore>()(
           }
 
           const input: CreateMessageInput = {
+            id: message.id, // Pass frontend-generated ID so DB matches AI SDK UI state
             session_id: currentSession.id,
             role: message.role,
             content: content || '', // Fallback to empty string if no text

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -98,6 +98,7 @@ export interface CreateChatSessionInput {
 }
 
 export interface CreateMessageInput {
+  id?: string; // Optional: Frontend-generated ID. If provided, backend uses it; otherwise generates one.
   session_id: string;
   role: "user" | "assistant" | "system";
   content: string;


### PR DESCRIPTION
## Summary

- **Fix ID mismatch** between AI SDK UI state and database when using the `useChat` hook
- **Pass frontend-generated IDs** to `sendMessage()` using `CreateUIMessage` format `{ id, role, parts }`
- **Ensure database and UI consistency** without manual ID synchronization

## Problem

When using AI SDK v5/v6 `useChat` hook, there was a **3-way ID mismatch**:

1. **Frontend generates**: `user-1704710400000`
2. **AI SDK generates internally**: `HzLYWiSJGVEUQBhR`
3. **Database receives**: `user-1704710400000`

This caused the error:
```
[CORE] [ERROR] Failed to edit message
  messageId: "HzLYWiSJGVEUQBhR"
```

Because the UI showed the AI SDK's ID, but the database had the frontend's ID.

## Root Cause

The AI SDK's `sendMessage()` was being called with shorthand format:
```typescript
sendMessageAI({ text: messageText, files: ... });
```

This made the AI SDK **generate its own ID internally**, ignoring the ID we persisted to the database.

## Solution

Use the full `CreateUIMessage` format with explicit ID:
```typescript
sendMessageAI({
  id: messageId, // Same ID we persisted to DB
  role: 'user',
  parts: [{ type: 'text', text: messageText }]
});
```

This follows [AI SDK best practices for message persistence](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot-message-persistence).

## Changes

| File | Change |
|------|--------|
| `src/types/database.ts` | Add optional `id` field to `CreateMessageInput` |
| `src/main/services/chatService.ts` | Use `input.id \|\| this.generateId()` |
| `src/renderer/stores/chatStore.ts` | Pass `id: message.id` to `CreateMessageInput` |
| `src/renderer/pages/ChatPage.tsx` | Use `CreateUIMessage` format in 4 `sendMessageAI()` calls |

## Result

**Before**:
```
Frontend → DB: "user-1704710400000"
Frontend → AI SDK: generates "HzLYWiSJGVEUQBhR"
UI shows: "HzLYWiSJGVEUQBhR" ❌ (doesn't match DB)
```

**After**:
```
Frontend → DB: "user-1704710400000"  
Frontend → AI SDK: "user-1704710400000" (explicit)
UI shows: "user-1704710400000" ✅ (matches DB)
```

## Test plan

- [ ] Send a message and immediately try to edit it (without page reload)
- [ ] Verify no "Message not found" error in console
- [ ] Verify message IDs match between DB and UI
- [ ] Test with attachments (images/files)
- [ ] Test message after stopping streaming
- [ ] Test widget messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)