### PR TITLE
feat(cowork): add working directory selector for Cowork mode

### DIFF
--- a/src/main/ipc/coworkHandlers.ts
+++ b/src/main/ipc/coworkHandlers.ts
@@ -1,0 +1,94 @@
+/**
+ * Cowork Mode IPC Handlers Module
+ *
+ * Handles cowork-specific IPC communication:
+ * - Working directory selection for coding tools
+ */
+
+import { ipcMain, dialog, BrowserWindow, IpcMainInvokeEvent } from 'electron';
+import { getLogger } from '../services/logging';
+
+const logger = getLogger();
+
+const CHANNEL = 'levante/cowork/select-working-directory';
+
+export interface SelectWorkingDirectoryOptions {
+  title?: string;
+  defaultPath?: string;
+  buttonLabel?: string;
+}
+
+export interface SelectWorkingDirectoryResult {
+  success: boolean;
+  data?: {
+    path: string;
+    canceled: boolean;
+  };
+  error?: string;
+}
+
+/**
+ * Register cowork IPC handlers
+ */
+export function setupCoworkHandlers(): void {
+  // Remove any existing handler to prevent registration conflicts
+  ipcMain.removeHandler(CHANNEL);
+
+  ipcMain.handle(CHANNEL, handleSelectWorkingDirectory);
+
+  logger.ipc.info('Cowork handlers registered successfully');
+}
+
+/**
+ * Handle working directory selection for cowork mode
+ */
+async function handleSelectWorkingDirectory(
+  event: IpcMainInvokeEvent,
+  options?: SelectWorkingDirectoryOptions
+): Promise<SelectWorkingDirectoryResult> {
+  try {
+    // Get the window from which the request originated
+    const win = BrowserWindow.fromWebContents(event.sender);
+
+    const dialogOptions: Electron.OpenDialogOptions = {
+      title: options?.title ?? 'Select Working Directory',
+      defaultPath: options?.defaultPath,
+      buttonLabel: options?.buttonLabel ?? 'Select',
+      properties: ['openDirectory', 'createDirectory'],
+    };
+
+    let result: Electron.OpenDialogReturnValue;
+
+    if (win && !win.isDestroyed()) {
+      // Show dialog attached to the requesting window
+      result = await dialog.showOpenDialog(win, dialogOptions);
+    } else {
+      // Fallback to unattached dialog if window not available
+      result = await dialog.showOpenDialog(dialogOptions);
+    }
+
+    const selectedPath = result.filePaths[0] ?? '';
+
+    logger.ipc.info('Cowork directory selection', {
+      canceled: result.canceled,
+      path: result.canceled ? undefined : selectedPath,
+    });
+
+    return {
+      success: true,
+      data: {
+        path: selectedPath,
+        canceled: result.canceled,
+      },
+    };
+  } catch (error) {
+    logger.ipc.error('Failed to select cowork working directory', {
+      error: error instanceof Error ? error.message : error,
+    });
+
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error',
+    };
+  }
+}

--- a/src/main/lifecycle/initialization.ts
+++ b/src/main/lifecycle/initialization.ts
@@ -30,6 +30,7 @@ import { setupAttachmentHandlers } from "../ipc/attachmentHandlers";
 import { registerAnalyticsHandlers } from "../ipc/analyticsHandlers";
 import { setupWidgetHandlers } from "../ipc/widgetHandlers";
 import { setupAnnouncementHandlers } from "../ipc/announcementHandlers";
+import { setupCoworkHandlers } from "../ipc/coworkHandlers";
 
 const logger = getLogger();
 
@@ -131,6 +132,7 @@ export async function registerIPCHandlers(getMainWindow: () => BrowserWindow | n
   setupOAuthHandlers();
   setupWidgetHandlers();
   setupAnnouncementHandlers();
+  setupCoworkHandlers();
 
   // Note: Log viewer handlers are registered separately in main.ts after window creation
 

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -908,6 +908,25 @@ export class AIService {
     }
   }
 
