### PR TITLE
fix(approval): add needsApproval to bash/write/edit tools and fix tool parameters

### DIFF
--- a/src/main/services/ai/codingTools/tools/bash.ts
+++ b/src/main/services/ai/codingTools/tools/bash.ts
@@ -25,6 +25,7 @@ export function createBashTool(config: BashToolConfig) {
   const maxBytes = config.maxOutputBytes ?? 50 * 1024;
 
   return tool({
+    needsApproval: true,
     description: `Execute a bash command in the shell.
 Foreground commands run in a bash shell with a ${Math.round(timeout / 1000)}s timeout.
 IMPORTANT:

--- a/src/main/services/ai/codingTools/tools/edit.ts
+++ b/src/main/services/ai/codingTools/tools/edit.ts
@@ -15,6 +15,7 @@ export interface EditToolConfig {
 
 export function createEditTool(config: EditToolConfig) {
   return tool({
+    needsApproval: true,
     description: `Edit a file by replacing exact string matches.
 The old_string must be unique in the file, or the edit will fail.
 Use replace_all: true to replace all occurrences.

--- a/src/main/services/ai/codingTools/tools/write.ts
+++ b/src/main/services/ai/codingTools/tools/write.ts
@@ -16,6 +16,7 @@ export interface WriteToolConfig {
 
 export function createWriteTool(config: WriteToolConfig) {
   return tool({
+    needsApproval: true,
     description: `Write content to a file. Creates parent directories if needed.
 The file_path must be an absolute path or relative to the current directory.
 IMPORTANT: This will overwrite existing files. Always read a file first before writing if it exists.`,

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -1433,7 +1433,7 @@ export class AIService {
               toolCall: {
                 id: chunk.toolCallId,
                 name: chunk.toolName,
-                arguments: (chunk as any).arguments || {},
+                arguments: (chunk as any).input || (chunk as any).arguments || {},
                 status: "running" as const,
                 timestamp: Date.now(),
               },


### PR DESCRIPTION
## Summary

- Añade `needsApproval: true` a las herramientas `bash`, `write` y `edit` del cowork mode para que requieran aprobación del usuario antes de ejecutarse
- Fix crítico: los parámetros de la tool no llegaban tras la aprobación porque AI SDK v5 usa `chunk.input` en vez de `chunk.arguments`. Restaurado el fallback dual: `chunk.input || chunk.arguments || {}`

## Archivos modificados

- **`src/main/services/ai/codingTools/tools/bash.ts`** — `needsApproval: true`
- **`src/main/services/ai/codingTools/tools/write.ts`** — `needsApproval: true`
- **`src/main/services/ai/codingTools/tools/edit.ts`** — `needsApproval: true`
- **`src/main/services/aiService.ts`** — Fix `chunk.input || chunk.arguments || {}` en `case "tool-call"`

## Test plan

- [ ] Activar cowork mode con un directorio seleccionado
- [ ] Pedir al modelo que ejecute un comando bash → aparece UI de aprobación con los parámetros correctos
- [ ] Aprobar → comando se ejecuta correctamente
- [ ] Pedir al modelo que escriba o edite un archivo → aparece UI de aprobación
- [ ] Verificar que los parámetros (ruta, contenido) se muestran y se pasan correctamente a la tool tras aprobar

🤖 Generated with [Claude Code](https://claude.com/claude-code)