### PR TITLE
feat: add Levante Platform as OAuth-based model provider

### DIFF
--- a/src/main/ipc/modelHandlers.ts
+++ b/src/main/ipc/modelHandlers.ts
@@ -167,6 +167,24 @@ export function setupModelHandlers() {
     }
   });
 
+  // Fetch Levante Platform models (uses OAuth tokens)
+  ipcMain.removeHandler('levante/models/levante-platform');
+  ipcMain.handle('levante/models/levante-platform', async (_, baseUrl?: string) => {
+    try {
+      const models = await ModelFetchService.fetchLevantePlatformModels(baseUrl);
+      return {
+        success: true,
+        data: models
+      };
+    } catch (error) {
+      logger.ipc.error('Failed to fetch Levante Platform models', { error: error instanceof Error ? error.message : error });
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error'
+      };
+    }
+  });
+
   // Validate Hugging Face model (fetch model info from HF API)
   ipcMain.removeHandler('levante/models/huggingface/validate');
   ipcMain.handle('levante/models/huggingface/validate', async (_, modelId: string, inferenceProvider?: string) => {

--- a/src/main/services/ai/providerResolver.ts
+++ b/src/main/services/ai/providerResolver.ts
@@ -7,6 +7,7 @@ import { createOpenRouter } from "@openrouter/ai-sdk-provider";
 import type { LanguageModel } from "ai";
 import type { ProviderConfig } from "../../../types/models";
 import { getLogger } from '../logging';
+import { getOAuthService } from '../oauth';
 
 const logger = getLogger();
 
@@ -96,7 +97,7 @@ export async function getModelProvider(modelId: string): Promise<LanguageModel> 
     });
 
     // Configure provider based on type