+  /**
+   * Validate cowork CWD path.
+   * Returns the path if valid, null otherwise.
+   * Does NOT fallback to process.cwd() - must be explicitly provided.
+   */
+  private async resolveValidCoworkCwd(cwd?: string): Promise<string | null> {
+    if (!cwd) {
+      return null;
+    }
+
+    try {
+      const fs = await import('fs/promises');
+      const stats = await fs.stat(cwd);
+      return stats.isDirectory() ? cwd : null;
+    } catch {
+      return null;
+    }
+  }
+
   async *streamChat(
     request: ChatRequest
   ): AsyncGenerator<ChatStreamChunk, void, unknown> {
@@ -1109,20 +1128,28 @@ export class AIService {
       // Cargar Coding Tools (si está habilitado code mode)
       // ──────────────────────────────────────────────────
       if (request.codeMode?.enabled) {
-        const codingTools = getCodingTools({
-          cwd: request.codeMode.cwd ?? process.cwd(),
-          enabled: request.codeMode.tools, // { bash: true, read: true, ... }
-        });
+        const validCwd = await this.resolveValidCoworkCwd(request.codeMode.cwd);
 
-        tools = {
-          ...tools,
-          ...codingTools,
-        };
+        if (!validCwd) {
+          this.logger.aiSdk.warn('Cowork code mode requested without valid cwd; skipping coding tools', {
+            requestedCwd: request.codeMode.cwd,
+          });
+        } else {
+          const codingTools = getCodingTools({
+            cwd: validCwd,
+            enabled: request.codeMode.tools, // { bash: true, read: true, ... }
+          });
 
-        this.logger.aiSdk.debug("Loaded coding tools", {
-          tools: Object.keys(codingTools),
-          cwd: request.codeMode.cwd,
-        });
+          tools = {
+            ...tools,
+            ...codingTools,
+          };
+
+          this.logger.aiSdk.debug("Loaded coding tools", {
+            tools: Object.keys(codingTools),
+            cwd: validCwd,
+          });
+        }
       }
 
       const messagesWithFileParts = await this.includeAttachmentsInMessageParts(

--- a/src/main/services/preferencesService.ts
+++ b/src/main/services/preferencesService.ts
@@ -218,6 +218,10 @@ export class PreferencesService {
           coworkMode: {
             type: 'boolean',
             default: false
+          },
+          coworkModeCwd: {
+            type: ['string', 'null'],
+            default: null
           }
         }
       });

--- a/src/preload/api/cowork.ts
+++ b/src/preload/api/cowork.ts
@@ -1,0 +1,16 @@
+import { ipcRenderer } from 'electron';
+
+export interface SelectWorkingDirectoryResult {
+  success: boolean;
+  data?: { path: string; canceled: boolean };
+  error?: string;
+}
+
+export const coworkApi = {
+  selectWorkingDirectory: (options?: {
+    title?: string;
+    defaultPath?: string;
+    buttonLabel?: string;
+  }): Promise<SelectWorkingDirectoryResult> =>
+    ipcRenderer.invoke('levante/cowork/select-working-directory', options),
+};

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -59,6 +59,7 @@ import { widgetApi } from "./api/widget";
 import { announcementsApi } from "./api/announcements";
 import { miniChatApi, onMiniChatShown, onMiniChatHidden, onSessionLoad } from "./api/miniChat";
 import { logViewerApi } from "./api/logViewer";
+import { coworkApi } from "./api/cowork";
 
 // Re-export types for backwards compatibility
 export type {
@@ -828,6 +829,19 @@ export interface LevanteAPI {
   onMiniChatShown: (callback: () => void) => () => void;
   onMiniChatHidden: (callback: () => void) => () => void;
   onSessionLoad: (callback: (data: { sessionId: string }) => void) => () => void;
+
+  // Cowork API
+  cowork: {
+    selectWorkingDirectory: (options?: {
+      title?: string;
+      defaultPath?: string;
+      buttonLabel?: string;
+    }) => Promise<{
+      success: boolean;
+      data?: { path: string; canceled: boolean };
+      error?: string;
+    }>;
+  };
 }
 
 // Assemble the complete API from modules
@@ -890,6 +904,9 @@ const api: LevanteAPI = {
 
   // Log viewer API
   logViewer: logViewerApi,
+
+  // Cowork API
+  cowork: coworkApi,
 };
 
 // Use `contextBridge` APIs to expose Electron APIs to

--- a/src/renderer/components/chat/ChatPromptInput.tsx
+++ b/src/renderer/components/chat/ChatPromptInput.tsx
@@ -59,6 +59,8 @@ interface ChatPromptInputProps {
   onMCPChange: (enabled: boolean) => void;
   coworkMode: boolean;
   onCoworkModeChange: (enabled: boolean) => void;
+  coworkModeCwd: string | null;
+  onCoworkModeCwdChange: (cwd: string | null) => void;
   model: string;
   onModelChange: (modelId: string) => void;
   availableModels: Model[];
@@ -92,6 +94,8 @@ export function ChatPromptInput({
   onMCPChange,
   coworkMode,
   onCoworkModeChange,
+  coworkModeCwd,
+  onCoworkModeCwdChange,
   model,
   onModelChange,
   availableModels,
@@ -234,6 +238,8 @@ export function ChatPromptInput({
             onMCPChange={onMCPChange}
             coworkMode={coworkMode}
             onCoworkModeChange={onCoworkModeChange}
+            coworkModeCwd={coworkModeCwd}
+            onCoworkModeCwdChange={onCoworkModeCwdChange}
           />
           {/* Add Context Menu (MCP resources + prompts + file upload) */}
           {onFilesSelected && (

--- a/src/renderer/components/chat/ToolsMenu.tsx
+++ b/src/renderer/components/chat/ToolsMenu.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Switch } from '@/components/ui/switch';
-import { Wrench, Settings, ChevronDown, ChevronRight, RefreshCw, Code2 } from 'lucide-react';
+import { Wrench, Settings, ChevronDown, ChevronRight, RefreshCw, Code2, FolderOpen, AlertTriangle } from 'lucide-react';
 import { cn } from '@/lib/utils';
 import { useTranslation } from 'react-i18next';
 import { useMCPStore } from '@/stores/mcpStore';
@@ -26,6 +26,8 @@ interface ToolsMenuProps {
   onMCPChange: (enabled: boolean) => void;
   coworkMode: boolean;
   onCoworkModeChange: (enabled: boolean) => void;
+  coworkModeCwd: string | null;
+  onCoworkModeCwdChange: (cwd: string | null) => void;
   className?: string;
 }
 
@@ -34,6 +36,8 @@ export function ToolsMenu({
   onMCPChange,
   coworkMode,
   onCoworkModeChange,
+  coworkModeCwd,
+  onCoworkModeCwdChange,
   className
 }: ToolsMenuProps) {
   const { t } = useTranslation('chat');
@@ -64,6 +68,32 @@ export function ToolsMenu({
     loadToolsCache();
     loadDisabledTools();
   }, [loadToolsCache, loadDisabledTools]);
+
+  // Show warning when cowork is enabled but no CWD selected
+  const showCoworkMissingDirWarning = coworkMode && !coworkModeCwd;
+
+  // Get short folder name (cross-platform)
+  const getShortFolderName = (path: string): string => {
+    const parts = path.split(/[\\/]/).filter(Boolean);
+    return parts[parts.length - 1] || path;
+  };
+
+  // Handle directory selection
+  const handleSelectDirectory = async () => {
+    try {
+      const result = await window.levante.cowork.selectWorkingDirectory({
+        title: t('tools_menu.cowork.select_directory_title', 'Select Working Directory'),
+        buttonLabel: t('tools_menu.cowork.select_button', 'Select'),
+        defaultPath: coworkModeCwd || undefined,
+      });
+
+      if (result.success && result.data && !result.data.canceled) {
+        onCoworkModeCwdChange(result.data.path);
+      }
+    } catch (error) {
+      console.error('Failed to select directory:', error);
+    }
+  };
 
   // Separate servers into enabled and disabled
   const enabledServers = activeServers.filter(server => server.enabled !== false);
@@ -108,7 +138,7 @@ export function ToolsMenu({
               <Code2 size={16} className="text-muted-foreground" />
               <span className="text-sm">{t('tools_menu.cowork.label', 'Cowork')}</span>
               {coworkMode && (
-                <Badge variant="secondary" className="text-xs bg-blue-100 text-blue-700">
+                <Badge variant="secondary" className={cn("text-xs", coworkModeCwd ? "bg-blue-100 text-blue-700" : "bg-amber-100 text-amber-700")}>
                   {t('tools_menu.cowork.active', 'active')}
                 </Badge>
               )}
@@ -119,6 +149,37 @@ export function ToolsMenu({
               onClick={(e) => e.stopPropagation()}
             />
           </div>
+          {/* Cowork Directory Selector - only show when cowork is enabled */}
+          {coworkMode && (
+            <div className="px-3 py-2 space-y-2">
+              <div
+                className="flex items-center gap-2 p-2 rounded-md border border-dashed cursor-pointer hover:bg-accent"
+                onClick={handleSelectDirectory}
+              >
+                <FolderOpen size={16} className={coworkModeCwd ? "text-blue-600" : "text-amber-500"} />
+                <div className="flex-1 min-w-0">
+                  {coworkModeCwd ? (
+                    <span className="text-sm truncate block" title={coworkModeCwd}>
+                      {getShortFolderName(coworkModeCwd)}
+                    </span>
+                  ) : (
+                    <span className="text-sm text-muted-foreground">
+                      {t('tools_menu.cowork.click_to_select', 'Click to select directory')}
+                    </span>
+                  )}
+                </div>
+              </div>
+              {/* Warning when no directory selected */}
+              {showCoworkMissingDirWarning && (
+                <div className="flex items-start gap-2 p-2 rounded-md bg-amber-50 dark:bg-amber-950/30 border border-amber-200 dark:border-amber-800">
+                  <AlertTriangle size={14} className="text-amber-500 mt-0.5 flex-shrink-0" />
+                  <span className="text-xs text-amber-700 dark:text-amber-300">
+                    {t('tools_menu.cowork.missing_directory_warning', 'Cowork is enabled but no working directory is selected. Coding tools are disabled.')}
+                  </span>
+                </div>
+              )}
+            </div>
+          )}
           {/* MCP Tools Toggle */}
           <div
             className="flex items-center justify-between rounded-sm px-3 py-2 hover:bg-accent cursor-pointer"
@@ -145,10 +206,31 @@ export function ToolsMenu({
       {/* 2. Cowork Mode Indicator - Only when Cowork is enabled */}
       {coworkMode && (
         <div
-          className="flex items-center justify-center h-8 w-8 rounded-lg ring-1 ring-blue-500/50 bg-blue-500/10 cursor-default"
-          title={t('tools_menu.cowork.tooltip', 'Cowork mode enabled - AI can execute code tools')}
+          className={cn(
+            "flex items-center justify-center h-8 rounded-lg ring-1 cursor-pointer gap-1 px-2",
+            coworkModeCwd
+              ? "ring-blue-500/50 bg-blue-500/10"
+              : "ring-amber-500/50 bg-amber-500/10"
+          )}
+          onClick={handleSelectDirectory}
+          title={coworkModeCwd
+            ? `${t('tools_menu.cowork.tooltip', 'Cowork mode enabled')}: ${coworkModeCwd}`
+            : t('tools_menu.cowork.no_directory', 'Click to select working directory')
+          }
         >
-          <Code2 size={16} className="text-blue-600" />
+          {coworkModeCwd ? (
+            <>
+              <Code2 size={16} className="text-blue-600" />
+              <span className="text-xs text-blue-600 max-w-20 truncate">
+                {getShortFolderName(coworkModeCwd)}
+              </span>
+            </>
+          ) : (
+            <>
+              <AlertTriangle size={16} className="text-amber-500" />
+              <Code2 size={16} className="text-amber-500" />
+            </>
+          )}
         </div>
       )}
 

--- a/src/renderer/locales/en/chat.json
+++ b/src/renderer/locales/en/chat.json
@@ -70,7 +70,22 @@
     "mcp_tools": {
       "label": "Tools (MCP)",
       "keywords": ["tools", "herramientas", "mcp"]
-    }
+    },
+    "cowork": {
+      "label": "Cowork",
+      "active": "active",
+      "tooltip": "Cowork mode enabled - AI can execute code tools",
+      "no_directory": "Click to select working directory",
+      "select_directory_title": "Select Working Directory",
+      "select_button": "Select",
+      "click_to_select": "Click to select directory",
+      "select_directory_hint": "Select a directory for coding tools",
+      "missing_directory_warning": "Cowork is enabled but no working directory is selected. Coding tools are disabled."
+    },
+    "enabled": "Enabled",
+    "no_enabled_servers": "No enabled servers",
+    "disabled_servers_info": "Toggle to enable",
+    "no_disabled_servers": "No disabled servers"
   },
   "paid_model_chat_warning": {
     "title": "Paid Model Notice",

--- a/src/renderer/locales/es/chat.json
+++ b/src/renderer/locales/es/chat.json
@@ -70,7 +70,22 @@
     "mcp_tools": {
       "label": "Herramientas (MCP)",
       "keywords": ["tools", "herramientas", "mcp"]
-    }
+    },
+    "cowork": {
+      "label": "Cowork",
+      "active": "activo",
+      "tooltip": "Modo Cowork activado - la IA puede ejecutar herramientas de código",
+      "no_directory": "Haz clic para seleccionar carpeta de trabajo",
+      "select_directory_title": "Seleccionar Carpeta de Trabajo",
+      "select_button": "Seleccionar",
+      "click_to_select": "Haz clic para seleccionar carpeta",
+      "select_directory_hint": "Selecciona una carpeta para las herramientas de código",
+      "missing_directory_warning": "Cowork está activado pero no hay carpeta de trabajo seleccionada. Las herramientas de código están desactivadas."
+    },
+    "enabled": "Habilitados",
+    "no_enabled_servers": "No hay servidores habilitados",
+    "disabled_servers_info": "Activa para habilitar",
+    "no_disabled_servers": "No hay servidores deshabilitados"
   },
   "paid_model_chat_warning": {
     "title": "Aviso sobre Modelo de Pago",

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -46,6 +46,7 @@ const ChatPage = () => {
   const [input, setInput] = useState('');
   const [enableMCP, setEnableMCP] = usePreference('enableMCP');
   const [coworkMode, setCoworkMode] = usePreference('coworkMode');
+  const [coworkModeCwd, setCoworkModeCwd] = usePreference('coworkModeCwd');
   const [userName, setUserName] = useState<string>(t('welcome.default_user_name'));
   const [isLoadingMessages, setIsLoadingMessages] = useState(false);
   const [pendingFirstMessage, setPendingFirstMessage] = useState<string | null>(null);
@@ -183,6 +184,7 @@ const ChatPage = () => {
         model: model || 'openai/gpt-4o',
         enableMCP: enableMCP ?? true,
         coworkMode: coworkMode ?? false,
+        coworkModeCwd: coworkModeCwd ?? null,
       }),
     [] // Keep same transport instance
   );
@@ -193,8 +195,9 @@ const ChatPage = () => {
       model: model || 'openai/gpt-4o',
       enableMCP: enableMCP ?? true,
       coworkMode: coworkMode ?? false,
+      coworkModeCwd: coworkModeCwd ?? null,
     });
-  }, [model, enableMCP, coworkMode, transport]);
+  }, [model, enableMCP, coworkMode, coworkModeCwd, transport]);
 
   // Use AI SDK native useChat hook
   const {
@@ -924,6 +927,8 @@ const ChatPage = () => {
                 onMCPChange={setEnableMCP}
                 coworkMode={coworkMode ?? false}
                 onCoworkModeChange={setCoworkMode}
+                coworkModeCwd={coworkModeCwd ?? null}
+                onCoworkModeCwdChange={setCoworkModeCwd}
                 model={model}
                 onModelChange={handleModelChange}
                 availableModels={filteredAvailableModels}
@@ -986,6 +991,8 @@ const ChatPage = () => {
               onMCPChange={setEnableMCP}
               coworkMode={coworkMode ?? false}
               onCoworkModeChange={setCoworkMode}
+              coworkModeCwd={coworkModeCwd ?? null}
+              onCoworkModeCwdChange={setCoworkModeCwd}
               model={model}
               onModelChange={handleModelChange}
               availableModels={filteredAvailableModels}

--- a/src/renderer/transports/ElectronChatTransport.ts
+++ b/src/renderer/transports/ElectronChatTransport.ts
@@ -32,6 +32,7 @@ export class ElectronChatTransport implements ChatTransport<UIMessage> {
       model?: string;
       enableMCP?: boolean;
       coworkMode?: boolean;
+      coworkModeCwd?: string | null;
     } = {}
   ) {}
 
@@ -59,6 +60,8 @@ export class ElectronChatTransport implements ChatTransport<UIMessage> {
       (bodyObj.enableMCP as boolean) ?? this.defaultOptions.enableMCP ?? true;
     const coworkMode =
       (bodyObj.coworkMode as boolean) ?? this.defaultOptions.coworkMode ?? false;
+    const coworkModeCwd =
+      (bodyObj.coworkModeCwd as string | null) ?? this.defaultOptions.coworkModeCwd ?? null;
     const attachments = bodyObj.attachments; // Extract attachments directly from body
 
     logger.aiSdk.debug("Transport body received", {
@@ -108,18 +111,24 @@ export class ElectronChatTransport implements ChatTransport<UIMessage> {
     }
 
     // Create Electron IPC request
+    // Only send codeMode when both coworkMode is enabled AND a valid CWD is selected
     const request: ChatRequest = {
       messages: messagesWithAttachments,
       model,
       enableMCP,
-      // Pass codeMode when coworkMode is enabled
-      ...(coworkMode && {
+      ...(coworkMode && coworkModeCwd && {
         codeMode: {
           enabled: true,
-          // cwd will be set by the main process
+          cwd: coworkModeCwd,
         },
       }),
     };
+
+    logger.aiSdk.debug("Transport request codeMode", {
+      coworkMode,
+      coworkModeCwd,
+      hasCodeMode: !!(coworkMode && coworkModeCwd),
+    });
 
     // Reset text part tracking for new stream
     this.hasStartedTextPart = false;
@@ -401,6 +410,7 @@ export function createElectronChatTransport(options?: {
   model?: string;
   enableMCP?: boolean;
   coworkMode?: boolean;
+  coworkModeCwd?: string | null;
 }): ElectronChatTransport {
   return new ElectronChatTransport(options);
 }

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -91,6 +91,8 @@ export interface UIPreferences {
   enableMCP: boolean;
   /** Enable Cowork mode (coding tools) in chat */
   coworkMode: boolean;
+  /** Working directory for Cowork mode (coding tools) */
+  coworkModeCwd: string | null;
 }
 
 export type PreferenceKey = keyof UIPreferences;
@@ -159,5 +161,6 @@ export const DEFAULT_PREFERENCES: UIPreferences = {
   },
   mcp: DEFAULT_MCP_PREFERENCES,
   enableMCP: true,
-  coworkMode: false
+  coworkMode: false,
+  coworkModeCwd: null
 };


### PR DESCRIPTION
## Summary
- Adds a working directory (CWD) selector for Cowork mode that persists in preferences
- Shows visual feedback: amber indicator when no directory selected, blue when configured
- Enforces security principle: no fallback to `process.cwd()` - user must explicitly select directory
- Coding tools are only enabled when both Cowork mode AND a valid CWD are set

## Changes
### New files
- `src/main/ipc/coworkHandlers.ts` - IPC handler for native directory picker
- `src/preload/api/cowork.ts` - Preload API for cowork functionality

### Modified files
- `src/types/preferences.ts` - Added `coworkModeCwd` preference
- `src/main/services/preferencesService.ts` - Schema for new preference
- `src/main/lifecycle/initialization.ts` - Register cowork handlers
- `src/preload/preload.ts` - Expose cowork API
- `src/renderer/components/chat/ToolsMenu.tsx` - UI with selector, indicator, warning
- `src/renderer/components/chat/ChatPromptInput.tsx` - Props drilling
- `src/renderer/pages/ChatPage.tsx` - State management and transport config
- `src/renderer/transports/ElectronChatTransport.ts` - Conditional codeMode sending
- `src/main/services/aiService.ts` - Backend CWD validation without fallback
- `src/renderer/locales/en/chat.json` - English translations
- `src/renderer/locales/es/chat.json` - Spanish translations

## Test plan
- [ ] Enable Cowork without selecting directory → amber indicator + warning visible
- [ ] Select a directory → warning disappears, blue indicator shows folder name
- [ ] Send message with Cowork ON but no CWD → coding tools NOT available
- [ ] Send message with Cowork ON and valid CWD → coding tools work correctly
- [ ] Restart app → CWD persists in preferences
- [ ] Cancel directory selector → no change to current CWD

🤖 Generated with [Claude Code](https://claude.com/claude-code)