### PR TITLE
feat(mcp): add individual tool enable/disable functionality

### DIFF
--- a/src/main/ipc/mcpHandlers/tools.ts
+++ b/src/main/ipc/mcpHandlers/tools.ts
@@ -1,11 +1,24 @@
 import { ipcMain } from "electron";
-import type { ToolCall } from "../../types/mcp.js";
+import type { ToolCall, ToolsCache, DisabledTools } from "../../types/mcp.js";
+import { preferencesService } from "../../services/preferencesService.js";
 
 export function registerToolHandlers(mcpService: any) {
-  // List tools from a specific server
+  // List tools from a specific server and update cache
   ipcMain.handle("levante/mcp/list-tools", async (_, serverId: string) => {
     try {
       const tools = await mcpService.listTools(serverId);
+
+      // Update cache in preferences
+      const prefs = preferencesService.getAll();
+      const toolsCache: ToolsCache = prefs.mcp?.toolsCache || {};
+
+      toolsCache[serverId] = {
+        tools,
+        lastUpdated: Date.now()
+      };
+
+      preferencesService.set('mcp.toolsCache', toolsCache);
+
       return { success: true, data: tools };
     } catch (error: any) {
       return { success: false, error: error.message };
@@ -24,4 +37,141 @@ export function registerToolHandlers(mcpService: any) {
       }
     }
   );
+
+  // Get tools cache (without reconnecting)
+  ipcMain.handle('levante/mcp/get-tools-cache', async () => {
+    try {
+      const prefs = preferencesService.getAll();
+      return { success: true, data: prefs.mcp?.toolsCache || {} };
+    } catch (error: any) {
+      return { success: false, error: 'Failed to get tools cache' };
+    }
+  });
+
+  // Get disabled tools
+  ipcMain.handle('levante/mcp/get-disabled-tools', async () => {
+    try {
+      const prefs = preferencesService.getAll();
+      return { success: true, data: prefs.mcp?.disabledTools || {} };
+    } catch (error: any) {
+      return { success: false, error: 'Failed to get disabled tools' };
+    }
+  });
+
+  // Set disabled tools for a server
+  ipcMain.handle('levante/mcp/set-disabled-tools', async (
+    _,
+    serverId: string,
+    toolNames: string[]
+  ) => {
+    try {
+      const prefs = preferencesService.getAll();
+      const disabledTools: DisabledTools = prefs.mcp?.disabledTools || {};
+
+      if (toolNames.length === 0) {
+        // If no disabled tools, remove the entry
+        delete disabledTools[serverId];
+      } else {
+        disabledTools[serverId] = toolNames;
+      }
+
+      preferencesService.set('mcp.disabledTools', disabledTools);
+
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: 'Failed to set disabled tools' };
+    }
+  });
+
+  // Toggle a specific tool (enable/disable)
+  // enabled=true → remove from disabledTools (enable)
+  // enabled=false → add to disabledTools (disable)
+  ipcMain.handle('levante/mcp/toggle-tool', async (
+    _,
+    serverId: string,
+    toolName: string,
+    enabled: boolean
+  ) => {
+    try {
+      const prefs = preferencesService.getAll();
+      const disabledTools: DisabledTools = prefs.mcp?.disabledTools || {};
+
+      // Initialize array if doesn't exist
+      if (!disabledTools[serverId]) {
+        disabledTools[serverId] = [];
+      }
+
+      if (enabled) {
+        // Enable = remove from disabled list
+        disabledTools[serverId] = disabledTools[serverId].filter(n => n !== toolName);
+        // Clean up if empty
+        if (disabledTools[serverId].length === 0) {
+          delete disabledTools[serverId];
+        }
+      } else {
+        // Disable = add to list
+        if (!disabledTools[serverId].includes(toolName)) {
+          disabledTools[serverId].push(toolName);
+        }
+      }
+
+      preferencesService.set('mcp.disabledTools', disabledTools);
+
+      return { success: true, data: disabledTools[serverId] || [] };
+    } catch (error: any) {
+      return { success: false, error: 'Failed to toggle tool' };
+    }
+  });
+
+  // Enable/disable all tools from a server
+  // enabled=true → clear disabledTools (enable all)
+  // enabled=false → add all to disabledTools (disable all)
+  ipcMain.handle('levante/mcp/toggle-all-tools', async (
+    _,
+    serverId: string,
+    enabled: boolean
+  ) => {
+    try {
+      const prefs = preferencesService.getAll();
+      const disabledTools: DisabledTools = prefs.mcp?.disabledTools || {};
+      const toolsCache: ToolsCache = prefs.mcp?.toolsCache || {};
+
+      if (enabled) {
+        // Enable all = remove entry from disabledTools
+        delete disabledTools[serverId];
+      } else {
+        // Disable all = add all tools to array
+        const serverTools = toolsCache[serverId]?.tools || [];
+        disabledTools[serverId] = serverTools.map(t => t.name);
+      }
+
+      preferencesService.set('mcp.disabledTools', disabledTools);
+
+      return { success: true, data: disabledTools[serverId] || [] };
+    } catch (error: any) {
+      return { success: false, error: 'Failed to toggle all tools' };
+    }
+  });
+
+  // Clear cache and disabled tools for a server (when removing server)
+  ipcMain.handle('levante/mcp/clear-server-tools', async (_, serverId: string) => {
+    try {
+      const prefs = preferencesService.getAll();
+
+      // Clear cache
+      const toolsCache: ToolsCache = { ...prefs.mcp?.toolsCache };
+      delete toolsCache[serverId];
+
+      // Clear disabled tools
+      const disabledTools: DisabledTools = { ...prefs.mcp?.disabledTools };
+      delete disabledTools[serverId];
+
+      preferencesService.set('mcp.toolsCache', toolsCache);
+      preferencesService.set('mcp.disabledTools', disabledTools);
+
+      return { success: true };
+    } catch (error: any) {
+      return { success: false, error: 'Failed to clear server tools' };
+    }
+  });
 }

--- a/src/main/services/ai/mcpToolsAdapter.ts
+++ b/src/main/services/ai/mcpToolsAdapter.ts
@@ -8,7 +8,7 @@
 import { tool, jsonSchema } from "ai";
 import { mcpService, configManager } from "../../ipc/mcpHandlers";
 import { mcpHealthService } from "../mcpHealthService";
-import type { Tool } from "../../types/mcp";
+import type { Tool, DisabledTools } from "../../types/mcp";
 import { getLogger } from "../logging";
 
 // Import from modules
@@ -25,8 +25,11 @@ const logger = getLogger();
 /**
  * Get all MCP tools from connected servers and convert them to AI SDK format
  * Optimized: Connects to servers in parallel for faster initialization
+ * @param disabledTools - Optional object mapping serverId to array of disabled tool names
  */