-    return configureProvider(providerWithModel, modelId);
+    return await configureProvider(providerWithModel, modelId);
   } catch (error) {
     logger.aiSdk.error("Error getting model provider configuration", {
       error: error instanceof Error ? error.message : error,
@@ -110,7 +111,7 @@ export async function getModelProvider(modelId: string): Promise<LanguageModel> 
 /**
  * Configure a specific provider based on its type
  */
-function configureProvider(provider: ProviderConfig, modelId: string) {
+async function configureProvider(provider: ProviderConfig, modelId: string): Promise<LanguageModel> {
   switch (provider.type) {
     case "vercel-gateway":
       return configureVercelGateway(provider, modelId);
@@ -138,6 +139,9 @@ function configureProvider(provider: ProviderConfig, modelId: string) {
 
     case "huggingface":
       return configureHuggingFace(provider, modelId);
+
+    case "levante-platform":
+      return await configureLevantePlatform(provider, modelId);
 
     default:
       throw new Error(`Unknown provider type: ${provider.type}`);
@@ -393,4 +397,39 @@ function configureHuggingFace(provider: ProviderConfig, modelId: string) {
   });
 
   return huggingface(modelId);
+}
+
+/**
+ * Configure Levante Platform provider
+ * Uses OAuth tokens instead of API keys
+ */
+async function configureLevantePlatform(provider: ProviderConfig, modelId: string) {
+  const LEVANTE_PLATFORM_SERVER_ID = "levante-platform";
+  // Use baseUrl from provider config, fallback to production URL
+  const baseUrl = provider.baseUrl || "https://platform.levante.ai";
+  const apiBaseUrl = `${baseUrl}/api/v1`;
+
+  // Get OAuth tokens
+  const oauthService = getOAuthService();
+  const tokens = await oauthService.getExistingToken(LEVANTE_PLATFORM_SERVER_ID);
+
+  if (!tokens) {
+    throw new Error(
+      "Levante Platform not authorized. Please connect your account in the Models page."
+    );
+  }
+
+  logger.aiSdk.debug("Creating Levante Platform provider", {
+    modelId,
+    baseURL: apiBaseUrl,
+  });
+
+  // Use OpenAI-compatible endpoint with OAuth token as API key
+  const levantePlatform = createOpenAICompatible({
+    name: "levante-platform",
+    apiKey: tokens.accessToken,
+    baseURL: apiBaseUrl,
+  });
+
+  return levantePlatform(modelId);
 }

--- a/src/main/services/modelFetchService.ts
+++ b/src/main/services/modelFetchService.ts
@@ -6,6 +6,7 @@ import {
   safeFetch,
   normalizeEndpoint,
 } from "../utils/urlValidator";
+import { getOAuthService } from "./oauth";
 
 interface ModelResponse {
   object: string;
@@ -374,6 +375,44 @@ export class ModelFetchService {
       logger.models.error("Failed to fetch Hugging Face models", {
         error: error instanceof Error ? error.message : error,
         hasApiKey: !!apiKey,
+      });
+      throw error;
+    }
+  }
+
+  // Fetch Levante Platform models
+  // Uses OAuth tokens instead of API keys
+  static async fetchLevantePlatformModels(baseUrl?: string): Promise<any[]> {
+    const LEVANTE_PLATFORM_SERVER_ID = "levante-platform";
+    const effectiveBaseUrl = baseUrl || "https://platform.levante.ai";
+
+    try {
+      // Get OAuth service and check for valid tokens
+      const oauthService = getOAuthService();
+      const tokens = await oauthService.getExistingToken(LEVANTE_PLATFORM_SERVER_ID);
+
+      if (!tokens) {
+        logger.models.warn("No OAuth tokens for Levante Platform. Please authorize first.");
+        return [];
+      }
+
+      // Fetch models using OAuth token
+      const response = await safeFetch(`${effectiveBaseUrl}/api/v1/models`, {
+        headers: {
+          Authorization: `Bearer ${tokens.accessToken}`,
+          "Content-Type": "application/json",
+        },
+      });
+
+      if (!response.ok) {
+        throw new Error(`Levante Platform API error: ${response.statusText}`);
+      }
+
+      const data: ModelResponse = await response.json();
+      return data.data || [];
+    } catch (error) {
+      logger.models.error("Failed to fetch Levante Platform models", {
+        error: error instanceof Error ? error.message : error,
       });
       throw error;
     }

--- a/src/main/services/oauth/OAuthDiscoveryService.ts
+++ b/src/main/services/oauth/OAuthDiscoveryService.ts
@@ -174,7 +174,7 @@ export class OAuthDiscoveryService {
 
     /**
      * Obtiene metadata completo de un authorization server
-     * Implementa RFC 8414
+     * Implementa RFC 8414 con fallback para paths
      */
     async fetchServerMetadata(
         authServerUrl: string
@@ -193,52 +193,97 @@ export class OAuthDiscoveryService {
                 return cached;
             }
 
-            // Construir metadata URL
-            const metadataUrl = this.buildMetadataUrl(
+            // Construir URLs candidatas (RFC 8414 con fallback)
+            const metadataUrls = this.buildAuthServerMetadataUrls(authServerUrl);
+
+            this.logger.oauth.debug('Fetching authorization server metadata (candidates)', {
                 authServerUrl,
-                this.AUTH_SERVER_PATH
-            );
-
-            this.logger.oauth.debug('Fetching metadata from URL', {
-                metadataUrl,
+                metadataUrls,
             });
 
-            // Fetch metadata
-            const response = await fetch(metadataUrl, {
-                method: 'GET',
-                headers: {
-                    Accept: 'application/json',
-                },
-            });
+            let lastError: OAuthDiscoveryError | null = null;
 
-            if (!response.ok) {
-                throw new OAuthDiscoveryError(
-                    `Failed to fetch authorization server metadata: ${response.status} ${response.statusText}`,
-                    'METADATA_FETCH_FAILED',
-                    {
-                        status: response.status,
-                        statusText: response.statusText,
-                        url: metadataUrl,
+            for (const metadataUrl of metadataUrls) {
+                try {
+                    this.logger.oauth.debug('Attempting authorization server metadata fetch', {
+                        metadataUrl,
+                    });
+
+                    const response = await fetch(metadataUrl, {
+                        method: 'GET',
+                        headers: {
+                            Accept: 'application/json',
+                        },
+                    });
+
+                    if (!response.ok) {
+                        const errorCode =
+                            response.status === 404 || response.status === 410
+                                ? 'METADATA_NOT_SUPPORTED'
+                                : 'METADATA_FETCH_FAILED';
+
+                        lastError = new OAuthDiscoveryError(
+                            `Failed to fetch authorization server metadata: ${response.status} ${response.statusText}`,
+                            errorCode,
+                            {
+                                status: response.status,
+                                statusText: response.statusText,
+                                url: metadataUrl,
+                            }
+                        );
+
+                        this.logger.oauth.debug('Authorization server metadata fetch failed, trying next', {
+                            metadataUrl,
+                            status: response.status,
+                        });
+                        continue;
                     }
-                );
+
+                    const metadata = (await response.json()) as AuthorizationServerMetadata;
+
+                    // Validar metadata
+                    this.validateAuthServerMetadata(metadata, authServerUrl);
+
+                    // Cache metadata
+                    this.saveToCache(this.metadataCache, authServerUrl, metadata);
+
+                    this.logger.oauth.info('Authorization server metadata fetched', {
+                        authServerUrl,
+                        metadataUrl,
+                        authorizationEndpoint: metadata.authorization_endpoint,
+                        tokenEndpoint: metadata.token_endpoint,
+                        hasRegistrationEndpoint: !!metadata.registration_endpoint,
+                    });
+
+                    return metadata;
+                } catch (error) {
+                    if (error instanceof OAuthDiscoveryError) {
+                        lastError = error;
+                    } else {
+                        lastError = new OAuthDiscoveryError(
+                            'Failed to fetch authorization server metadata',
+                            'NETWORK_ERROR',
+                            { error, url: metadataUrl }
+                        );
+                    }
+
+                    this.logger.oauth.debug('Authorization server metadata fetch attempt failed', {
+                        metadataUrl,
+                        error: error instanceof Error ? error.message : error,
+                    });
+                }
             }
 
-            const metadata = (await response.json()) as AuthorizationServerMetadata;
+            // Si llegamos aquí, ninguna URL funcionó
+            if (lastError) {
+                throw lastError;
+            }
 
-            // Validar metadata
-            this.validateAuthServerMetadata(metadata, authServerUrl);
-
-            // Cache metadata
-            this.saveToCache(this.metadataCache, authServerUrl, metadata);
-
-            this.logger.oauth.info('Authorization server metadata fetched', {
-                authServerUrl,
-                authorizationEndpoint: metadata.authorization_endpoint,
-                tokenEndpoint: metadata.token_endpoint,
-                hasRegistrationEndpoint: !!metadata.registration_endpoint,
-            });
-
-            return metadata;
+            throw new OAuthDiscoveryError(
+                'Failed to fetch authorization server metadata from all candidates',
+                'METADATA_FETCH_FAILED',
+                { authServerUrl, metadataUrls }
+            );
         } catch (error) {
             if (error instanceof OAuthDiscoveryError) {
                 throw error;
@@ -544,15 +589,6 @@ export class OAuthDiscoveryService {
     // ========== Private Methods ==========
 
     /**
-     * Construye URL de metadata
-     */
-    private buildMetadataUrl(baseUrl: string, path: string): string {
-        const url = new URL(baseUrl);
-        url.pathname = path;
-        return url.toString();
-    }
-
-    /**
      * Construye las URLs posibles para metadata de protected resource,
      * probando primero la variante path-aware y luego la raíz.
      */
@@ -567,6 +603,31 @@ export class OAuthDiscoveryService {
         }
 
         urls.push(`${origin}${this.PROTECTED_RESOURCE_PATH}`);
+        return urls;
+    }
+
+    /**
+     * Construye las URLs posibles para metadata de authorization server.
+     * Según RFC 8414, debe preservar el path del authorization server.
+     *
+     * Orden de prioridad:
+     * 1. Path preservado + /.well-known/oauth-authorization-server (RFC 8414 correcto)
+     * 2. Origin + /.well-known/oauth-authorization-server (fallback)
+     */
+    private buildAuthServerMetadataUrls(authServerUrl: string): string[] {
+        const parsed = new URL(authServerUrl);
+        const origin = parsed.origin;
+        const normalizedPath = parsed.pathname.replace(/\/$/, '');
+        const urls: string[] = [];
+
+        // 1. RFC 8414: Preservar path + well-known
+        if (normalizedPath && normalizedPath !== '/') {
+            urls.push(`${origin}${normalizedPath}${this.AUTH_SERVER_PATH}`);
+        }
+
+        // 2. Fallback: Origin + well-known (comportamiento actual)
+        urls.push(`${origin}${this.AUTH_SERVER_PATH}`);
+
         return urls;
     }
 

--- a/src/main/services/oauth/__tests__/OAuthDiscoveryService.test.ts
+++ b/src/main/services/oauth/__tests__/OAuthDiscoveryService.test.ts
@@ -21,6 +21,12 @@ vi.mock('../../logging', () => ({
             warn: vi.fn(),
             error: vi.fn(),
         },
+        oauth: {
+            info: vi.fn(),
+            debug: vi.fn(),
+            warn: vi.fn(),
+            error: vi.fn(),
+        },
     }),
 }));
 
@@ -424,11 +430,6 @@ describe('OAuthDiscoveryService', () => {
         it('should use as_uri from WWW-Authenticate header', async () => {
             const wwwAuth = 'Bearer as_uri="https://custom-auth.example.com"';
 
-            const resourceMetadata: ProtectedResourceMetadata = {
-                resource: 'https://mcp.example.com',
-                authorization_servers: ['https://auth.example.com'],
-            };
-
             const serverMetadata: AuthorizationServerMetadata = {
                 issuer: 'https://custom-auth.example.com',
                 authorization_endpoint: 'https://custom-auth.example.com/authorize',
@@ -437,16 +438,12 @@ describe('OAuthDiscoveryService', () => {
                 code_challenge_methods_supported: ['S256'],
             };
 
-            global.fetch = vi
-                .fn()
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => resourceMetadata,
-                })
-                .mockResolvedValueOnce({
-                    ok: true,
-                    json: async () => serverMetadata,
-                });
+            // Cuando hay as_uri, NO se hace discovery de protected resource,
+            // se va directo a fetchServerMetadata
+            global.fetch = vi.fn().mockResolvedValue({
+                ok: true,
+                json: async () => serverMetadata,
+            });
 
             const result = await discoveryService.discoverFromUnauthorized(
                 'https://mcp.example.com',
@@ -459,20 +456,18 @@ describe('OAuthDiscoveryService', () => {
             );
         });
 
-        it('should throw error if no authorization server found', async () => {
-            const resourceMetadata: ProtectedResourceMetadata = {
-                resource: 'https://mcp.example.com',
-                authorization_servers: [], // Array vacío
-            };
-
+        it('should fallback to origin and fail if no metadata available anywhere', async () => {
+            // Simular que tanto el protected resource como el fallback al origin fallan
             global.fetch = vi.fn().mockResolvedValue({
-                ok: true,
-                json: async () => resourceMetadata,
+                ok: false,
+                status: 404,
+                statusText: 'Not Found',
             });
 
+            // Cuando todos los intentos de discovery fallan, debe lanzar error
             await expect(
                 discoveryService.discoverFromUnauthorized('https://mcp.example.com')
-            ).rejects.toThrow('missing or invalid "authorization_servers"');
+            ).rejects.toThrow('Failed to fetch authorization server metadata');
         });
     });
 
@@ -604,10 +599,11 @@ describe('OAuthDiscoveryService', () => {
         });
 
         it('should throw error if registration fails', async () => {
+            // El código usa response.text() primero, luego JSON.parse
             global.fetch = vi.fn().mockResolvedValue({
                 ok: false,
                 status: 400,
-                json: async () => ({
+                text: async () => JSON.stringify({
                     error: 'invalid_redirect_uri',
                     error_description: 'Invalid redirect URI',
                 }),

--- a/src/preload/api/models.ts
+++ b/src/preload/api/models.ts
@@ -21,4 +21,8 @@ export const modelsApi = {
     ipcRenderer.invoke('levante/models/huggingface', apiKey),
   validateHuggingFaceModel: (modelId: string, inferenceProvider: string) =>
     ipcRenderer.invoke('levante/models/huggingface/validate', modelId, inferenceProvider),
+  // Levante Platform uses OAuth tokens instead of API keys
+  // baseUrl is optional - defaults to https://platform.levante.ai
+  fetchLevantePlatform: (baseUrl?: string) =>
+    ipcRenderer.invoke('levante/models/levante-platform', baseUrl),
 };

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -258,6 +258,9 @@ export interface LevanteAPI {
       modelId: string,
       inferenceProvider: string
     ) => Promise<{ success: boolean; data?: any; error?: string }>;
+    // Levante Platform uses OAuth tokens instead of API keys
+    // baseUrl is optional - defaults to https://platform.levante.ai
+    fetchLevantePlatform: (baseUrl?: string) => Promise<{ success: boolean; data?: any[]; error?: string }>;
   };
 
   // Inference functionality

--- a/src/renderer/components/onboarding/ProviderStep.tsx
+++ b/src/renderer/components/onboarding/ProviderStep.tsx
@@ -14,6 +14,7 @@ import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/component
 import { CheckCircle2, XCircle, Loader2, ExternalLink, ChevronDown, Search } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useOpenRouterOAuth } from '@/hooks/useOpenRouterOAuth';
+import { useLevantePlatformOAuth } from '@/hooks/useLevantePlatformOAuth';
 import type { Model } from '../../../types/models';
 
 interface ProviderStepProps {
@@ -39,6 +40,13 @@ const PROVIDERS = [
     description: '100+ models with a single API key',
     requiresKey: true,
     signupUrl: 'https://openrouter.ai/keys',
+  },
+  {
+    id: 'levante-platform',
+    name: 'Levante Platform',
+    description: 'Powered by Levante - Sign in with your account',
+    requiresKey: false,  // Uses OAuth, not API key
+    usesOAuth: true,
   },
   {
     id: 'vercel-gateway',
@@ -115,12 +123,28 @@ export function ProviderStep({
     }
   });
 
+  // OAuth hook for Levante Platform
+  const {
+    isAuthenticating: isLevantePlatformAuthenticating,
+    isConnected: isLevantePlatformConnected,
+    initiateOAuthFlow: initiateLevantePlatformOAuth,
+  } = useLevantePlatformOAuth({
+    onSuccess: () => {
+      // Auto-validate after successful OAuth
+      setTimeout(() => {
+        onValidate();
+      }, 500);
+    }
+  });
+
   const showApiKeyField = provider?.requiresKey;
   const showEndpointField = provider?.requiresEndpoint;
 
   // Check if required fields are filled
   const canValidate = () => {
     if (!selectedProvider) return false;
+    // Levante Platform uses OAuth - valid when connected
+    if (selectedProvider === 'levante-platform') return isLevantePlatformConnected;
     if (provider?.requiresKey && !apiKey) return false;
     if (provider?.requiresEndpoint && !endpoint) return false;
     return true;
@@ -177,6 +201,38 @@ export function ProviderStep({
                 <p className="text-xs text-center text-muted-foreground">
                   {t('provider.oauth.connect_message')}
                 </p>
+              </div>
+            )}
+
+            {/* OAuth Login for Levante Platform */}
+            {selectedProvider === 'levante-platform' && (
+              <div className="space-y-3">
+                {isLevantePlatformConnected ? (
+                  <Alert className="border-green-500/50 bg-green-500/10 dark:bg-green-500/20 [&>svg]:top-3.5">
+                    <CheckCircle2 className="h-4 w-4 text-green-600 dark:text-green-400" />
+                    <AlertDescription className="text-green-700 dark:text-green-300">
+                      {t('provider.oauth.connected', 'Connected to Levante Platform')}
+                    </AlertDescription>
+                  </Alert>
+                ) : (
+                  <>
+                    <Button
+                      onClick={initiateLevantePlatformOAuth}
+                      disabled={isLevantePlatformAuthenticating}
+                      className="w-full h-11"
+                      variant="default"
+                      type="button"
+                    >
+                      <ExternalLink className="mr-2 h-4 w-4" />
+                      {isLevantePlatformAuthenticating
+                        ? t('provider.oauth.waiting')
+                        : t('provider.oauth.sign_in_levante', 'Sign in with Levante Platform')}
+                    </Button>
+                    <p className="text-xs text-center text-muted-foreground">
+                      {t('provider.oauth.connect_message_levante', 'Sign in with your Levante Platform account to access AI models')}
+                    </p>
+                  </>
+                )}
               </div>
             )}
 

--- a/src/renderer/hooks/useLevantePlatformOAuth.ts
+++ b/src/renderer/hooks/useLevantePlatformOAuth.ts
@@ -1,0 +1,124 @@
+import { useState, useEffect } from 'react';
+import { toast } from 'sonner';
+import { logger } from '@/services/logger';
+import { useOAuthStore } from '@/stores/oauthStore';
+
+const LEVANTE_PLATFORM_SERVER_ID = 'levante-platform';
+const LEVANTE_PLATFORM_DEFAULT_URL = 'https://platform.levante.ai';
+
+interface UseLevantePlatformOAuthOptions {
+  onSuccess?: () => void;
+  onError?: (error: string) => void;
+  /** Override base URL for local development */
+  baseUrl?: string;
+}
+
+/**
+ * Hook for Levante Platform OAuth using RFC 8414 Discovery
+ *
+ * Uses the existing MCP OAuth infrastructure which handles:
+ * - RFC 8414 OAuth Discovery
+ * - RFC 7591 Dynamic Client Registration (DCR)
+ * - PKCE (S256)
+ * - Token refresh
+ */
+export function useLevantePlatformOAuth(options: UseLevantePlatformOAuthOptions = {}) {
+  const { onSuccess, onError, baseUrl = LEVANTE_PLATFORM_DEFAULT_URL } = options;
+  const [isAuthenticating, setIsAuthenticating] = useState(false);
+
+  const {
+    servers,
+    authorize,
+    disconnect,
+    refreshStatus,
+    loading,
+    errors
+  } = useOAuthStore();
+
+  const serverStatus = servers[LEVANTE_PLATFORM_SERVER_ID];
+  const isLoading = loading[LEVANTE_PLATFORM_SERVER_ID] || false;
+  const error = errors[LEVANTE_PLATFORM_SERVER_ID] || null;
+  const isConnected = serverStatus?.hasTokens && serverStatus?.isTokenValid;
+
+  // Load status on mount
+  useEffect(() => {
+    refreshStatus(LEVANTE_PLATFORM_SERVER_ID).catch(() => {
+      // Silently ignore - no tokens yet is expected
+    });
+  }, [refreshStatus]);
+
+  const initiateOAuthFlow = async () => {
+    try {
+      setIsAuthenticating(true);
+      logger.core.info('Initiating Levante Platform OAuth flow');
+
+      toast.info('Connecting to Levante Platform', {
+        description: 'Opening authorization in your browser...',
+        duration: 10000
+      });
+
+      // Use the existing MCP OAuth infrastructure
+      // This handles RFC 8414 discovery, DCR, and PKCE automatically
+      await authorize({
+        serverId: LEVANTE_PLATFORM_SERVER_ID,
+        mcpServerUrl: baseUrl,
+        scopes: ['openid', 'email'],  // Levante Platform uses OpenID scopes
+      });
+
+      logger.core.info('Levante Platform OAuth completed successfully');
+
+      toast.success('Connected to Levante Platform!', {
+        description: 'Your account has been connected',
+        duration: 5000
+      });
+
+      onSuccess?.();
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to authenticate';
+      logger.core.error('Levante Platform OAuth failed', { error: errorMessage });
+
+      toast.error('Authentication failed', {
+        description: errorMessage,
+        duration: 5000
+      });
+
+      onError?.(errorMessage);
+    } finally {
+      setIsAuthenticating(false);
+    }
+  };
+
+  const disconnectOAuth = async () => {
+    try {
+      setIsAuthenticating(true);
+      logger.core.info('Disconnecting from Levante Platform');
+
+      await disconnect(LEVANTE_PLATFORM_SERVER_ID, true);
+
+      toast.success('Disconnected from Levante Platform', {
+        duration: 3000
+      });
+
+    } catch (error) {
+      const errorMessage = error instanceof Error ? error.message : 'Failed to disconnect';
+      logger.core.error('Levante Platform disconnect failed', { error: errorMessage });
+
+      toast.error('Disconnect failed', {
+        description: errorMessage,
+        duration: 5000
+      });
+    } finally {
+      setIsAuthenticating(false);
+    }
+  };
+
+  return {
+    isAuthenticating: isAuthenticating || isLoading,
+    isConnected,
+    serverStatus,
+    error,
+    initiateOAuthFlow,
+    disconnectOAuth,
+  };
+}

--- a/src/renderer/pages/ModelPage.tsx
+++ b/src/renderer/pages/ModelPage.tsx
@@ -22,7 +22,7 @@ import { Loader2, CheckCircle, XCircle, RefreshCw, Search, Plus } from 'lucide-r
 import { useModelStore } from '@/stores/modelStore';
 import type { ProviderConfig } from '../../types/models';
 import { useTranslation } from 'react-i18next';
-import { OpenRouterConfig, GatewayConfig, LocalConfig, CloudConfig } from './ModelPage/ProviderConfigs';
+import { OpenRouterConfig, LevantePlatformConfig, GatewayConfig, LocalConfig, CloudConfig } from './ModelPage/ProviderConfigs';
 import { ModelList } from './ModelPage/ModelList';
 import { AddInferenceModelDialog } from '@/components/dialogs/AddInferenceModelDialog';
 
@@ -86,6 +86,8 @@ const ModelPage = () => {
     switch (provider.type) {
       case 'openrouter':
         return <OpenRouterConfig provider={provider} />;
+      case 'levante-platform':
+        return <LevantePlatformConfig provider={provider} />;
       case 'vercel-gateway':
         return <GatewayConfig provider={provider} />;
       case 'local':

--- a/src/renderer/pages/ModelPage/ProviderConfigs.tsx
+++ b/src/renderer/pages/ModelPage/ProviderConfigs.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
-import { ExternalLink, RefreshCw } from 'lucide-react';
+import { ExternalLink, RefreshCw, CheckCircle2, XCircle } from 'lucide-react';
 import { useModelStore } from '@/stores/modelStore';
 import { useOpenRouterOAuth } from '@/hooks/useOpenRouterOAuth';
+import { useLevantePlatformOAuth } from '@/hooks/useLevantePlatformOAuth';
 import type { ProviderConfig } from '../../../types/models';
 import { useTranslation } from 'react-i18next';
 
@@ -98,6 +99,117 @@ export const OpenRouterConfig = ({ provider }: { provider: ProviderConfig }) => 
         <RefreshCw className={`w-4 h-4 mr-2 ${syncing ? 'animate-spin' : ''}`} />
         {t('models.sync')}
       </Button>
+    </div>
+  );
+};
+
+export const LevantePlatformConfig = ({ provider }: { provider: ProviderConfig }) => {
+  const { t } = useTranslation('models');
+  const { syncProviderModels, syncing, updateProvider } = useModelStore();
+  const [baseUrl, setBaseUrl] = React.useState(provider.baseUrl || 'https://platform.levante.ai');
+
+  // Sync local state when provider changes
+  React.useEffect(() => {
+    setBaseUrl(provider.baseUrl || 'https://platform.levante.ai');
+  }, [provider.baseUrl]);
+
+  // OAuth hook using RFC 8414 Discovery
+  // Pass baseUrl for local development
+  const {
+    isAuthenticating,
+    isConnected,
+    initiateOAuthFlow,
+    disconnectOAuth,
+  } = useLevantePlatformOAuth({
+    baseUrl,
+    onSuccess: () => {
+      // Sync models after successful OAuth
+      syncProviderModels(provider.id);
+    }
+  });
+
+  const handleSaveBaseUrl = async () => {
+    await updateProvider(provider.id, { baseUrl });
+  };
+
+  const handleSync = () => {
+    syncProviderModels(provider.id);
+  };
+
+  return (
+    <div className="space-y-6">
+      {/* Base URL Configuration - for local development */}
+      <div className="space-y-2">
+        <Label htmlFor="levante-url">{t('base_url.label', 'Base URL')}</Label>
+        <div className="flex gap-2">
+          <Input
+            id="levante-url"
+            type="url"
+            value={baseUrl}
+            onChange={(e) => setBaseUrl(e.target.value)}
+          />
+          <Button onClick={handleSaveBaseUrl} variant="outline">{t('stats.save', 'Save')}</Button>
+        </div>
+        <p className="text-xs text-muted-foreground">
+          {t('base_url.help_levante', 'Use http://localhost:3000 for local development')}
+        </p>
+      </div>
+
+      {/* OAuth Status */}
+      <div className="flex items-center gap-2 text-sm">
+        {isConnected ? (
+          <>
+            <CheckCircle2 className="w-4 h-4 text-green-500" />
+            <span className="text-green-600 dark:text-green-400">
+              {t('oauth.connected', 'Connected')}
+            </span>
+          </>
+        ) : (
+          <>
+            <XCircle className="w-4 h-4 text-muted-foreground" />
+            <span className="text-muted-foreground">
+              {t('oauth.not_connected', 'Not connected')}
+            </span>
+          </>
+        )}
+      </div>
+
+      {/* OAuth Login/Disconnect Button */}
+      <div className="space-y-3">
+        {isConnected ? (
+          <Button
+            onClick={disconnectOAuth}
+            disabled={isAuthenticating}
+            className="w-full h-11"
+            variant="outline"
+          >
+            {isAuthenticating ? t('oauth.disconnecting', 'Disconnecting...') : t('oauth.disconnect', 'Disconnect')}
+          </Button>
+        ) : (
+          <>
+            <Button
+              onClick={initiateOAuthFlow}
+              disabled={isAuthenticating}
+              className="w-full h-11"
+              variant="default"
+            >
+              <ExternalLink className="w-4 h-4 mr-2" />
+              {isAuthenticating ? t('oauth.waiting') : t('oauth.sign_in_levante', 'Sign in with Levante Platform')}
+            </Button>
+            <p className="text-xs text-center text-muted-foreground">
+              {t('oauth.connect_message_levante', 'Connect your Levante Platform account to access AI models')}
+            </p>
+          </>
+        )}
+      </div>
+
+      {/* Sync Button - only show when connected */}
+      {isConnected && (
+        <Button onClick={handleSync} disabled={syncing} variant="outline" className="w-full">
+          <RefreshCw className={`w-4 h-4 mr-2 ${syncing ? 'animate-spin' : ''}`} />
+          {t('models.sync')}
+        </Button>
+      )}
     </div>
   );
 };

--- a/src/renderer/services/model/providers/levanteProvider.ts
+++ b/src/renderer/services/model/providers/levanteProvider.ts
@@ -1,0 +1,70 @@
+import type { Model } from '../../../../types/models';
+import { getRendererLogger } from '@/services/logger';
+
+const logger = getRendererLogger();
+
+/**
+ * Fetch models from Levante Platform API
+ * Uses OAuth tokens from the OAuth store (not API keys)
+ * @param baseUrl - Optional base URL override for local development
+ */
+export async function fetchLevantePlatformModels(baseUrl?: string): Promise<Model[]> {
+  try {
+    const result = await window.levante.models.fetchLevantePlatform(baseUrl);
+
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to fetch Levante Platform models');
+    }
+
+    const data = result.data || [];
+
+    return data.map((model: any): Model => ({
+      id: model.id,
+      name: model.name || model.id,
+      provider: 'levante-platform',
+      contextLength: model.context_length || model.contextLength || 128000,
+      pricing: model.pricing ? {
+        input: parseFloat(model.pricing.input || model.pricing.prompt) * 1000000,
+        output: parseFloat(model.pricing.output || model.pricing.completion) * 1000000
+      } : undefined,
+      description: model.description,
+      capabilities: parseLevantePlatformCapabilities(model),
+      isAvailable: true,
+      userDefined: false
+    }));
+  } catch (error) {
+    logger.models.error('Failed to fetch Levante Platform models', {
+      error: error instanceof Error ? error.message : error
+    });
+    throw error;
+  }
+}
+
+/**
+ * Parse Levante Platform model capabilities
+ */
+function parseLevantePlatformCapabilities(model: any): string[] {
+  const capabilities: string[] = ['text'];
+
+  // Check for vision/multimodal capabilities
+  if (model.capabilities?.includes('vision') ||
+    model.modalities?.includes('image') ||
+    model.id.toLowerCase().includes('vision')) {
+    capabilities.push('vision');
+  }
+
+  // Check for function/tool calling
+  if (model.capabilities?.includes('tools') ||
+    model.capabilities?.includes('function_calling') ||
+    model.supports_tools) {
+    capabilities.push('tools');
+  }
+
+  // Check for reasoning
+  if (model.capabilities?.includes('reasoning') ||
+    model.id.toLowerCase().includes('reasoning')) {
+    capabilities.push('reasoning');
+  }
+
+  return capabilities;
+}

--- a/src/renderer/services/modelService.ts
+++ b/src/renderer/services/modelService.ts
@@ -11,6 +11,7 @@ import { fetchAnthropicModels } from './model/providers/anthropicProvider';
 import { fetchGroqModels } from './model/providers/groqProvider';
 import { fetchXAIModels } from './model/providers/xAIProvider';
 import { fetchHuggingFaceModels } from './model/providers/huggingfaceProvider';
+import { fetchLevantePlatformModels } from './model/providers/levanteProvider';
 import { classifyModel, getCompatibleCategories, type ModelClassification } from '../../utils/modelClassification';
 
 const logger = getRendererLogger();
@@ -64,6 +65,9 @@ class ModelServiceImpl {
       // Set default providers if none exist
       if (this.providers.length === 0) {
         await this.initializeDefaultProviders();
+      } else {
+        // Add any new providers that don't exist yet (for existing users)
+        await this.addMissingProviders();
       }
 
       this.isInitialized = true;
@@ -86,6 +90,16 @@ class ModelServiceImpl {
         isActive: false,
         settings: {},
         modelSource: 'dynamic'
+      },
+      {
+        id: 'levante-platform',
+        name: 'Levante Platform',
+        type: 'levante-platform',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic',
+        baseUrl: 'http://localhost:3000'
       },
       {
         id: 'vercel-gateway',
@@ -170,6 +184,128 @@ class ModelServiceImpl {
     await this.saveProviders();
   }
 
+  // Get default providers list (used for initialization and migration)
+  private getDefaultProviders(): ProviderConfig[] {
+    return [
+      {
+        id: 'openrouter',
+        name: 'OpenRouter',
+        type: 'openrouter',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic'
+      },
+      {
+        id: 'levante-platform',
+        name: 'Levante Platform',
+        type: 'levante-platform',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic',
+        baseUrl: 'https://platform.levante.ai'
+      },
+      {
+        id: 'vercel-gateway',
+        name: 'Vercel AI Gateway',
+        type: 'vercel-gateway',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic',
+        baseUrl: 'https://ai-gateway.vercel.sh/v1'
+      },
+      {
+        id: 'local',
+        name: 'Local Provider',
+        type: 'local',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'user-defined'
+      },
+      {
+        id: 'openai',
+        name: 'OpenAI',
+        type: 'openai',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic'
+      },
+      {
+        id: 'anthropic',
+        name: 'Anthropic',
+        type: 'anthropic',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic'
+      },
+      {
+        id: 'google',
+        name: 'Google AI',
+        type: 'google',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic'
+      },
+      {
+        id: 'groq',
+        name: 'Groq',
+        type: 'groq',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic',
+        baseUrl: 'https://api.groq.com/openai/v1'
+      },
+      {
+        id: 'xai',
+        name: 'xAI',
+        type: 'xai',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic',
+        baseUrl: 'https://api.x.ai/v1'
+      },
+      {
+        id: 'huggingface',
+        name: 'Hugging Face',
+        type: 'huggingface',
+        models: [],
+        isActive: false,
+        settings: {},
+        modelSource: 'dynamic',
+        baseUrl: 'https://router.huggingface.co/v1'
+      }
+    ];
+  }
+
+  // Add any new providers that exist in defaults but not in user's saved providers
+  private async addMissingProviders(): Promise<void> {
+    const defaultProviders = this.getDefaultProviders();
+    const existingIds = new Set(this.providers.map(p => p.id));
+
+    const missingProviders = defaultProviders.filter(p => !existingIds.has(p.id));
+
+    if (missingProviders.length > 0) {
+      logger.models.info('Adding missing providers', {
+        providers: missingProviders.map(p => p.id)
+      });
+
+      // Add missing providers after OpenRouter (position 1)
+      const openrouterIndex = this.providers.findIndex(p => p.id === 'openrouter');
+      const insertIndex = openrouterIndex >= 0 ? openrouterIndex + 1 : 0;
+
+      this.providers.splice(insertIndex, 0, ...missingProviders);
+      await this.saveProviders();
+    }
+  }
+
   // Get active provider
   async getActiveProvider(): Promise<ProviderConfig | null> {
     if (!this.activeProviderId) return null;
@@ -228,8 +364,8 @@ class ModelServiceImpl {
     // Only sync providers that have API keys configured to avoid empty results
     const now = Date.now();
     this.providers.forEach(provider => {
-      // Skip providers without API key (except openrouter which works without key)
-      const hasCredentials = provider.apiKey || provider.type === 'openrouter';
+      // Skip providers without API key (except openrouter which works without key, and levante-platform which uses OAuth)
+      const hasCredentials = provider.apiKey || provider.type === 'openrouter' || provider.type === 'levante-platform';
 
       if (provider.modelSource === 'dynamic' &&
         hasCredentials &&
@@ -413,6 +549,12 @@ class ModelServiceImpl {
       switch (provider.type) {
         case 'openrouter':
           models = await fetchOpenRouterModels(provider.apiKey);
+          break;
+        case 'levante-platform':
+          // Levante Platform uses OAuth tokens, not API keys
+          // The fetch function will get the token from the OAuth store
+          // Pass baseUrl for local development override
+          models = await fetchLevantePlatformModels(provider.baseUrl);
           break;
         case 'vercel-gateway':
           if (provider.apiKey && provider.baseUrl) {

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -27,7 +27,7 @@ export interface Model {
 }
 
 export type CloudProviderType = 'openai' | 'anthropic' | 'google' | 'groq' | 'xai' | 'huggingface';
-export type ProviderType = 'openrouter' | 'vercel-gateway' | 'local' | CloudProviderType;
+export type ProviderType = 'openrouter' | 'vercel-gateway' | 'local' | 'levante-platform' | CloudProviderType;
 
 export interface ProviderConfig {
   id: string;


### PR DESCRIPTION
## Summary

- Integrates **Levante Platform** as a new AI model provider using OAuth 2.1 authentication
- Leverages existing MCP OAuth infrastructure (~98% code reuse)
- Supports both production (`https://platform.levante.ai`) and local development (`http://localhost:3000`)

## Changes

### Backend (Main Process)
- `modelHandlers.ts`: New IPC handler `levante/models/levante-platform`
- `providerResolver.ts`: New `configureLevantePlatform()` using OAuth tokens
- `modelFetchService.ts`: New `fetchLevantePlatformModels()` method
- `OAuthDiscoveryService.ts`: Improved RFC 8414 discovery with path-aware fallback

### Frontend (Renderer)
- `useLevantePlatformOAuth.ts`: New hook for OAuth flow management
- `levanteProvider.ts`: New service for fetching Levante Platform models
- `ProviderStep.tsx`: Added Levante Platform to onboarding
- `ProviderConfigs.tsx`: New `LevantePlatformConfig` component
- `modelService.ts`: Added provider + automatic migration for existing users

### Bridge (Preload)
- Added `fetchLevantePlatform` API method

### Types
- Added `levante-platform` to `ProviderType`

## Architecture

```
User → OAuth Discovery (RFC 8414) → DCR (RFC 7591) → PKCE Auth → Token → API
```

Reuses:
- `OAuthDiscoveryService` - Discovery & DCR
- `OAuthFlowManager` - PKCE, token exchange, refresh
- `OAuthTokenStore` - Encrypted storage
- `oauthStore` - UI state management

## Test plan

- [ ] Test OAuth flow with Levante Platform (production)
- [ ] Test OAuth flow with local development server
- [ ] Verify model listing after successful auth
- [ ] Test disconnect/reconnect flow
- [ ] Verify existing users get the new provider added automatically
- [ ] Test onboarding flow with Levante Platform selection

🤖 Generated with [Claude Code](https://claude.com/claude-code)