### PR TITLE
fix: corregir detección de skills instaladas tras reinicio

### DIFF
--- a/src/main/services/__tests__/skillsService.test.ts
+++ b/src/main/services/__tests__/skillsService.test.ts
@@ -124,8 +124,8 @@ describe('SkillsService', () => {
       expect(result.projectId).toBeUndefined();
       expect(result.filePath).toContain(mockGlobalSkillsDir);
 
-      // SKILL.md should exist inside skill directory
-      const skillMdPath = path.join(mockGlobalSkillsDir, 'skill-one', 'SKILL.md');
+      // skill.md should exist inside skill directory
+      const skillMdPath = path.join(mockGlobalSkillsDir, 'skill-one', 'skill.md');
       await expect(fs.access(skillMdPath)).resolves.toBeUndefined();
     });
 
@@ -141,8 +141,8 @@ describe('SkillsService', () => {
       expect(result.scopedKey).toBe('project:proj_test_1:test/skill-one');
       expect(result.filePath).toContain(tmpProjectCwd);
 
-      // SKILL.md should exist inside skill directory
-      const skillMdPath = path.join(tmpProjectCwd, '.levante', 'skills', 'skill-one', 'SKILL.md');
+      // skill.md should exist inside skill directory
+      const skillMdPath = path.join(tmpProjectCwd, '.levante', 'skills', 'skill-one', 'skill.md');
       await expect(fs.access(skillMdPath)).resolves.toBeUndefined();
     });
 
@@ -182,11 +182,11 @@ describe('SkillsService', () => {
       await service.uninstallSkill(mockBundle.id, { scope: 'global' });
 
       // Global skill dir should be gone
-      const globalPath = path.join(mockGlobalSkillsDir, 'skill-one', 'SKILL.md');
+      const globalPath = path.join(mockGlobalSkillsDir, 'skill-one', 'skill.md');
       await expect(fs.access(globalPath)).rejects.toThrow();
 
       // Project skill dir should still exist
-      const projectPath = path.join(tmpProjectCwd, '.levante', 'skills', 'skill-one', 'SKILL.md');
+      const projectPath = path.join(tmpProjectCwd, '.levante', 'skills', 'skill-one', 'skill.md');
       await expect(fs.access(projectPath)).resolves.toBeUndefined();
     });
 
@@ -197,11 +197,11 @@ describe('SkillsService', () => {
       await service.uninstallSkill(mockBundle.id, { scope: 'project', projectId: 'proj_test_1' });
 
       // Project skill dir should be gone
-      const projectPath = path.join(tmpProjectCwd, '.levante', 'skills', 'skill-one', 'SKILL.md');
+      const projectPath = path.join(tmpProjectCwd, '.levante', 'skills', 'skill-one', 'skill.md');
       await expect(fs.access(projectPath)).rejects.toThrow();
 
       // Global skill dir should still exist
-      const globalPath = path.join(mockGlobalSkillsDir, 'skill-one', 'SKILL.md');
+      const globalPath = path.join(mockGlobalSkillsDir, 'skill-one', 'skill.md');
       await expect(fs.access(globalPath)).resolves.toBeUndefined();
     });
   });

--- a/src/main/services/skillsService.ts
+++ b/src/main/services/skillsService.ts
@@ -80,9 +80,31 @@ function sanitizePathSegment(value: string): string {
 }
 
 function buildSkillDir(baseDir: string, skillId: string): { name: string; skillDir: string } {
-  const name = sanitizePathSegment(decodeURIComponent(skillId).trim());
+  const decoded = decodeURIComponent(skillId).trim();
+  const parts = decoded.split('/');
+  const leafName = parts[parts.length - 1] || decoded;
+  const name = sanitizePathSegment(leafName);
   if (!name) throw new Error(`Invalid skill id after sanitization: ${skillId}`);
   return { name, skillDir: path.join(baseDir, name) };
+}
+
+function buildSkillFile(bundle: SkillBundleResponse, installedAt: string): string {
+  const lines: string[] = ['---'];
+  lines.push(`id: ${JSON.stringify(bundle.id)}`);
+  lines.push(`name: ${JSON.stringify(bundle.name)}`);
+  lines.push(`description: ${JSON.stringify(bundle.description ?? '')}`);
+  lines.push(`category: ${JSON.stringify(bundle.category ?? '')}`);
+  if (bundle.version)     lines.push(`version: ${JSON.stringify(bundle.version)}`);
+  if (bundle.author)      lines.push(`author: ${JSON.stringify(bundle.author)}`);
+  if (bundle.license)     lines.push(`license: ${JSON.stringify(bundle.license)}`);
+  if (bundle.allowedTools) lines.push(`allowed-tools: ${JSON.stringify(bundle.allowedTools)}`);
+  if (bundle.model)       lines.push(`model: ${JSON.stringify(bundle.model)}`);
+  if (bundle.userInvocable !== undefined) lines.push(`user-invocable: "${bundle.userInvocable}"`);
+  lines.push(`installed-at: ${JSON.stringify(installedAt)}`);
+  lines.push('---');
+  lines.push('');
+  lines.push(bundle.content ?? '');
+  return lines.join('\n');
 }
 
 function parseFrontmatter(raw: string): { meta: Record<string, string>; content: string } {
@@ -302,10 +324,15 @@ export class SkillsService {
       fileKeys.push(relativePath);
     }
 
+    const installedAt = new Date().toISOString();
+
+    // Always write canonical skill.md (overwrites any skill.md that may have come from bundle.files)
+    const skillMdContent = buildSkillFile(bundle, installedAt);
+    await fs.writeFile(path.join(skillDir, 'skill.md'), skillMdContent, 'utf-8');
+
     logger.core.info('Skill installed', { skillId: bundle.id, skillDir, scope, filesCount: fileKeys.length });
 
     const filePath = path.join(skillDir, 'skill.md');
-    const installedAt = new Date().toISOString();
 
     return {
       ...bundle,


### PR DESCRIPTION
## Summary

- **`buildSkillDir`** extrae ahora solo el segmento hoja de IDs con namespace (`test/skill-one` → directorio `skill-one`), alineando install/uninstall/isInstalled con lo que espera el scanner
- **`buildSkillFile`** (nuevo helper) genera un `skill.md` canónico a partir de los metadatos del bundle + `bundle.content`
- **`installSkill`** siempre escribe `skill.md` con `buildSkillFile` después de copiar `bundle.files`, garantizando que el fichero existe en disco y que `scanSkillsDir` lo encuentre tras reiniciar la app
- Tests actualizados: las comprobaciones de `SKILL.md` pasan a `skill.md`

## Root cause

`scanSkillsDir` siempre buscaba `skill.md` (hardcoded), pero `installSkill` solo copiaba los ficheros de `bundle.files` (que pueden llamarse `SKILL.md` u otro nombre). Al reiniciar, el store se vaciaba y la reconstrucción desde disco fallaba silenciosamente → las skills aparecían como no instaladas.

## Test plan

- [x] `pnpm test src/main/services/__tests__/skillsService.test.ts` → 10/10 tests pasan
- [x] `pnpm typecheck` → sin errores de tipos
- [ ] Manual: instalar una skill → cerrar app → reabrir → la skill sigue apareciendo como instalada

🤖 Generated with [Claude Code](https://claude.com/claude-code)