-export async function getMCPTools(): Promise<Record<string, any>> {
+export async function getMCPTools(
+  disabledTools?: DisabledTools
+): Promise<Record<string, any>> {
   const startTime = Date.now();
 
   try {
@@ -105,16 +108,29 @@ export async function getMCPTools(): Promise<Record<string, any>> {
     });
 
     // PHASE 3: Convert tools to AI SDK format
+    let skippedDisabledCount = 0;
+
     for (const result of toolsResults) {
       if (result.status !== "fulfilled" || !result.value.success) continue;
 
       const { serverId, tools: serverTools } = result.value;
+      const serverDisabledTools = disabledTools?.[serverId] || [];
 
       for (const mcpTool of serverTools) {
         if (!mcpTool.name || mcpTool.name.trim() === "") {
           logger.aiSdk.error("Invalid tool name from server", {
             serverId,
             tool: mcpTool,
+          });
+          continue;
+        }
+
+        // Skip disabled tools
+        if (serverDisabledTools.includes(mcpTool.name)) {
+          skippedDisabledCount++;
+          logger.aiSdk.debug("Skipping disabled tool", {
+            serverId,
+            toolName: mcpTool.name,
           });
           continue;
         }
@@ -151,13 +167,14 @@ export async function getMCPTools(): Promise<Record<string, any>> {
     }
 
     // Log summary
-    const disabledCount = Object.keys(config.disabled || {}).length;
+    const disabledServersCount = Object.keys(config.disabled || {}).length;
     const totalDuration = Date.now() - startTime;
 
     logger.aiSdk.info("MCP tools loading complete", {
       totalCount: Object.keys(allTools).length,
       activeServers: serverEntries.length,
-      disabledServers: disabledCount,
+      disabledServers: disabledServersCount,
+      disabledTools: skippedDisabledCount,
       durationMs: totalDuration,
       toolNames: Object.keys(allTools),
     });

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -941,7 +941,13 @@ export class AIService {
       const builtInTools = await getBuiltInTools(builtInToolsConfig);
 
       if (enableMCP) {
-        const mcpTools = await getMCPTools();
+        // Get disabled tools from preferences for filtering
+        const { preferencesService } = await import("./preferencesService");
+        await preferencesService.initialize();
+        const prefs = await preferencesService.getAll();
+        const disabledTools = prefs.mcp?.disabledTools;
+
+        const mcpTools = await getMCPTools(disabledTools);
         tools = { ...builtInTools, ...mcpTools };
         this.logger.aiSdk.debug("Passing tools to streamText", {
           toolCount: Object.keys(tools).length,
@@ -1755,7 +1761,13 @@ export class AIService {
       // Get MCP tools if enabled
       let tools = {};
       if (enableMCP) {
-        tools = await getMCPTools();
+        // Get disabled tools from preferences for filtering
+        const { preferencesService } = await import("./preferencesService");
+        await preferencesService.initialize();
+        const prefs = await preferencesService.getAll();
+        const disabledTools = prefs.mcp?.disabledTools;
+
+        tools = await getMCPTools(disabledTools);
       }
 
       // Get built-in tools config for system prompt

--- a/src/main/services/mcp/mcpUseService.ts
+++ b/src/main/services/mcp/mcpUseService.ts
@@ -307,6 +307,9 @@ export class MCPUseService implements IMCPService {
         this.clients.set(config.id, client);
         this.sessions.set(config.id, session);
 
+        // Set up tools/list_changed notification handler
+        this.setupToolsListChangedHandler(config.id, session);
+
         this.logger.mcp.info("Successfully connected to MCP server (mcp-use)", {
           serverId: config.id,
           codeMode: codeModeConfig.enabled,
@@ -801,6 +804,82 @@ export class MCPUseService implements IMCPService {
         serverId,
         mcpServerUrl,
         wwwAuth
+      });
+    }
+  }
+
+  /**
+   * Set up handler for tools/list_changed MCP notification.
+   * When tools list changes on the server, update the cache and notify the renderer.
+   */
+  private async setupToolsListChangedHandler(
+    serverId: string,
+    session: MCPSession
+  ): Promise<void> {
+    try {
+      // Check if the session/connector supports notifications
+      // mcp-use's connector may have different event mechanisms
+      const connector = session.connector;
+
+      // Try to set up notification handler if supported
+      // The connector may have an 'on' method for MCP notifications
+      if (connector && typeof (connector as any).on === 'function') {
+        (connector as any).on('notification', async (notification: any) => {
+          if (notification.method === 'notifications/tools/list_changed') {
+            this.logger.mcp.info('Tools list changed notification received', { serverId });
+
+            try {
+              // Fetch updated tools list
+              const tools = await this.listTools(serverId);
+
+              // Update tools cache in preferences
+              const preferencesService = new PreferencesService();
+              await preferencesService.initialize();
+              const prefs = await preferencesService.getAll();
+
+              const toolsCache = prefs.mcp?.toolsCache || {};
+              toolsCache[serverId] = {
+                tools,
+                lastUpdated: Date.now()
+              };
+
+              await preferencesService.set('mcp.toolsCache', toolsCache);
+
+              // Notify renderer
+              const { BrowserWindow } = await import('electron');
+              const mainWindow = BrowserWindow.getAllWindows()[0];
+
+              if (mainWindow && !mainWindow.isDestroyed()) {
+                mainWindow.webContents.send('levante/mcp/tools-updated', {
+                  serverId,
+                  tools
+                });
+              }
+
+              this.logger.mcp.info('Tools cache updated after list_changed notification', {
+                serverId,
+                toolCount: tools.length
+              });
+            } catch (error) {
+              this.logger.mcp.error('Failed to update tools cache after list_changed', {
+                serverId,
+                error: error instanceof Error ? error.message : error
+              });
+            }
+          }
+        });
+
+        this.logger.mcp.debug('Tools list_changed notification handler registered', { serverId });
+      } else {
+        // mcp-use connector doesn't support notifications directly
+        // This is expected behavior - tools will be refreshed on demand
+        this.logger.mcp.debug('Connector does not support notifications, tools will refresh on demand', { serverId });
+      }
+    } catch (error) {
+      // Non-critical error - don't fail the connection
+      this.logger.mcp.debug('Failed to set up tools list_changed handler', {
+        serverId,
+        error: error instanceof Error ? error.message : error
       });
     }
   }

--- a/src/main/services/preferencesService.ts
+++ b/src/main/services/preferencesService.ts
@@ -163,7 +163,17 @@ export class PreferencesService {
                   vmMemoryLimit: 134217728
                 }
               },
-              e2bApiKey: { type: 'string' }
+              e2bApiKey: { type: 'string' },
+              /** Cache de tools por servidor (para mostrar en UI sin reconectar) */
+              toolsCache: {
+                type: 'object',
+                default: {}
+              },
+              /** Tools deshabilitadas por servidor (las que NO se incluyen) */
+              disabledTools: {
+                type: 'object',
+                default: {}
+              }
             },
             required: ['sdk', 'codeModeDefaults'],
             default: {
@@ -173,7 +183,9 @@ export class PreferencesService {
                 executor: 'vm',
                 vmTimeout: 30000,
                 vmMemoryLimit: 134217728
-              }
+              },
+              toolsCache: {},
+              disabledTools: {}
             }
           },
           security: {

--- a/src/main/types/mcp.ts
+++ b/src/main/types/mcp.ts
@@ -54,7 +54,7 @@ export interface ToolAnnotations {
 
 export interface Tool {
   name: string;
-  description: string;
+  description?: string;
   inputSchema?: {
     type: string;
     properties?: Record<string, any>;
@@ -64,6 +64,38 @@ export interface Tool {
   _meta?: Record<string, any>;
   /** Tool behavior annotations (MCP spec) */
   annotations?: ToolAnnotations;
+}
+
+/**
+ * Tool con información de servidor para UI
+ */
+export interface ServerTool extends Tool {
+  serverId: string;
+  serverName?: string;
+  enabled: boolean;  // Si está seleccionada para uso
+}
+
+/**
+ * Cache de tools por servidor
+ */
+export interface ToolsCache {
+  [serverId: string]: {
+    tools: Tool[];
+    lastUpdated: number;  // timestamp
+  };
+}
+
+/**
+ * Tools deshabilitadas por servidor
+ * serverId → array de toolNames bloqueados
+ * Si un servidor no está en el objeto, todas sus tools están habilitadas (default)
+ * Ventajas de este enfoque:
+ * - Nuevas tools quedan habilitadas automáticamente
+ * - Lista más compacta (normalmente se bloquean pocas tools)
+ * - Patrón usado por Claude Desktop (disallowedTools) y mcp-use
+ */
+export interface DisabledTools {
+  [serverId: string]: string[];  // toolNames bloqueados
 }
 
 export interface ToolCall {

--- a/src/preload/api/mcp.ts
+++ b/src/preload/api/mcp.ts
@@ -133,4 +133,35 @@ export const mcpApi = {
 
   getPrompt: (serverId: string, name: string, args?: Record<string, any>) =>
     ipcRenderer.invoke('levante/mcp/get-prompt', serverId, name, args),
+
+  // Tools management
+  getToolsCache: () =>
+    ipcRenderer.invoke('levante/mcp/get-tools-cache'),
+
+  getDisabledTools: () =>
+    ipcRenderer.invoke('levante/mcp/get-disabled-tools'),
+
+  setDisabledTools: (serverId: string, toolNames: string[]) =>
+    ipcRenderer.invoke('levante/mcp/set-disabled-tools', serverId, toolNames),
+
+  toggleTool: (serverId: string, toolName: string, enabled: boolean) =>
+    ipcRenderer.invoke('levante/mcp/toggle-tool', serverId, toolName, enabled),
+
+  toggleAllTools: (serverId: string, enabled: boolean) =>
+    ipcRenderer.invoke('levante/mcp/toggle-all-tools', serverId, enabled),
+
+  clearServerTools: (serverId: string) =>
+    ipcRenderer.invoke('levante/mcp/clear-server-tools', serverId),
+
+  // Event listeners
+  onToolsUpdated: (
+    callback: (data: { serverId: string; tools: any[] }) => void
+  ) => {
+    const handler = (_event: any, data: any) => callback(data);
+    ipcRenderer.on('levante/mcp/tools-updated', handler);
+
+    return () => {
+      ipcRenderer.removeListener('levante/mcp/tools-updated', handler);
+    };
+  },
 };

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -36,6 +36,7 @@ import type {
   ValidationResult,
   ProviderValidationConfig,
 } from "./types";
+import type { Tool, ToolsCache, DisabledTools } from "../main/types/mcp";
 import type { RuntimeInfo, RuntimeType } from "../types/runtime";
 
 // Import API modules
@@ -566,6 +567,31 @@ export interface LevanteAPI {
       name: string,
       args?: Record<string, any>
     ) => Promise<{ success: boolean; data?: MCPPromptResult; error?: string }>;
+
+    // Tools management
+    getToolsCache: () => Promise<{ success: boolean; data?: ToolsCache; error?: string }>;
+    getDisabledTools: () => Promise<{ success: boolean; data?: DisabledTools; error?: string }>;
+    setDisabledTools: (
+      serverId: string,
+      toolNames: string[]
+    ) => Promise<{ success: boolean; error?: string }>;
+    toggleTool: (
+      serverId: string,
+      toolName: string,
+      enabled: boolean
+    ) => Promise<{ success: boolean; data?: string[]; error?: string }>;
+    toggleAllTools: (
+      serverId: string,
+      enabled: boolean
+    ) => Promise<{ success: boolean; data?: string[]; error?: string }>;
+    clearServerTools: (
+      serverId: string
+    ) => Promise<{ success: boolean; error?: string }>;
+
+    // Event listeners
+    onToolsUpdated: (
+      callback: (data: { serverId: string; tools: Tool[] }) => void
+    ) => () => void;
   };
 
   // Logger functionality

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,6 +11,7 @@ import { useChatStore, initializeChatStore } from '@/stores/chatStore'
 import { logger } from '@/services/logger'
 import { modelService } from '@/services/modelService'
 import { setupMermaidValidationHandler } from '@/services/mermaidValidationService'
+import { useMCPEvents } from '@/hooks/useMCPEvents'
 
 import { useTranslation } from 'react-i18next'
 import { toast, Toaster } from 'sonner'
@@ -24,6 +25,9 @@ function App() {
   const [wizardCompleted, setWizardCompleted] = useState<boolean | null>(null)
   const [theme, setTheme] = useState<'light' | 'dark' | 'system'>('system')
   const { i18n } = useTranslation()
+
+  // Listen for MCP events (tools/list_changed, etc.)
+  useMCPEvents()
 
   // MCP Deep Link Modal state
   const [mcpModalOpen, setMcpModalOpen] = useState(false)

--- a/src/renderer/components/chat/ToolsMenu.tsx
+++ b/src/renderer/components/chat/ToolsMenu.tsx
@@ -1,18 +1,24 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 import { Button } from '@/components/ui/button';
 import {
   DropdownMenu,
   DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
-import { Wrench, ChevronDown, Search } from 'lucide-react';
+import { Wrench, Settings, ChevronDown, ChevronRight, RefreshCw } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
+import { useMCPStore } from '@/stores/mcpStore';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Badge } from '@/components/ui/badge';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger
+} from '@/components/ui/collapsible';
+import { ToolsWarning } from '@/components/settings/ToolsWarning';
+import type { Tool } from '@/types/mcp';
 
 interface ToolsMenuProps {
   enableMCP: boolean;
@@ -26,100 +32,290 @@ export function ToolsMenu({
   className
 }: ToolsMenuProps) {
   const { t } = useTranslation('chat');
-  const [searchQuery, setSearchQuery] = useState('');
   const [open, setOpen] = useState(false);
+  const [expandedServers, setExpandedServers] = useState<Record<string, boolean>>({});
 
-  // Filter tools based on search
-  const tools = [
-    {
-      id: 'mcp-tools',
-      label: t('tools_menu.mcp_tools.label'),
-      icon: Wrench,
-      enabled: enableMCP,
-      onChange: onMCPChange,
-      keywords: t('tools_menu.mcp_tools.keywords', { returnObjects: true }) as string[]
+  // MCP Store
+  const {
+    activeServers,
+    connectionStatus,
+    toolsCache,
+    loadingTools,
+    loadToolsCache,
+    loadDisabledTools,
+    fetchServerTools,
+    toggleTool,
+    toggleAllTools,
+    isToolEnabled,
+    getEnabledToolsCount,
+    getEnabledToolsTotal,
+    enableServer,
+    disableServer,
+  } = useMCPStore();
+
+  // Load tools cache and disabled tools on mount
+  useEffect(() => {
+    loadToolsCache();
+    loadDisabledTools();
+  }, [loadToolsCache, loadDisabledTools]);
+
+  // Show ALL configured servers (including disabled ones so user can re-enable them)
+  const allServers = activeServers;
+
+  // Get only connected and enabled servers for tool count
+  const connectedServers = activeServers.filter(
+    server => server.enabled !== false && connectionStatus[server.id] === 'connected'
+  );
+
+  // Total enabled tools count
+  const totalEnabledTools = getEnabledToolsTotal();
+
+  // Toggle server expansion
+  const toggleServerExpansion = (serverId: string) => {
+    setExpandedServers(prev => ({
+      ...prev,
+      [serverId]: !prev[serverId]
+    }));
+    // Fetch tools if not already cached
+    if (!toolsCache[serverId] && !loadingTools[serverId]) {
+      fetchServerTools(serverId);
     }
-  ];
-
-  const filteredTools = searchQuery.trim()
-    ? tools.filter(tool =>
-      tool.label.toLowerCase().includes(searchQuery.toLowerCase()) ||
-      tool.keywords.some(keyword => keyword.includes(searchQuery.toLowerCase()))
-    )
-    : tools;
-
-  const activeCount = tools.filter(t => t.enabled).length;
+  };
 
   return (
-    <DropdownMenu open={open} onOpenChange={setOpen}>
-      <DropdownMenuTrigger asChild>
-        <Button
-          variant="ghost"
-          size="sm"
-          className={cn(
-            'gap-1.5 rounded-lg text-muted-foreground',
-            activeCount > 0 && 'text-foreground',
-            className
-          )}
-          type="button"
-        >
-          <Wrench size={16} />
-          <span>{t('tools_menu.button_label')}</span>
-          {activeCount > 0 && (
-            <span className="rounded-full bg-primary px-1.5 py-0.5 text-xs text-primary-foreground">
-              {activeCount}
-            </span>
-          )}
-          <ChevronDown size={14} />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="start" className="w-80">
+    <div className={cn('flex items-center gap-1', className)}>
+      {/* 1. Settings Dropdown (Gear icon) - Only MCP toggle */}
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <Button
+            variant="ghost"
+            size="icon"
+            className="rounded-lg text-muted-foreground h-8 w-8"
+            type="button"
+          >
+            <Settings size={16} />
+          </Button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent align="start" className="w-72">
+          <div
+            className="flex items-center justify-between rounded-sm px-3 py-2 hover:bg-accent cursor-pointer"
+            onClick={() => onMCPChange(!enableMCP)}
+          >
+            <div className="flex items-center gap-2">
+              <Wrench size={16} className="text-muted-foreground" />
+              <span className="text-sm">{t('tools_menu.mcp_tools.label')}</span>
+              {enableMCP && totalEnabledTools > 0 && (
+                <Badge variant="secondary" className="text-xs">
+                  {totalEnabledTools} active
+                </Badge>
+              )}
+            </div>
+            <Switch
+              checked={enableMCP}
+              onCheckedChange={onMCPChange}
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>
+        </DropdownMenuContent>
+      </DropdownMenu>
 
-        {/* Search input */}
-        <div className="p-2">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 transform -translate-y-1/2 text-muted-foreground" size={14} />
-            <Input
-              placeholder={t('tools_menu.search_placeholder')}
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-8 h-8"
+      {/* 2. Tools Dropdown (Wrench icon) - Only when MCP is enabled */}
+      {enableMCP && (
+        <DropdownMenu open={open} onOpenChange={setOpen}>
+          <DropdownMenuTrigger asChild>
+            <div className="flex items-center justify-center h-8 w-8 rounded-lg ring-1 ring-primary/50 bg-primary/10 cursor-pointer">
+              <Wrench size={16} className="text-foreground" />
+            </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-96 max-h-[70vh] overflow-hidden flex flex-col">
+            {/* Warning */}
+            <div className="px-2">
+              <ToolsWarning />
+            </div>
+
+            {/* Server Tools List */}
+            {allServers.length > 0 ? (
+              <div className="flex-1 overflow-y-auto p-2 space-y-2">
+                <div className="text-xs text-muted-foreground px-2 mb-2">
+                  {t('tools_menu.tool_selection', 'Select tools to use')}
+                </div>
+
+                {allServers.map((server) => (
+                  <ServerToolsSection
+                    key={server.id}
+                    serverId={server.id}
+                    serverName={server.name || server.id}
+                    serverEnabled={server.enabled !== false}
+                    isConnected={connectionStatus[server.id] === 'connected'}
+                    onServerToggle={(enabled) => enabled ? enableServer(server.id) : disableServer(server.id)}
+                    isExpanded={expandedServers[server.id] || false}
+                    onToggleExpand={() => toggleServerExpansion(server.id)}
+                    tools={toolsCache[server.id]?.tools || []}
+                    isLoading={loadingTools[server.id] || false}
+                    enabledCount={getEnabledToolsCount(server.id)}
+                    isToolEnabled={(toolName) => isToolEnabled(server.id, toolName)}
+                    onToggleTool={(toolName, enabled) => toggleTool(server.id, toolName, enabled)}
+                    onToggleAll={(enabled) => toggleAllTools(server.id, enabled)}
+                    onRefresh={() => fetchServerTools(server.id)}
+                  />
+                ))}
+              </div>
+            ) : (
+              <div className="p-4 text-center text-sm text-muted-foreground">
+                {t('tools_menu.no_servers', 'No MCP servers connected')}
+              </div>
+            )}
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
+    </div>
+  );
+}
+
+// Server Tools Section Component
+interface ServerToolsSectionProps {
+  serverId: string;
+  serverName: string;
+  serverEnabled: boolean;
+  isConnected: boolean;
+  onServerToggle: (enabled: boolean) => void;
+  isExpanded: boolean;
+  onToggleExpand: () => void;
+  tools: Tool[];
+  isLoading: boolean;
+  enabledCount: number;
+  isToolEnabled: (toolName: string) => boolean;
+  onToggleTool: (toolName: string, enabled: boolean) => void;
+  onToggleAll: (enabled: boolean) => void;
+  onRefresh: () => void;
+}
+
+function ServerToolsSection({
+  serverName,
+  serverEnabled,
+  isConnected,
+  onServerToggle,
+  isExpanded,
+  onToggleExpand,
+  tools,
+  isLoading,
+  enabledCount,
+  isToolEnabled,
+  onToggleTool,
+  onToggleAll,
+  onRefresh,
+}: ServerToolsSectionProps) {
+  const { t } = useTranslation('chat');
+
+  const allEnabled = tools.length > 0 && enabledCount === tools.length;
+  const someEnabled = enabledCount > 0 && enabledCount < tools.length;
+
+  return (
+    <Collapsible open={isExpanded && serverEnabled} onOpenChange={onToggleExpand}>
+      <div className={cn("border rounded-md", !serverEnabled && "opacity-60")}>
+        <div className="flex items-center justify-between p-2">
+          {/* Left side - clickable to expand */}
+          <CollapsibleTrigger asChild>
+            <div className={cn(
+              "flex items-center gap-2 flex-1 cursor-pointer hover:bg-accent rounded-md p-1 -m-1",
+              !serverEnabled && "cursor-default hover:bg-transparent"
+            )}>
+              {serverEnabled ? (
+                isExpanded ? (
+                  <ChevronDown className="h-4 w-4" />
+                ) : (
+                  <ChevronRight className="h-4 w-4" />
+                )
+              ) : (
+                <ChevronRight className="h-4 w-4 text-muted-foreground" />
+              )}
+              <span className={cn("text-sm font-medium", !serverEnabled && "text-muted-foreground")}>
+                {serverName}
+              </span>
+              {serverEnabled && isConnected && (
+                <Badge variant="secondary" className="text-xs">
+                  {enabledCount}/{tools.length}
+                </Badge>
+              )}
+              {!serverEnabled && (
+                <Badge variant="outline" className="text-xs text-muted-foreground">
+                  {t('tools_menu.disabled', 'disabled')}
+                </Badge>
+              )}
+            </div>
+          </CollapsibleTrigger>
+
+          {/* Right side - controls */}
+          <div className="flex items-center gap-1" onClick={e => e.stopPropagation()}>
+            {serverEnabled && isConnected && (
+              <Button
+                variant="ghost"
+                size="icon"
+                className="h-6 w-6"
+                onClick={onRefresh}
+                disabled={isLoading}
+              >
+                <RefreshCw className={`h-3 w-3 ${isLoading ? 'animate-spin' : ''}`} />
+              </Button>
+            )}
+            <Switch
+              checked={serverEnabled}
+              onCheckedChange={onServerToggle}
+              className="scale-75"
             />
           </div>
         </div>
 
-        <DropdownMenuSeparator />
-
-        {/* Tools list */}
-        <div className="p-1">
-          {filteredTools.length === 0 ? (
-            <div className="p-4 text-center text-sm text-muted-foreground">
-              {t('tools_menu.no_results')}
+        <CollapsibleContent>
+          <div className="border-t p-2 space-y-1">
+            {/* Toggle all */}
+            <div className="flex items-center gap-2 p-1 border-b pb-2 mb-1">
+              <Checkbox
+                checked={allEnabled}
+                data-indeterminate={someEnabled}
+                onCheckedChange={() => onToggleAll(!allEnabled)}
+              />
+              <span className="text-xs font-medium text-muted-foreground">
+                {t('tools_menu.select_all', 'Select all')}
+              </span>
             </div>
-          ) : (
-            filteredTools.map((tool) => {
-              const Icon = tool.icon;
-              return (
-                <div
-                  key={tool.id}
-                  className="flex items-center justify-between rounded-sm px-2 py-2 hover:bg-accent cursor-pointer"
-                  onClick={() => tool.onChange(!tool.enabled)}
-                >
-                  <div className="flex items-center gap-2">
-                    <Icon size={16} className="text-muted-foreground" />
-                    <span className="text-sm">{tool.label}</span>
-                  </div>
-                  <Switch
-                    checked={tool.enabled}
-                    onCheckedChange={tool.onChange}
-                    onClick={(e) => e.stopPropagation()}
-                  />
-                </div>
-              );
-            })
-          )}
-        </div>
-      </DropdownMenuContent>
-    </DropdownMenu>
+
+            {/* Tool list */}
+            {isLoading ? (
+              <div className="text-xs text-muted-foreground py-2 text-center">
+                {t('tools_menu.loading_tools', 'Loading tools...')}
+              </div>
+            ) : tools.length === 0 ? (
+              <div className="text-xs text-muted-foreground py-2 text-center">
+                {t('tools_menu.no_tools', 'No tools available')}
+              </div>
+            ) : (
+              <div className="max-h-48 overflow-y-auto space-y-1">
+                {tools.map((tool) => (
+                  <label
+                    key={tool.name}
+                    className="flex items-start gap-2 p-1.5 hover:bg-accent rounded cursor-pointer"
+                  >
+                    <Checkbox
+                      checked={isToolEnabled(tool.name)}
+                      onCheckedChange={(checked) => onToggleTool(tool.name, checked === true)}
+                      className="mt-0.5"
+                    />
+                    <div className="flex-1 min-w-0">
+                      <div className="text-xs font-medium truncate">{tool.name}</div>
+                      {tool.description && (
+                        <div className="text-xs text-muted-foreground line-clamp-1">
+                          {tool.description}
+                        </div>
+                      )}
+                    </div>
+                  </label>
+                ))}
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
   );
 }

--- a/src/renderer/components/settings/ToolSelector.tsx
+++ b/src/renderer/components/settings/ToolSelector.tsx
@@ -1,0 +1,158 @@
+import { useState, useEffect } from 'react';
+import { useTranslation } from 'react-i18next';
+import { useMCPStore } from '@/stores/mcpStore';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Collapsible,
+  CollapsibleContent,
+  CollapsibleTrigger
+} from '@/components/ui/collapsible';
+import {
+  ChevronDown,
+  ChevronRight,
+  RefreshCw,
+} from 'lucide-react';
+import type { Tool } from '@/types/mcp';
+
+interface ToolSelectorProps {
+  serverId: string;
+  serverName: string;
+}
+
+export function ToolSelector({ serverId, serverName }: ToolSelectorProps) {
+  const { t } = useTranslation(['settings', 'common']);
+  const [isOpen, setIsOpen] = useState(false);
+
+  const {
+    toolsCache,
+    loadingTools,
+    fetchServerTools,
+    toggleTool,
+    toggleAllTools,
+    isToolEnabled,
+    getEnabledToolsCount,
+  } = useMCPStore();
+
+  const tools = toolsCache[serverId]?.tools || [];
+  const enabledCount = getEnabledToolsCount(serverId);
+  const isLoading = loadingTools[serverId] || false;
+
+  // Load tools when expanded
+  useEffect(() => {
+    if (isOpen && tools.length === 0) {
+      fetchServerTools(serverId);
+    }
+  }, [isOpen, serverId, tools.length, fetchServerTools]);
+
+  const allEnabled = tools.length > 0 && enabledCount === tools.length;
+  const someEnabled = enabledCount > 0 && enabledCount < tools.length;
+
+  const handleToggleAll = () => {
+    toggleAllTools(serverId, !allEnabled);
+  };
+
+  const handleRefresh = async () => {
+    await fetchServerTools(serverId);
+  };
+
+  return (
+    <Collapsible open={isOpen} onOpenChange={setIsOpen}>
+      <div className="border rounded-lg p-3">
+        <CollapsibleTrigger asChild>
+          <div className="flex items-center justify-between cursor-pointer">
+            <div className="flex items-center gap-2">
+              {isOpen ? (
+                <ChevronDown className="h-4 w-4" />
+              ) : (
+                <ChevronRight className="h-4 w-4" />
+              )}
+              <span className="font-medium">{serverName}</span>
+              <Badge variant="secondary">
+                {enabledCount}/{tools.length} tools
+              </Badge>
+            </div>
+
+            <div className="flex items-center gap-2" onClick={e => e.stopPropagation()}>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={handleRefresh}
+                disabled={isLoading}
+              >
+                <RefreshCw className={`h-4 w-4 ${isLoading ? 'animate-spin' : ''}`} />
+              </Button>
+            </div>
+          </div>
+        </CollapsibleTrigger>
+
+        <CollapsibleContent>
+          <div className="mt-3 pt-3 border-t">
+            {/* Toggle all */}
+            <div className="flex items-center justify-between mb-3 pb-2 border-b">
+              <label className="flex items-center gap-2 cursor-pointer">
+                <Checkbox
+                  checked={allEnabled}
+                  data-indeterminate={someEnabled}
+                  onCheckedChange={handleToggleAll}
+                />
+                <span className="text-sm font-medium">
+                  {t('settings:mcp_tools.select_all', 'Select all')}
+                </span>
+              </label>
+            </div>
+
+            {/* Tool list */}
+            {isLoading ? (
+              <div className="text-sm text-muted-foreground py-2">
+                {t('settings:mcp_tools.loading', 'Loading tools...')}
+              </div>
+            ) : tools.length === 0 ? (
+              <div className="text-sm text-muted-foreground py-2">
+                {t('settings:mcp_tools.no_tools', 'No tools available')}
+              </div>
+            ) : (
+              <div className="space-y-2 max-h-64 overflow-y-auto">
+                {tools.map((tool: Tool) => (
+                  <ToolItem
+                    key={tool.name}
+                    tool={tool}
+                    enabled={isToolEnabled(serverId, tool.name)}
+                    onToggle={(enabled) => toggleTool(serverId, tool.name, enabled)}
+                  />
+                ))}
+              </div>
+            )}
+          </div>
+        </CollapsibleContent>
+      </div>
+    </Collapsible>
+  );
+}
+
+interface ToolItemProps {
+  tool: Tool;
+  enabled: boolean;
+  onToggle: (enabled: boolean) => void;
+}
+
+function ToolItem({ tool, enabled, onToggle }: ToolItemProps) {
+  return (
+    <label className="flex items-start gap-2 cursor-pointer p-2 hover:bg-accent rounded">
+      <Checkbox
+        checked={enabled}
+        onCheckedChange={(checked) => onToggle(checked === true)}
+        className="mt-0.5"
+      />
+      <div className="flex-1 min-w-0">
+        <div className="text-sm font-medium truncate">{tool.name}</div>
+        {tool.description && (
+          <div className="text-xs text-muted-foreground line-clamp-2">
+            {tool.description}
+          </div>
+        )}
+      </div>
+    </label>
+  );
+}

--- a/src/renderer/components/settings/ToolsWarning.tsx
+++ b/src/renderer/components/settings/ToolsWarning.tsx
@@ -1,0 +1,39 @@
+import { useMCPStore } from '@/stores/mcpStore';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { AlertTriangle } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+const TOOLS_WARNING_THRESHOLD = 40;
+const TOOLS_LIMIT = 80;
+
+export function ToolsWarning() {
+  const { t } = useTranslation(['settings', 'common']);
+  const getEnabledToolsTotal = useMCPStore(state => state.getEnabledToolsTotal);
+
+  const totalEnabled = getEnabledToolsTotal();
+
+  if (totalEnabled < TOOLS_WARNING_THRESHOLD) {
+    return null;
+  }
+
+  const isOverLimit = totalEnabled >= TOOLS_LIMIT;
+
+  return (
+    <Alert variant={isOverLimit ? "destructive" : "default"} className={!isOverLimit ? "border-yellow-500/50 bg-yellow-50 dark:bg-yellow-950/20" : ""}>
+      <AlertTriangle className="h-4 w-4" />
+      <AlertDescription>
+        {isOverLimit ? (
+          t('settings:mcp_tools.over_limit',
+            `You have {{count}} tools enabled. This exceeds the recommended limit of ${TOOLS_LIMIT} and may significantly impact performance.`,
+            { count: totalEnabled }
+          )
+        ) : (
+          t('settings:mcp_tools.warning',
+            `You have {{count}} tools enabled. Consider disabling unused tools for better performance (recommended: <${TOOLS_WARNING_THRESHOLD}).`,
+            { count: totalEnabled }
+          )
+        )}
+      </AlertDescription>
+    </Alert>
+  );
+}

--- a/src/renderer/hooks/useMCPEvents.ts
+++ b/src/renderer/hooks/useMCPEvents.ts
@@ -1,0 +1,25 @@
+import { useEffect } from 'react';
+import { useMCPStore } from '@/stores/mcpStore';
+
+/**
+ * Hook to listen for MCP events from the main process.
+ * Currently handles:
+ * - tools/list_changed: When a server's tools list changes
+ */
+export function useMCPEvents() {
+  const { loadToolsCache } = useMCPStore();
+
+  useEffect(() => {
+    // Listen for tools updated event
+    const cleanup = window.levante.mcp.onToolsUpdated((data) => {
+      console.log('MCP tools updated for server:', data.serverId);
+
+      // Reload the tools cache to get the updated tools
+      loadToolsCache();
+    });
+
+    return () => {
+      cleanup();
+    };
+  }, [loadToolsCache]);
+}

--- a/src/renderer/locales/en/chat.json
+++ b/src/renderer/locales/en/chat.json
@@ -57,6 +57,12 @@
     "title": "Search & tools",
     "search_placeholder": "Search menu",
     "no_results": "No tools found",
+    "tool_selection": "Select tools to use",
+    "no_servers": "No MCP servers configured",
+    "disabled": "disabled",
+    "select_all": "Select all",
+    "loading_tools": "Loading tools...",
+    "no_tools": "No tools available",
     "web_search": {
       "label": "Web search",
       "keywords": ["web", "search", "internet", "búsqueda"]

--- a/src/renderer/locales/en/settings.json
+++ b/src/renderer/locales/en/settings.json
@@ -259,5 +259,12 @@
         "apply_note": "Changes apply to new MCP server connections"
       }
     }
+  },
+  "mcp_tools": {
+    "select_all": "Select all",
+    "loading": "Loading tools...",
+    "no_tools": "No tools available",
+    "warning": "You have {{count}} tools enabled. Consider disabling unused tools for better performance (recommended: <40).",
+    "over_limit": "You have {{count}} tools enabled. This exceeds the recommended limit of 80 and may significantly impact performance."
   }
 }

--- a/src/renderer/locales/es/chat.json
+++ b/src/renderer/locales/es/chat.json
@@ -57,6 +57,12 @@
     "title": "Búsqueda y herramientas",
     "search_placeholder": "Buscar en el menú",
     "no_results": "No se encontraron herramientas",
+    "tool_selection": "Selecciona herramientas a usar",
+    "no_servers": "No hay servidores MCP configurados",
+    "disabled": "deshabilitado",
+    "select_all": "Seleccionar todo",
+    "loading_tools": "Cargando herramientas...",
+    "no_tools": "No hay herramientas disponibles",
     "web_search": {
       "label": "Búsqueda web",
       "keywords": ["web", "búsqueda", "search", "internet"]

--- a/src/renderer/locales/es/settings.json
+++ b/src/renderer/locales/es/settings.json
@@ -208,5 +208,12 @@
         "apply_note": "Los cambios se aplican a nuevas conexiones de servidores MCP"
       }
     }
+  },
+  "mcp_tools": {
+    "select_all": "Seleccionar todo",
+    "loading": "Cargando herramientas...",
+    "no_tools": "No hay herramientas disponibles",
+    "warning": "Tienes {{count}} herramientas habilitadas. Considera deshabilitar las que no uses para mejorar el rendimiento (recomendado: <40).",
+    "over_limit": "Tienes {{count}} herramientas habilitadas. Esto excede el límite recomendado de 80 y puede afectar significativamente el rendimiento."
   }
 }

--- a/src/renderer/stores/mcpStore.ts
+++ b/src/renderer/stores/mcpStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import { MCPServerConfig, MCPConnectionStatus, MCPProvider, MCPRegistryEntry, MCPSource, MCPCategory } from '../types/mcp';
+import { MCPServerConfig, MCPConnectionStatus, MCPProvider, MCPRegistryEntry, MCPSource, MCPCategory, Tool, ToolsCache, DisabledTools } from '../types/mcp';
 import mcpProvidersData from '../data/mcpProviders.json';
 import { useOAuthStore } from './oauthStore';
 
@@ -19,11 +19,18 @@ interface MCPStore {
   providerErrors: Record<string, string | null>;
   providersSynced: boolean;
 
+  // Tools state
+  toolsCache: ToolsCache;
+  disabledTools: DisabledTools;
+  loadingTools: Record<string, boolean>;
+
   // Actions
   loadActiveServers: () => Promise<void>;
   refreshConnectionStatus: () => Promise<void>;
   connectServer: (config: MCPServerConfig) => Promise<void>;
   disconnectServer: (serverId: string) => Promise<void>;
+  enableServer: (serverId: string) => Promise<void>;
+  disableServer: (serverId: string) => Promise<void>;
   testConnection: (config: MCPServerConfig) => Promise<boolean>;
   addServer: (config: MCPServerConfig) => Promise<void>;
   updateServer: (serverId: string, config: Partial<Omit<MCPServerConfig, 'id'>>) => Promise<void>;
@@ -41,6 +48,19 @@ interface MCPStore {
   getFilteredEntries: () => MCPRegistryEntry[];
   getAvailableSources: () => MCPSource[];
   getAvailableCategories: () => MCPCategory[];
+
+  // Tools actions
+  loadToolsCache: () => Promise<void>;
+  loadDisabledTools: () => Promise<void>;
+  fetchServerTools: (serverId: string) => Promise<Tool[]>;
+  toggleTool: (serverId: string, toolName: string, enabled: boolean) => Promise<void>;
+  toggleAllTools: (serverId: string, enabled: boolean) => Promise<void>;
+  isToolEnabled: (serverId: string, toolName: string) => boolean;
+  getServerTools: (serverId: string) => Tool[];
+  getEnabledToolsCount: (serverId: string) => number;
+  getDisabledToolsCount: (serverId: string) => number;
+  getTotalToolsCount: () => number;
+  getEnabledToolsTotal: () => number;
 
   // Helper methods
   isServerActive: (serverId: string) => boolean;
@@ -64,7 +84,10 @@ export const useMCPStore = create<MCPStore>((set, get) => ({
   providerErrors: {},
   providersSynced: false,
 
-
+  // Tools initial state
+  toolsCache: {},
+  disabledTools: {},
+  loadingTools: {},
 
   // Load active servers from configuration
   loadActiveServers: async () => {
@@ -237,6 +260,49 @@ export const useMCPStore = create<MCPStore>((set, get) => ({
     }
   },
 
+  // Enable a server (move config to active + connect)
+  enableServer: async (serverId: string) => {
+    try {
+      // 1. Get server config (already available in activeServers with enabled=false)
+      const server = get().getServerById(serverId);
+      if (!server) {
+        console.error('Server not found:', serverId);
+        return;
+      }
+
+      // 2. Move from disabled to mcpServers in config (persistence)
+      const result = await window.levante.mcp.enableServer(serverId);
+      if (!result.success) {
+        console.error('Failed to enable server in config:', result.error);
+        return;
+      }
+
+      // 3. Connect using existing connectServer logic (handles OAuth, runtime errors, etc.)
+      // This will update activeServers and connectionStatus appropriately
+      await get().connectServer({ ...server, enabled: true });
+    } catch (error) {
+      // connectServer may throw for OAuth/runtime errors - these are handled by the UI
+      // Only log unexpected errors
+      if (!(error as any).code && !(error as any).errorCode) {
+        console.error('Failed to enable server:', error);
+      }
+      throw error; // Re-throw for UI handling
+    }
+  },
+
+  // Disable a server (disconnect + move config to disabled)
+  disableServer: async (serverId: string) => {
+    try {
+      // Use disconnectServer which already does:
+      // 1. mcpService.disconnectServer() - runtime disconnection
+      // 2. configManager.disableServer() - moves config to disabled section
+      // 3. Updates store state (activeServers.enabled=false, connectionStatus='disconnected')
+      await get().disconnectServer(serverId);
+    } catch (error) {
+      console.error('Failed to disable server:', error);
+    }
+  },
+
   // Test connection to a server
   testConnection: async (config: MCPServerConfig) => {
     try {
@@ -329,13 +395,29 @@ export const useMCPStore = create<MCPStore>((set, get) => ({
           window.levante.analytics?.trackMCP?.(server.name || server.id, 'removed').catch(() => { });
         }
 
-        set(state => ({
-          activeServers: state.activeServers.filter(s => s.id !== serverId),
-          connectionStatus: {
-            ...state.connectionStatus,
-            [serverId]: 'disconnected'
-          }
-        }));
+        // Clean up tools cache and disabled tools
+        try {
+          await window.levante.mcp.clearServerTools(serverId);
+        } catch (clearError) {
+          console.warn('Failed to clear server tools:', clearError);
+        }
+
+        set(state => {
+          const newToolsCache = { ...state.toolsCache };
+          const newDisabledTools = { ...state.disabledTools };
+          delete newToolsCache[serverId];
+          delete newDisabledTools[serverId];
+
+          return {
+            activeServers: state.activeServers.filter(s => s.id !== serverId),
+            connectionStatus: {
+              ...state.connectionStatus,
+              [serverId]: 'disconnected'
+            },
+            toolsCache: newToolsCache,
+            disabledTools: newDisabledTools
+          };
+        });
       } else {
         set({ error: result.error || 'Failed to remove server' });
       }
@@ -548,5 +630,168 @@ export const useMCPStore = create<MCPStore>((set, get) => ({
     });
 
     return Array.from(categories).sort();
+  },
+
+  // Load tools cache from preferences
+  loadToolsCache: async () => {
+    try {
+      const result = await window.levante.mcp.getToolsCache();
+      if (result.success && result.data) {
+        set({ toolsCache: result.data });
+      }
+    } catch (error) {
+      console.error('Failed to load tools cache:', error);
+    }
+  },
+
+  // Load disabled tools from preferences
+  loadDisabledTools: async () => {
+    try {
+      const result = await window.levante.mcp.getDisabledTools();
+      if (result.success && result.data) {
+        set({ disabledTools: result.data });
+      }
+    } catch (error) {
+      console.error('Failed to load disabled tools:', error);
+    }
+  },
+
+  // Fetch tools from a server (with cache update)
+  fetchServerTools: async (serverId: string) => {
+    set(state => ({
+      loadingTools: { ...state.loadingTools, [serverId]: true }
+    }));
+
+    try {
+      const result = await window.levante.mcp.listTools(serverId);
+
+      if (result.success && result.data) {
+        const tools = result.data;
+
+        // Update local cache
+        set(state => ({
+          toolsCache: {
+            ...state.toolsCache,
+            [serverId]: {
+              tools,
+              lastUpdated: Date.now()
+            }
+          },
+          loadingTools: { ...state.loadingTools, [serverId]: false }
+        }));
+
+        return tools;
+      }
+
+      set(state => ({
+        loadingTools: { ...state.loadingTools, [serverId]: false }
+      }));
+      return [];
+    } catch (error) {
+      console.error('Failed to fetch server tools:', error);
+      set(state => ({
+        loadingTools: { ...state.loadingTools, [serverId]: false }
+      }));
+      return [];
+    }
+  },
+
+  // Toggle a specific tool
+  toggleTool: async (serverId: string, toolName: string, enabled: boolean) => {
+    try {
+      const result = await window.levante.mcp.toggleTool(serverId, toolName, enabled);
+
+      if (result.success) {
+        set(state => {
+          const newDisabledTools = { ...state.disabledTools };
+          if (result.data && result.data.length > 0) {
+            newDisabledTools[serverId] = result.data;
+          } else {
+            delete newDisabledTools[serverId];
+          }
+          return { disabledTools: newDisabledTools };
+        });
+      }
+    } catch (error) {
+      console.error('Failed to toggle tool:', error);
+    }
+  },
+
+  // Toggle all tools from a server
+  toggleAllTools: async (serverId: string, enabled: boolean) => {
+    try {
+      const result = await window.levante.mcp.toggleAllTools(serverId, enabled);
+
+      if (result.success) {
+        set(state => {
+          const newDisabledTools = { ...state.disabledTools };
+          if (result.data && result.data.length > 0) {
+            newDisabledTools[serverId] = result.data;
+          } else {
+            delete newDisabledTools[serverId];
+          }
+          return { disabledTools: newDisabledTools };
+        });
+      }
+    } catch (error) {
+      console.error('Failed to toggle all tools:', error);
+    }
+  },
+
+  // Check if a tool is enabled
+  isToolEnabled: (serverId: string, toolName: string) => {
+    const { disabledTools } = get();
+
+    // If no entry for this server, all are enabled
+    if (!disabledTools[serverId]) {
+      return true;
+    }
+
+    // Enabled if NOT in the disabled list
+    return !disabledTools[serverId].includes(toolName);
+  },
+
+  // Get tools from a server from cache
+  getServerTools: (serverId: string) => {
+    const { toolsCache } = get();
+    return toolsCache[serverId]?.tools || [];
+  },
+
+  // Count enabled tools for a server
+  getEnabledToolsCount: (serverId: string) => {
+    const { disabledTools, toolsCache } = get();
+    const totalTools = toolsCache[serverId]?.tools?.length || 0;
+    const disabledCount = disabledTools[serverId]?.length || 0;
+
+    return totalTools - disabledCount;
+  },
+
+  // Count disabled tools for a server
+  getDisabledToolsCount: (serverId: string) => {
+    const { disabledTools } = get();
+    return disabledTools[serverId]?.length || 0;
+  },
+
+  // Count total tools from all servers
+  getTotalToolsCount: () => {
+    const { toolsCache } = get();
+    return Object.values(toolsCache).reduce(
+      (sum, cache) => sum + (cache.tools?.length || 0),
+      0
+    );
+  },
+
+  // Count total enabled tools
+  getEnabledToolsTotal: () => {
+    const { disabledTools, toolsCache, activeServers } = get();
+
+    return activeServers.reduce((sum, server) => {
+      if (!server.enabled) return sum;
+
+      const totalTools = toolsCache[server.id]?.tools?.length || 0;
+      const disabledCount = disabledTools[server.id]?.length || 0;
+
+      return sum + (totalTools - disabledCount);
+    }, 0);
   }
 }));

--- a/src/renderer/types/mcp.ts
+++ b/src/renderer/types/mcp.ts
@@ -170,3 +170,6 @@ export type MCPConnectionStatus =
   | "connecting"
   | "error"
   | "pending_oauth";
+
+// Re-export tool selection types from main
+export type { Tool, ServerTool, ToolsCache, DisabledTools } from '../../main/types/mcp';

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -14,6 +14,21 @@ export interface MCPPreferences {
   };
   /** E2B API key (encrypted, optional) */
   e2bApiKey?: string;
+  /** Cache of tools per server (for showing in UI without reconnecting) */
+  toolsCache?: {
+    [serverId: string]: {
+      tools: Array<{
+        name: string;
+        description?: string;
+        inputSchema?: any;
+      }>;
+      lastUpdated: number;
+    };
+  };
+  /** Tools disabled by server (the ones NOT included) */
+  disabledTools?: {
+    [serverId: string]: string[];
+  };
 }
 
 export interface UIPreferences {


### PR DESCRIPTION
## Summary

This PR adds the ability to **enable/disable individual MCP tools** from the chat UI, giving users fine-grained control over which tools are available to the AI model.

### Key Features

- 🎛️ **Tool Selection UI**: New dropdown in chat toolbar showing all MCP servers and their tools with checkboxes
- 🔌 **Server Toggle**: Enable/disable entire MCP servers with real connection management
- ⚠️ **Performance Warning**: Alert when >40 tools enabled, error when >80
- 💾 **Persistence**: Tool preferences saved to `ui-preferences.json`
- 🔄 **Real-time Updates**: Listen for MCP `tools/list_changed` notifications

## Screenshots

The new UI consists of two dropdowns in the chat toolbar:
1. **Settings dropdown** (gear icon): Toggle MCP globally
2. **Tools dropdown** (wrench icon, when MCP enabled): Select individual tools

## Technical Implementation

### Data Model: Negative List Pattern

Instead of storing enabled tools, we store **disabled tools only**:

```typescript
// Only disabled tools are stored
disabledTools: {
  "server-id": ["tool1", "tool2"]  // These are disabled
}
```

**Benefits:**
- New tools are enabled by default (no action needed)
- Compact storage (usually few tools disabled)
- Follows Claude Desktop's `disallowedTools` pattern

### Architecture

```
┌─────────────────────────────────────────────────────────────────────┐
│                           RENDERER                                   │
├─────────────────────────────────────────────────────────────────────┤
│  ToolsMenu.tsx ──► mcpStore.ts ──► IPC API (preload)                │
│       ▲                  │                    │                      │
│       │                  │                    ▼                      │
│  ToolsWarning.tsx    toolsCache         levante/mcp/*               │
│  useMCPEvents.ts     disabledTools                                  │
└─────────────────────────────────────────────────────────────────────┘
                                │
                                ▼
┌─────────────────────────────────────────────────────────────────────┐
│                           MAIN PROCESS                               │
├─────────────────────────────────────────────────────────────────────┤
│  tools.ts (IPC handlers) ──► preferencesService.ts                  │
│         │                            │                               │
│         ▼                            ▼                               │
│  mcpToolsAdapter.ts            ui-preferences.json                  │
│  (filters disabledTools)       (toolsCache, disabledTools)          │
└─────────────────────────────────────────────────────────────────────┘
```

### New IPC Handlers

| Handler | Description |
|---------|-------------|
| `levante/mcp/get-tools-cache` | Get cached tools without reconnecting |
| `levante/mcp/get-disabled-tools` | Get disabled tools map |
| `levante/mcp/toggle-tool` | Toggle individual tool |
| `levante/mcp/toggle-all-tools` | Toggle all tools for a server |
| `levante/mcp/clear-server-tools` | Cleanup on server removal |

### AI Integration

The `getMCPTools()` function in `mcpToolsAdapter.ts` now:
1. Accepts a `disabledTools` parameter
2. Filters out disabled tools before passing to AI
3. Logs disabled tool count for debugging

```typescript
// In aiService.ts
const disabledTools = prefs.mcp?.disabledTools;
const mcpTools = await getMCPTools(disabledTools);
// Only enabled tools passed to AI model
```

### Store Changes (mcpStore.ts)

**New State:**
- `toolsCache`: Cached tools per server
- `disabledTools`: Map of disabled tool names per server  
- `loadingTools`: Loading state per server

**New Actions:**
- `toggleTool(serverId, toolName, enabled)`
- `toggleAllTools(serverId, enabled)`
- `isToolEnabled(serverId, toolName)`
- `getEnabledToolsCount(serverId)`
- `getEnabledToolsTotal()`

**Fixed Actions:**
- `enableServer`: Now calls `connectServer()` (real connection)
- `disableServer`: Now calls `disconnectServer()` (real disconnection)

## Files Changed

### Main Process
- `src/main/ipc/mcpHandlers/tools.ts` - New IPC handlers
- `src/main/services/ai/mcpToolsAdapter.ts` - Filter disabled tools
- `src/main/services/aiService.ts` - Pass disabled tools to adapter
- `src/main/services/mcp/mcpUseService.ts` - tools/list_changed handler
- `src/main/services/preferencesService.ts` - Schema for new fields
- `src/main/types/mcp.ts` - TypeScript types

### Preload
- `src/preload/api/mcp.ts` - Expose new IPC methods
- `src/preload/preload.ts` - Type definitions

### Renderer
- `src/renderer/App.tsx` - Initialize MCP events hook
- `src/renderer/components/chat/ToolsMenu.tsx` - Redesigned UI
- `src/renderer/components/settings/ToolSelector.tsx` - New component
- `src/renderer/components/settings/ToolsWarning.tsx` - New component
- `src/renderer/hooks/useMCPEvents.ts` - New hook
- `src/renderer/stores/mcpStore.ts` - State management
- `src/renderer/types/mcp.ts` - Re-export types

### Translations
- `src/renderer/locales/en/chat.json` - English strings
- `src/renderer/locales/es/chat.json` - Spanish strings
- `src/renderer/locales/en/settings.json` - English strings
- `src/renderer/locales/es/settings.json` - Spanish strings

### Types
- `src/types/preferences.ts` - MCPPreferences interface

## Test Plan

- [ ] Enable/disable individual tools and verify they don't appear in AI responses
- [ ] Toggle server on/off and verify real connection/disconnection
- [ ] Enable >40 tools and verify warning appears
- [ ] Enable >80 tools and verify error appears
- [ ] Remove a server and verify cache/disabled tools are cleaned up
- [ ] Restart app and verify tool preferences persist
- [ ] Test with OAuth server to verify enable still handles auth flow
- [ ] Test in both English and Spanish locales

🤖 Generated with [Claude Code](https://claude.com/claude-code)