### PR TITLE
feat(approval): restore full tool approval flow with approve/deny UI

### DIFF
--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -84,6 +84,12 @@ export interface ChatStreamChunk {
     status: "success" | "error";
     timestamp: number;
   };
+  toolApproval?: {
+    approvalId: string;
+    toolCallId: string;
+    toolName: string;
+    input: Record<string, any>;
+  };
   generatedAttachment?: {
     type: "image" | "audio" | "video";
     mime: string;
@@ -125,6 +131,21 @@ function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
 
     const sanitizedParts = parts.map((part: any) => {
       if (!part) return part;
+
+      // FIX: Handle denied tool approvals
+      // When a tool is denied by the user, convert it to output-available with a denial message
+      // so that convertToModelMessages generates a proper tool_result.
+      // Without this, Anthropic/OpenRouter returns 500 because tool_use lacks tool_result.
+      if (part.state === 'approval-responded') {
+        const wasDenied = part.approval?.approved === false;
+        if (wasDenied) {
+          part = {
+            ...part,
+            state: 'output-available',
+            output: 'Tool execution was denied by the user.',
+          };
+        }
+      }
 
       // Remove providerExecuted if null (GitHub Issue #8061)
       // Databases like MongoDB convert undefined to null, causing validation errors
@@ -1347,6 +1368,37 @@ export class AIService {
             });
             // Clean up the accumulated text
             reasoningBlocks.delete(endId);
+            break;
+
+          case "tool-approval-request":
+            // Herramienta con needsApproval: true requiere aprobación del usuario
+            const approvalChunk = chunk as {
+              type: string;
+              approvalId: string;
+              toolCall?: {
+                toolCallId: string;
+                toolName: string;
+                input?: Record<string, unknown>;
+              };
+            };
+
+            this.logger.aiSdk.info("Tool approval request received", {
+              approvalId: approvalChunk.approvalId,
+              toolCallId: approvalChunk.toolCall?.toolCallId,
+              toolName: approvalChunk.toolCall?.toolName,
+            });
+
+            // Garantizar que input NUNCA sea undefined
+            const toolInput = approvalChunk.toolCall?.input ?? {};
+
+            yield {
+              toolApproval: {
+                approvalId: approvalChunk.approvalId,
+                toolCallId: approvalChunk.toolCall?.toolCallId ?? '',
+                toolName: approvalChunk.toolCall?.toolName ?? '',
+                input: toolInput,
+              },
+            };
             break;
 
           case "tool-call":

--- a/src/preload/types/index.ts
+++ b/src/preload/types/index.ts
@@ -53,6 +53,12 @@ export interface ChatStreamChunk {
     status: 'success' | 'error';
     timestamp: number;
   };
+  toolApproval?: {
+    approvalId: string;
+    toolCallId: string;
+    toolName: string;
+    input: Record<string, any>;
+  };
   generatedAttachment?: {
     type: 'image' | 'audio' | 'video';
     mime: string;

--- a/src/renderer/components/ai-elements/tool-approval.tsx
+++ b/src/renderer/components/ai-elements/tool-approval.tsx
@@ -1,0 +1,153 @@
+/**
+ * ToolApprovalInline - UI para aprobar/denegar ejecución de herramientas
+ */
+
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '@/lib/utils';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import {
+  Wrench,
+  X,
+  Check,
+  ChevronDown,
+  ChevronUp,
+} from 'lucide-react';
+import { CodeBlock } from './code-block';
+
+// ═══════════════════════════════════════════════════════
+// TYPES
+// ═══════════════════════════════════════════════════════
+
+interface ToolApprovalInlineProps {
+  /** Nombre de la herramienta (formato: serverId_toolName) */
+  toolName: string;
+  /** Argumentos que se van a pasar a la herramienta */
+  input: Record<string, unknown>;
+  /** ID de aprobación del AI SDK */
+  approvalId: string;
+  /** Callback cuando el usuario aprueba */
+  onApprove: () => void;
+  /** Callback cuando el usuario deniega */
+  onDeny: () => void;
+  /** Callback cuando el usuario aprueba para toda la sesión */
+  onApproveForSession?: (serverId: string) => void;
+  /** Clases CSS adicionales */
+  className?: string;
+}
+
+// ═══════════════════════════════════════════════════════
+// COMPONENT
+// ═══════════════════════════════════════════════════════
+
+export function ToolApprovalInline({
+  toolName,
+  input,
+  approvalId,
+  onApprove,
+  onDeny,
+  onApproveForSession,
+  className,
+}: ToolApprovalInlineProps) {
+  const { t } = useTranslation('chat');
+  const [showDetails, setShowDetails] = useState(false);
+
+  // Extraer nombre de herramienta sin prefijo del servidor
+  // Formato: serverId_toolName → toolName
+  const displayToolName = toolName.includes('_')
+    ? toolName.split('_').slice(1).join('_')
+    : toolName;
+
+  // Extraer serverId
+  const serverId = toolName.includes('_')
+    ? toolName.split('_')[0]
+    : 'unknown';
+
+  // Handler para aprobar para toda la sesión
+  const handleApproveForSession = () => {
+    // Primero aprobar esta herramienta
+    onApprove();
+    // Luego registrar el servidor para auto-aprobación
+    onApproveForSession?.(serverId);
+  };
+
+  return (
+    <div
+      className={cn(
+        'space-y-3',
+        className
+      )}
+    >
+      {/* Tool Info */}
+      <div className="flex items-center gap-2 text-sm">
+        <Wrench className="w-4 h-4 text-muted-foreground" />
+        <span className="font-mono font-medium">{displayToolName}</span>
+        <Badge variant="outline" className="text-xs">
+          {serverId}
+        </Badge>
+      </div>
+
+      {/* Toggle Parameters */}
+      <button
+        onClick={() => setShowDetails(!showDetails)}
+        className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+      >
+        {showDetails ? (
+          <>
+            <ChevronUp className="w-3 h-3" />
+            {t('tool_approval.hide_parameters')}
+          </>
+        ) : (
+          <>
+            <ChevronDown className="w-3 h-3" />
+            {t('tool_approval.show_parameters')}
+          </>
+        )}
+      </button>
+
+      {/* Parameters */}
+      {showDetails && (
+        <div className="rounded-md border overflow-hidden">
+          <CodeBlock
+            code={JSON.stringify(input, null, 2)}
+            language="json"
+          />
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-wrap gap-2 pt-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onDeny}
+          className="gap-1"
+        >
+          <X className="w-3 h-3" />
+          {t('tool_approval.deny')}
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={onApprove}
+          className="gap-1"
+        >
+          <Check className="w-3 h-3" />
+          {t('tool_approval.approve')}
+        </Button>
+        {/* Botón para aprobar todas las herramientas del servidor para esta sesión */}
+        {onApproveForSession && (
+          <Button
+            size="sm"
+            onClick={handleApproveForSession}
+            className="gap-1"
+          >
+            <Check className="w-3 h-3" />
+            {t('tool_approval.approve_for_session')}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/renderer/components/chat/ChatMessageItem.tsx
+++ b/src/renderer/components/chat/ChatMessageItem.tsx
@@ -23,6 +23,7 @@ import {
   ReasoningTrigger,
 } from '@/components/ai-elements/reasoning';
 import { ToolCall } from '@/components/ai-elements/tool-call';
+import { ToolApprovalInline } from '@/components/ai-elements/tool-approval';
 import { UIResourceMessage } from '@/components/chat/UIResourceMessage';
 import { MessageAttachments } from '@/components/chat/MessageAttachments';
 import { extractUIResources } from '@/types/ui-resource';
@@ -30,6 +31,8 @@ import { cn } from '@/lib/utils';
 import { getRendererLogger } from '@/services/logger';
 import type { UIMessage } from '@ai-sdk/react';
 import { useState, useMemo } from 'react';
+import { Check } from 'lucide-react';
+import { Badge } from '@/components/ui/badge';
 
 const logger = getRendererLogger();
 
@@ -44,6 +47,9 @@ interface ChatMessageItemProps {
   onSendMessage?: (text: string) => void;
   chatMessages?: UIMessage[];
   onEditMessage?: (messageId: string, newContent: string) => Promise<void>;
+  addToolApprovalResponse?: (response: { id: string; approved: boolean }) => void;
+  onApproveServerForSession?: (serverId: string) => void;
+  isServerAutoApproved?: (serverId: string) => boolean;
 }
 
 // ============================================================================
@@ -56,7 +62,10 @@ export function ChatMessageItem({
   onPrompt,
   onSendMessage,
   chatMessages,
-  onEditMessage
+  onEditMessage,
+  addToolApprovalResponse,
+  onApproveServerForSession,
+  isServerAutoApproved,
 }: ChatMessageItemProps) {
   const isAssistant = message.role === 'assistant';
   const isUser = message.role === 'user';
@@ -276,6 +285,52 @@ export function ChatMessageItem({
 
                   // Tool calls (MCP)
                   if (part?.type?.startsWith('tool-')) {
+                    // Si está esperando aprobación, mostrar UI de aprobación
+                    if (part.state === 'approval-requested' && addToolApprovalResponse) {
+                      const toolName = part.toolName || part.type.replace(/^tool-/, '');
+                      const serverId = toolName.includes('_') ? toolName.split('_')[0] : 'unknown';
+
+                      // Si el servidor está auto-aprobado, aprobar automáticamente
+                      if (isServerAutoApproved?.(serverId)) {
+                        queueMicrotask(() => {
+                          addToolApprovalResponse({
+                            id: part.approval?.id || part.toolCallId,
+                            approved: true,
+                          });
+                        });
+
+                        return (
+                          <div key={`${message.id}-${i}`} className="flex items-center gap-2 text-sm text-muted-foreground">
+                            <Check className="w-4 h-4 text-green-500" />
+                            <span>Auto-approved: {toolName.split('_').slice(1).join('_')}</span>
+                            <Badge variant="outline" className="text-xs">{serverId}</Badge>
+                          </div>
+                        );
+                      }
+
+                      return (
+                        <ToolApprovalInline
+                          key={`${message.id}-${i}`}
+                          toolName={toolName}
+                          input={part.input || {}}
+                          approvalId={part.approval?.id || part.toolCallId}
+                          onApprove={() => {
+                            addToolApprovalResponse({
+                              id: part.approval?.id || part.toolCallId,
+                              approved: true,
+                            });
+                          }}
+                          onDeny={() => {
+                            addToolApprovalResponse({
+                              id: part.approval?.id || part.toolCallId,
+                              approved: false,
+                            });
+                          }}
+                          onApproveForSession={onApproveServerForSession}
+                        />
+                      );
+                    }
+
                     return (
                       <ToolCallPart
                         key={`${message.id}-${i}`}

--- a/src/renderer/hooks/useToolAutoApproval.ts
+++ b/src/renderer/hooks/useToolAutoApproval.ts
@@ -1,0 +1,57 @@
+/**
+ * useToolAutoApproval - Hook para manejar auto-aprobación de herramientas por sesión
+ *
+ * Este hook mantiene un estado en memoria de los servidores MCP cuyas herramientas
+ * se deben auto-aprobar durante la sesión actual.
+ */
+
+import { useState, useCallback } from 'react';
+
+interface UseToolAutoApprovalReturn {
+  /** Set de IDs de servidores MCP auto-aprobados para esta sesión */
+  autoApprovedServers: Set<string>;
+
+  /** Añade un servidor a la lista de auto-aprobados */
+  approveServerForSession: (serverId: string) => void;
+
+  /** Verifica si un servidor está auto-aprobado */
+  isServerAutoApproved: (serverId: string) => boolean;
+
+  /** Limpia todos los auto-approvals (llamar al cambiar de sesión) */
+  clearAutoApprovals: () => void;
+}
+
+export function useToolAutoApproval(): UseToolAutoApprovalReturn {
+  const [autoApprovedServers, setAutoApprovedServers] = useState<Set<string>>(new Set());
+
+  const approveServerForSession = useCallback((serverId: string) => {
+    setAutoApprovedServers(prev => {
+      const newSet = new Set(prev);
+      newSet.add(serverId);
+      return newSet;
+    });
+  }, []);
+
+  const isServerAutoApproved = useCallback((serverId: string) => {
+    return autoApprovedServers.has(serverId);
+  }, [autoApprovedServers]);
+
+  const clearAutoApprovals = useCallback(() => {
+    setAutoApprovedServers(new Set());
+  }, []);
+
+  return {
+    autoApprovedServers,
+    approveServerForSession,
+    isServerAutoApproved,
+    clearAutoApprovals,
+  };
+}
+
+/**
+ * Extrae el serverId del nombre de la herramienta
+ * Formato esperado: serverId_toolName → serverId
+ */
+export function extractServerIdFromToolName(toolName: string): string {
+  return toolName.includes('_') ? toolName.split('_')[0] : 'unknown';
+}

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -35,6 +35,7 @@ import { useMCPResources } from '@/hooks/useMCPResources';
 import { useFileAttachments } from '@/hooks/useFileAttachments';
 import { useModelSelection, isInferenceModel } from '@/hooks/useModelSelection';
 import { usePreference } from '@/hooks/usePreferences';
+import { useToolAutoApproval } from '@/hooks/useToolAutoApproval';
 import { WebPreviewPanel } from '@/components/chat/WebPreviewPanel';
 import { WebPreviewToast } from '@/components/chat/WebPreviewToast';
 import { useWebPreview } from '@/hooks/useWebPreview';
@@ -73,6 +74,13 @@ const ChatPage = () => {
     clearResources,
     getContextString,
   } = useMCPResources();
+
+  // Tool auto-approval hook
+  const {
+    approveServerForSession,
+    isServerAutoApproved,
+    clearAutoApprovals,
+  } = useToolAutoApproval();
 
   // Chat store
   const currentSession = useChatStore((state) => state.currentSession);
@@ -288,9 +296,39 @@ const ChatPage = () => {
     status,
     stop,
     error: chatError,
+    addToolApprovalResponse,
   } = useChat({
     id: currentSession?.id || 'new-chat',
     transport,
+
+    // ═══════════════════════════════════════════════════════
+    // Solo continuar automáticamente si hay APROBACIONES (approved: true)
+    // NO continuar si hay DENEGACIONES - respetar la decisión del usuario
+    // ═══════════════════════════════════════════════════════
+    sendAutomaticallyWhen: ({ messages }) => {
+      const lastAssistantMessage = messages
+        .slice()
+        .reverse()
+        .find((m) => m.role === 'assistant');
+
+      if (!lastAssistantMessage) return false;
+
+      const toolParts =
+        lastAssistantMessage.parts?.filter((p: any) =>
+          p.type?.startsWith('tool-')
+        ) || [];
+
+      const partsWithApprovalResponse = toolParts.filter(
+        (p: any) => p.state === 'approval-responded' && p.approval
+      );
+
+      if (partsWithApprovalResponse.length === 0) return false;
+
+      // Solo continuar si TODAS las respuestas son aprobaciones
+      return partsWithApprovalResponse.every(
+        (p: any) => p.approval.approved === true
+      );
+    },
 
     // Persist messages after AI finishes
     onFinish: async ({ message }) => {
@@ -570,9 +608,10 @@ const ChatPage = () => {
     // Update ref
     previousSessionIdRef.current = currentSessionId;
 
-    // Clear attachments and MCP resources when changing sessions
+    // Clear attachments, MCP resources, and auto-approvals when changing sessions
     clearAttachments();
     clearResources();
+    clearAutoApprovals();
 
     // If we just created this session, skip loading historical messages
     // (the messages are already in useChat state from sendMessageAI)
@@ -605,7 +644,7 @@ const ChatPage = () => {
       setMessages([]);
       focusPromptInput();
     }
-  }, [currentSession?.id, loadHistoricalMessages, setMessages, clearAttachments, clearResources, focusPromptInput]);
+  }, [currentSession?.id, loadHistoricalMessages, setMessages, clearAttachments, clearResources, clearAutoApprovals, focusPromptInput]);
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
@@ -1061,6 +1100,9 @@ const ChatPage = () => {
                       onSendMessage={handleSendMessage}
                       chatMessages={messages}
                       onEditMessage={handleEditMessage}
+                      addToolApprovalResponse={addToolApprovalResponse}
+                      onApproveServerForSession={approveServerForSession}
+                      isServerAutoApproved={isServerAutoApproved}
                     />
                   ))}
 

--- a/src/renderer/transports/ElectronChatTransport.ts
+++ b/src/renderer/transports/ElectronChatTransport.ts
@@ -310,6 +310,29 @@ export class ElectronChatTransport implements ChatTransport<UIMessage> {
       }
     }
 
+    // Handle tool approval requests (for needsApproval: true tools)
+    if (chunk.toolApproval) {
+      // Garantizar que input sea siempre un objeto
+      const safeInput = chunk.toolApproval.input ?? {};
+
+      // NO emitir tool-input-start aquí - si lo emitimos, resetea el part a 'input-streaming'
+      // y tool-approval-request nunca puede transicionar a 'approval-requested'
+
+      // Emit tool-approval-request chunk for AI SDK to set state to 'approval-requested'
+      yield {
+        type: "tool-approval-request",
+        toolCallId: chunk.toolApproval.toolCallId,
+        toolName: chunk.toolApproval.toolName,
+        approvalId: chunk.toolApproval.approvalId,
+        input: safeInput,
+        toolCall: {
+          toolCallId: chunk.toolApproval.toolCallId,
+          toolName: chunk.toolApproval.toolName,
+          input: safeInput,
+        },
+      } as any;
+    }
+
     // Handle tool calls (MCP integration)
     if (chunk.toolCall) {
       // Start of tool input


### PR DESCRIPTION
## Summary

- Restaura el sistema completo de aprobación de herramientas (tool approval) eliminado accidentalmente al hacer merge de develop en la rama anterior
- Añade UI inline de Approve / Deny / Approve for session en el chat
- Añade hook `useToolAutoApproval` para auto-aprobación por servidor a nivel de sesión
- Maneja correctamente el chunk `tool-approval-request` del AI SDK v5 en el transport y en el main process

## Contexto

El flujo completo de aprobación existió en PR #173 (enero) pero fue revertido. La rama `feat/approval-tool-execution2` todavía tenía el código, pero el commit `fa0fc9e` (merge de develop) lo eliminó al incorporar el revert. Esta PR restaura el flujo desde ese punto.

## Archivos modificados

- **`src/renderer/components/ai-elements/tool-approval.tsx`** (nuevo) — Componente `ToolApprovalInline` con botones Aprobar / Denegar / Aprobar para esta sesión
- **`src/renderer/hooks/useToolAutoApproval.ts`** (nuevo) — Hook para gestión de auto-aprobación por servidor durante la sesión
- **`src/preload/types/index.ts`** — Campo `toolApproval` añadido a `ChatStreamChunk`
- **`src/main/services/aiService.ts`** — Handler `tool-approval-request` en el stream + sanitización de denegaciones en `sanitizeMessagesForModel`
- **`src/renderer/transports/ElectronChatTransport.ts`** — Conversión del chunk `toolApproval` al formato AI SDK
- **`src/renderer/components/chat/ChatMessageItem.tsx`** — Renderizado de la UI de aprobación cuando `part.state === 'approval-requested'`
- **`src/renderer/pages/ChatPage.tsx`** — Integración de `useToolAutoApproval`, `addToolApprovalResponse` y `sendAutomaticallyWhen`

## Test plan

- [ ] Usar un proveedor OpenRouter/OpenAI con herramientas MCP habilitadas
- [ ] Verificar que aparece la UI de aprobación cuando el modelo solicita ejecutar una herramienta
- [ ] Aprobar → herramienta se ejecuta y el modelo continúa
- [ ] Denegar → herramienta devuelve mensaje de denegación al modelo
- [ ] "Aprobar para esta sesión" → el servidor se auto-aprueba en las siguientes llamadas de la misma sesión
- [ ] Cambiar de sesión → auto-aprobaciones se limpian

🤖 Generated with [Claude Code](https://claude.com/claude-code)