### PR TITLE
fix(chat): implement JavaScript-based auto-resize for textarea

### DIFF
--- a/src/renderer/components/ai-elements/prompt-input.tsx
+++ b/src/renderer/components/ai-elements/prompt-input.tsx
@@ -17,7 +17,7 @@ import type {
   HTMLAttributes,
   KeyboardEventHandler,
 } from 'react';
-import { Children, forwardRef } from 'react';
+import { Children, forwardRef, useCallback, useEffect, useRef } from 'react';
 
 export type PromptInputProps = HTMLAttributes<HTMLFormElement>;
 
@@ -46,11 +46,47 @@ export const PromptInputTextarea = forwardRef<
       className,
       placeholder = 'What would you like to know?',
       minHeight = 48,
-      maxHeight = 300,
+      maxHeight = 164,
       ...props
     },
     ref
   ) => {
+    const internalRef = useRef<HTMLTextAreaElement>(null);
+
+    // Merge refs to support both external ref and internal ref
+    const setRefs = useCallback(
+      (element: HTMLTextAreaElement | null) => {
+        internalRef.current = element;
+        if (typeof ref === 'function') {
+          ref(element);
+        } else if (ref) {
+          ref.current = element;
+        }
+      },
+      [ref]
+    );
+
+    const adjustHeight = useCallback(() => {
+      const textarea = internalRef.current;
+      if (!textarea) return;
+
+      // Reset height to recalculate
+      textarea.style.height = 'auto';
+
+      // Calculate new height within bounds
+      const newHeight = Math.min(Math.max(textarea.scrollHeight, minHeight), maxHeight);
+      textarea.style.height = `${newHeight}px`;
+    }, [minHeight, maxHeight]);
+
+    useEffect(() => {
+      adjustHeight();
+    }, [props.value, adjustHeight]);
+
+    const handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+      onChange?.(e);
+      adjustHeight();
+    };
+
     const handleKeyDown: KeyboardEventHandler<HTMLTextAreaElement> = (e) => {
       if (e.key === 'Enter') {
         // Don't submit if IME composition is in progress
@@ -74,18 +110,16 @@ export const PromptInputTextarea = forwardRef<
 
     return (
       <Textarea
-        ref={ref}
+        ref={setRefs}
         className={cn(
           'w-full resize-none rounded-none border-none p-3 shadow-none outline-none ring-0',
-          'field-sizing-content bg-transparent dark:bg-transparent',
+          'overflow-y-auto bg-transparent dark:bg-transparent',
           'focus-visible:ring-0',
           className
         )}
-        style={{ minHeight, maxHeight }}
+        style={{ minHeight: `${minHeight}px` }}
         name="message"
-        onChange={(e) => {
-          onChange?.(e);
-        }}
+        onChange={handleChange}
         onKeyDown={handleKeyDown}
         placeholder={placeholder}
         {...props}


### PR DESCRIPTION
## Summary

- Replace CSS `field-sizing-content` with JavaScript-based auto-resize since the CSS property is experimental and not supported in Electron's Chromium version
- Textarea now grows dynamically as the user types, capped at 164px (~6 lines) with internal scrolling
- Proper ref merging to maintain compatibility with external refs

## Problem

The chat textarea was not resizing automatically because `field-sizing-content` is an experimental CSS property that doesn't work in Electron's bundled Chromium version.

## Solution

Implemented auto-resize using React hooks:
- `useRef` for internal textarea reference
- `useCallback` for memoized `adjustHeight` function
- `useEffect` to trigger resize on value changes

The `adjustHeight` function:
```javascript
const newHeight = Math.min(Math.max(textarea.scrollHeight, minHeight), maxHeight);
```
- Minimum height: 48px
- Maximum height: 164px (shows scrollbar beyond this)

## Test plan

- [ ] Type multiple lines in the chat input - textarea should grow
- [ ] Exceed 6 lines - internal scrollbar should appear
- [ ] Delete text - textarea should shrink back
- [ ] Verify Enter submits, Shift+Enter adds newline

🤖 Generated with [Claude Code](https://claude.com/claude-code)