### PR TITLE
feat(skills): add Skills panel to chat UI with per-skill toggle

### DIFF
--- a/src/main/ipc/skillsHandlers.ts
+++ b/src/main/ipc/skillsHandlers.ts
@@ -6,6 +6,7 @@ import type {
   InstallSkillOptions,
   UninstallSkillOptions,
   ListInstalledSkillsOptions,
+  SetUserInvocableOptions,
 } from '../../types/skills';
 
 const logger = getLogger();
@@ -101,6 +102,43 @@ export function setupSkillsHandlers(): void {
       logger.ipc.error('Failed to uninstall skill', {
         skillId: payload?.skillId,
         scope: payload?.options?.scope,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return fail(error);
+    }
+  });
+
+  ipcMain.removeHandler('levante/skills:setUserInvocable');
+  ipcMain.handle('levante/skills:setUserInvocable', async (_, payload: {
+    skillId: string;
+    userInvocable: boolean;
+    options: SetUserInvocableOptions;
+  }) => {
+    if (!payload?.skillId) {
+      return fail(new Error('Invalid setUserInvocable payload: skillId is required'));
+    }
+    if (typeof payload?.userInvocable !== 'boolean') {
+      return fail(new Error('Invalid setUserInvocable payload: userInvocable must be boolean'));
+    }
+    if (!payload?.options?.scope) {
+      return fail(new Error('Invalid setUserInvocable payload: options.scope is required'));
+    }
+    if (payload.options.scope === 'project' && !payload.options.projectId) {
+      return fail(new Error('projectId is required when scope is "project"'));
+    }
+
+    try {
+      const data = await skillsService.setUserInvocable(
+        payload.skillId,
+        payload.userInvocable,
+        payload.options
+      );
+      return ok(data);
+    } catch (error) {
+      logger.ipc.error('Failed to set skill user-invocable', {
+        skillId: payload?.skillId,
+        scope: payload?.options?.scope,
+        projectId: payload?.options?.projectId,
         error: error instanceof Error ? error.message : String(error),
       });
       return fail(error);

--- a/src/main/services/__tests__/skillsService.test.ts
+++ b/src/main/services/__tests__/skillsService.test.ts
@@ -259,4 +259,43 @@ describe('SkillsService', () => {
       ).rejects.toThrow('projectId is required');
     });
   });
+
+  describe('setUserInvocable', () => {
+    it('updates user-invocable for global skill', async () => {
+      await service.installSkill(mockBundle, { scope: 'global' });
+
+      const updated = await service.setUserInvocable(mockBundle.id, false, { scope: 'global' });
+      expect(updated.userInvocable).toBe(false);
+
+      const listed = await service.listInstalledSkills({ mode: 'global' });
+      expect(listed[0].userInvocable).toBe(false);
+    });
+
+    it('updates user-invocable for project skill', async () => {
+      await service.installSkill(mockBundle, { scope: 'project', projectId: 'proj_test_1' });
+
+      const updated = await service.setUserInvocable(mockBundle.id, true, {
+        scope: 'project',
+        projectId: 'proj_test_1',
+      });
+      expect(updated.userInvocable).toBe(true);
+      expect(updated.scope).toBe('project');
+    });
+  });
+
+  describe('listInstalledSkills (project-and-global)', () => {
+    it('returns project + global instances without merge', async () => {
+      await service.installSkill(mockBundle, { scope: 'global' });
+      await service.installSkill(mockBundle, { scope: 'project', projectId: 'proj_test_1' });
+
+      const result = await service.listInstalledSkills({
+        mode: 'project-and-global',
+        projectId: 'proj_test_1',
+      });
+
+      expect(result).toHaveLength(2);
+      expect(result.some((s) => s.scope === 'project')).toBe(true);
+      expect(result.some((s) => s.scope === 'global')).toBe(true);
+    });
+  });
 });

--- a/src/main/services/preferencesService.ts
+++ b/src/main/services/preferencesService.ts
@@ -215,6 +215,10 @@ export class PreferencesService {
             type: 'boolean',
             default: true
           },
+          enableSkills: {
+            type: 'boolean',
+            default: true
+          },
           coworkMode: {
             type: 'boolean',
             default: false

--- a/src/main/services/skillsService.ts
+++ b/src/main/services/skillsService.ts
@@ -13,6 +13,7 @@ import type {
   InstallSkillOptions,
   UninstallSkillOptions,
   ListInstalledSkillsOptions,
+  SetUserInvocableOptions,
 } from '../../types/skills';
 
 const logger = getLogger();
@@ -128,6 +129,77 @@ function parseFrontmatter(raw: string): { meta: Record<string, string>; content:
   }
 
   return { meta, content: content.trim() };
+}
+
+function updateFrontmatterBoolean(raw: string, key: string, value: boolean): string {
+  const match = raw.match(/^---\n([\s\S]*?)\n---\n?([\s\S]*)$/);
+  if (!match) {
+    throw new Error('Invalid skill file: missing YAML frontmatter');
+  }
+
+  const [, frontmatter, content] = match;
+  const lines = frontmatter.split('\n');
+  const newLine = `${key}: "${value}"`;
+
+  let replaced = false;
+  const updatedLines = lines.map((line) => {
+    const trimmed = line.trimStart();
+    if (trimmed.startsWith(`${key}:`)) {
+      replaced = true;
+      const indent = line.slice(0, line.length - trimmed.length);
+      return `${indent}${newLine}`;
+    }
+    return line;
+  });
+
+  if (!replaced) {
+    const installedAtIndex = updatedLines.findIndex((line) => line.trimStart().startsWith('installed-at:'));
+    if (installedAtIndex >= 0) {
+      updatedLines.splice(installedAtIndex, 0, newLine);
+    } else {
+      updatedLines.push(newLine);
+    }
+  }
+
+  return `---\n${updatedLines.join('\n')}\n---\n${content}`;
+}
+
+async function readInstalledSkillFromFile(input: {
+  filePath: string;
+  fallbackSkillId: string;
+  scope: SkillScope;
+  project?: { id: string; name: string; cwd: string };
+}): Promise<InstalledSkill> {
+  const { filePath, fallbackSkillId, scope, project } = input;
+  const raw = await fs.readFile(filePath, 'utf-8');
+  const { meta, content } = parseFrontmatter(raw);
+
+  const skillId = meta['id']?.trim() || fallbackSkillId;
+
+  return {
+    id: skillId,
+    name: meta['name'] ?? skillId,
+    description: meta['description'] ?? '',
+    category: meta['category'] ?? '',
+    author: meta['author'],
+    version: meta['version'],
+    license: meta['license'],
+    allowedTools: meta['allowed-tools'],
+    model: meta['model'],
+    userInvocable: meta['user-invocable'] === undefined ? undefined : meta['user-invocable'] === 'true',
+    content,
+    installedAt: meta['installed-at'] ?? new Date().toISOString(),
+    filePath,
+    scope,
+    ...(project
+      ? {
+          projectId: project.id,
+          projectName: project.name,
+          projectCwd: project.cwd,
+        }
+      : {}),
+    scopedKey: buildScopedKey(scope, skillId, project?.id),
+  };
 }
 
 async function apiFetch<T>(endpoint: string): Promise<T> {
@@ -374,6 +446,48 @@ export class SkillsService {
     }
   }
 
+  async setUserInvocable(
+    skillId: string,
+    userInvocable: boolean,
+    options: SetUserInvocableOptions
+  ): Promise<InstalledSkill> {
+    const scope = options.scope;
+    let baseDir: string;
+    let project: { id: string; name: string; cwd: string } | undefined;
+
+    if (scope === 'project') {
+      if (!options.projectId) {
+        throw new Error('projectId is required when scope is "project"');
+      }
+      project = await resolveProjectForScope(options.projectId);
+      baseDir = getProjectSkillsDir(project.cwd);
+    } else {
+      baseDir = getGlobalSkillsDir();
+    }
+
+    const { skillDir } = buildSkillDir(baseDir, skillId);
+    const filePath = path.join(skillDir, 'skill.md');
+
+    const raw = await fs.readFile(filePath, 'utf-8');
+    const updatedRaw = updateFrontmatterBoolean(raw, 'user-invocable', userInvocable);
+    await fs.writeFile(filePath, updatedRaw, 'utf-8');
+
+    logger.core.info('Skill user-invocable updated', {
+      skillId,
+      scope,
+      projectId: project?.id,
+      userInvocable,
+      filePath,
+    });
+
+    return await readInstalledSkillFromFile({
+      filePath,
+      fallbackSkillId: skillId,
+      scope,
+      project,
+    });
+  }
+
   async isInstalled(skillId: string): Promise<boolean> {
     const { skillDir } = buildSkillDir(getGlobalSkillsDir(), skillId);
     try {
@@ -419,6 +533,28 @@ export class SkillsService {
 
       const result = [...merged.values()];
       result.sort((a, b) => a.id.localeCompare(b.id));
+      return result;
+    }
+
+    if (mode === 'project-and-global') {
+      if (!options.projectId) {
+        throw new Error('projectId is required for mode "project-and-global"');
+      }
+
+      const project = await resolveProjectForScope(options.projectId);
+      const globalDir = getGlobalSkillsDir();
+      const projectDir = getProjectSkillsDir(project.cwd);
+
+      const [globalSkills, projectSkills] = await Promise.all([
+        scanSkillsDir({ dir: globalDir, scope: 'global' }),
+        scanSkillsDir({ dir: projectDir, scope: 'project', project }),
+      ]);
+
+      const result = [...projectSkills, ...globalSkills];
+      result.sort((a, b) => {
+        if (a.scope !== b.scope) return a.scope === 'project' ? -1 : 1;
+        return a.id.localeCompare(b.id);
+      });
       return result;
     }
 

--- a/src/preload/api/skills.ts
+++ b/src/preload/api/skills.ts
@@ -8,6 +8,7 @@ import type {
   InstallSkillOptions,
   UninstallSkillOptions,
   ListInstalledSkillsOptions,
+  SetUserInvocableOptions,
 } from '../../types/skills';
 
 export const skillsApi = {
@@ -31,4 +32,11 @@ export const skillsApi = {
 
   isInstalled: (skillId: string): Promise<IPCResult<boolean>> =>
     ipcRenderer.invoke('levante/skills:isInstalled', skillId),
+
+  setUserInvocable: (
+    skillId: string,
+    userInvocable: boolean,
+    options: SetUserInvocableOptions
+  ): Promise<IPCResult<InstalledSkill>> =>
+    ipcRenderer.invoke('levante/skills:setUserInvocable', { skillId, userInvocable, options }),
 };

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -882,6 +882,11 @@ export interface LevanteAPI {
     uninstall: (skillId: string, options: import('../types/skills').UninstallSkillOptions) => Promise<import('../types/skills').IPCResult<boolean>>;
     listInstalled: (options?: import('../types/skills').ListInstalledSkillsOptions) => Promise<import('../types/skills').IPCResult<import('../types/skills').InstalledSkill[]>>;
     isInstalled: (skillId: string) => Promise<import('../types/skills').IPCResult<boolean>>;
+    setUserInvocable: (
+      skillId: string,
+      userInvocable: boolean,
+      options: import('../types/skills').SetUserInvocableOptions
+    ) => Promise<import('../types/skills').IPCResult<import('../types/skills').InstalledSkill>>;
   };
 }
 

--- a/src/renderer/components/chat/ChatPromptInput.tsx
+++ b/src/renderer/components/chat/ChatPromptInput.tsx
@@ -63,6 +63,9 @@ interface ChatPromptInputProps {
   onCoworkModeCwdChange: (cwd: string | null) => void | Promise<void>;
   coworkModeCwdSource?: 'none' | 'global' | 'project' | 'session';
   onResetCoworkModeCwdOverride?: () => void | Promise<void>;
+  enableSkills: boolean;
+  onSkillsChange: (enabled: boolean) => void;
+  projectId?: string | null;
   model: string;
   onModelChange: (modelId: string) => void;
   availableModels: Model[];
@@ -100,6 +103,9 @@ export function ChatPromptInput({
   onCoworkModeCwdChange,
   coworkModeCwdSource = 'none',
   onResetCoworkModeCwdOverride,
+  enableSkills,
+  onSkillsChange,
+  projectId,
   model,
   onModelChange,
   availableModels,
@@ -246,6 +252,9 @@ export function ChatPromptInput({
             onCoworkModeCwdChange={onCoworkModeCwdChange}
             coworkModeCwdSource={coworkModeCwdSource}
             onResetCoworkModeCwdOverride={onResetCoworkModeCwdOverride}
+            enableSkills={enableSkills}
+            onSkillsChange={onSkillsChange}
+            projectId={projectId}
           />
           {/* Add Context Menu (MCP resources + prompts + file upload) */}
           {onFilesSelected && (

--- a/src/renderer/components/chat/SkillsPanel.tsx
+++ b/src/renderer/components/chat/SkillsPanel.tsx
@@ -1,0 +1,151 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
+import { Switch } from '@/components/ui/switch';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { Loader2 } from 'lucide-react';
+import { useSkillsStore } from '@/stores/skillsStore';
+import type { InstalledSkill } from '../../../types/skills';
+
+interface SkillsPanelProps {
+  projectId?: string | null;
+}
+
+type SkillsTab = 'enabled' | 'disabled';
+
+export function SkillsPanel({ projectId }: SkillsPanelProps) {
+  const { t } = useTranslation('chat');
+  const {
+    installedSkills,
+    isLoadingInstalled,
+    error,
+    clearError,
+    loadInstalledForChat,
+    toggleUserInvocable,
+  } = useSkillsStore();
+
+  const [tab, setTab] = useState<SkillsTab>('enabled');
+  const [pendingKeys, setPendingKeys] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    clearError();
+    loadInstalledForChat(projectId);
+  }, [clearError, loadInstalledForChat, projectId]);
+
+  const sorted = useMemo(() => {
+    return [...installedSkills].sort((a, b) => {
+      if (a.scope !== b.scope) return a.scope === 'project' ? -1 : 1;
+      return a.name.localeCompare(b.name);
+    });
+  }, [installedSkills]);
+
+  const enabledSkills = useMemo(
+    () => sorted.filter((s) => s.userInvocable !== false),
+    [sorted]
+  );
+  const disabledSkills = useMemo(
+    () => sorted.filter((s) => s.userInvocable === false),
+    [sorted]
+  );
+
+  const toggle = async (skill: InstalledSkill, enabled: boolean) => {
+    setPendingKeys((prev) => new Set(prev).add(skill.scopedKey));
+    try {
+      await toggleUserInvocable(skill, enabled);
+    } finally {
+      setPendingKeys((prev) => {
+        const next = new Set(prev);
+        next.delete(skill.scopedKey);
+        return next;
+      });
+    }
+  };
+
+  const renderList = (skills: InstalledSkill[], emptyText: string) => {
+    if (skills.length === 0) {
+      return <div className="p-3 text-xs text-muted-foreground">{emptyText}</div>;
+    }
+
+    return (
+      <div className="max-h-[300px] overflow-y-auto">
+        {skills.map((skill) => {
+          const checked = skill.userInvocable !== false;
+          const isPending = pendingKeys.has(skill.scopedKey);
+
+          return (
+            <div
+              key={skill.scopedKey}
+              className="flex items-start justify-between gap-3 px-3 py-2 border-b last:border-b-0"
+            >
+              <div className="min-w-0">
+                <div className="text-sm font-medium truncate">{skill.name}</div>
+                <div className="text-xs text-muted-foreground truncate">{skill.id}</div>
+                {skill.description && (
+                  <div className="text-xs text-muted-foreground mt-1 line-clamp-2">
+                    {skill.description}
+                  </div>
+                )}
+                <div className="mt-1">
+                  <Badge variant="secondary" className="text-[10px]">
+                    {skill.scope === 'project'
+                      ? t('tools_menu.skills.scope_project', 'project')
+                      : t('tools_menu.skills.scope_global', 'global')}
+                  </Badge>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2">
+                {isPending && <Loader2 className="h-3 w-3 animate-spin text-muted-foreground" />}
+                <Switch
+                  checked={checked}
+                  disabled={isPending}
+                  onCheckedChange={(v) => toggle(skill, v === true)}
+                />
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    );
+  };
+
+  return (
+    <div className="w-96">
+      <div className="px-3 py-2 border-b">
+        <div className="text-sm font-medium">
+          {t('tools_menu.skills.panel_title', 'Skills')}
+        </div>
+      </div>
+
+      {error && (
+        <div className="px-3 py-2 text-xs text-red-600 border-b">
+          {error}
+        </div>
+      )}
+
+      {isLoadingInstalled ? (
+        <div className="p-3 text-xs text-muted-foreground">
+          {t('tools_menu.loading_tools', 'Loading tools...')}
+        </div>
+      ) : (
+        <Tabs value={tab} onValueChange={(v) => setTab(v as SkillsTab)} className="w-full">
+          <TabsList className="mx-3 mt-2 grid w-auto grid-cols-2">
+            <TabsTrigger value="enabled" className="text-xs">
+              {t('tools_menu.skills.enabled', 'Enabled')} ({enabledSkills.length})
+            </TabsTrigger>
+            <TabsTrigger value="disabled" className="text-xs">
+              {t('tools_menu.skills.disabled', 'Disabled')} ({disabledSkills.length})
+            </TabsTrigger>
+          </TabsList>
+
+          <TabsContent value="enabled" className="mt-2">
+            {renderList(enabledSkills, t('tools_menu.skills.empty_enabled', 'No enabled skills'))}
+          </TabsContent>
+          <TabsContent value="disabled" className="mt-2">
+            {renderList(disabledSkills, t('tools_menu.skills.empty_disabled', 'No disabled skills'))}
+          </TabsContent>
+        </Tabs>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/components/chat/ToolsMenu.tsx
+++ b/src/renderer/components/chat/ToolsMenu.tsx
@@ -6,7 +6,7 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Switch } from '@/components/ui/switch';
-import { Wrench, Settings, ChevronDown, ChevronRight, RefreshCw, Code2, FolderOpen, AlertTriangle } from 'lucide-react';
+import { Wrench, Settings, ChevronDown, ChevronRight, RefreshCw, Code2, FolderOpen, AlertTriangle, BookOpen } from 'lucide-react';
 import { BackgroundTasksDropdown } from '@/components/chat/BackgroundTasksDropdown';
 import { WebPreviewButton } from '@/components/chat/WebPreviewButton';
 import { cn } from '@/lib/utils';
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/collapsible';
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { ToolsWarning } from '@/components/settings/ToolsWarning';
+import { SkillsPanel } from '@/components/chat/SkillsPanel';
 import type { Tool } from '@/types/mcp';
 
 interface ToolsMenuProps {
@@ -32,6 +33,9 @@ interface ToolsMenuProps {
   onCoworkModeCwdChange: (cwd: string | null) => void | Promise<void>;
   coworkModeCwdSource?: 'none' | 'global' | 'project' | 'session';
   onResetCoworkModeCwdOverride?: () => void | Promise<void>;
+  enableSkills: boolean;
+  onSkillsChange: (enabled: boolean) => void;
+  projectId?: string | null;
   className?: string;
 }
 
@@ -44,10 +48,14 @@ export function ToolsMenu({
   onCoworkModeCwdChange,
   coworkModeCwdSource = 'none',
   onResetCoworkModeCwdOverride,
+  enableSkills,
+  onSkillsChange,
+  projectId,
   className
 }: ToolsMenuProps) {
   const { t } = useTranslation('chat');
   const [open, setOpen] = useState(false);
+  const [skillsOpen, setSkillsOpen] = useState(false);
   const [expandedServers, setExpandedServers] = useState<Record<string, boolean>>({});
   const [activeTab, setActiveTab] = useState<'enabled' | 'disabled'>('enabled');
 
@@ -215,6 +223,21 @@ export function ToolsMenu({
               )}
             </div>
           )}
+          {/* Skills Toggle */}
+          <div
+            className="flex items-center justify-between rounded-sm px-3 py-2 hover:bg-accent cursor-pointer"
+            onClick={() => onSkillsChange(!enableSkills)}
+          >
+            <div className="flex items-center gap-2">
+              <BookOpen size={16} className="text-muted-foreground" />
+              <span className="text-sm">{t('tools_menu.skills.show_in_chat', 'Show skills in chat')}</span>
+            </div>
+            <Switch
+              checked={enableSkills}
+              onCheckedChange={onSkillsChange}
+              onClick={(e) => e.stopPropagation()}
+            />
+          </div>
           {/* MCP Tools Toggle */}
           <div
             className="flex items-center justify-between rounded-sm px-3 py-2 hover:bg-accent cursor-pointer"
@@ -259,9 +282,6 @@ export function ToolsMenu({
               <span className="text-xs text-blue-600 max-w-20 truncate">
                 {getShortFolderName(coworkModeCwd)}
               </span>
-              <span className="text-[10px] uppercase tracking-wide text-blue-600/80">
-                {getCwdSourceLabel(coworkModeCwdSource)}
-              </span>
             </>
           ) : (
             <>
@@ -279,6 +299,20 @@ export function ToolsMenu({
 
       {/* Web Preview Button - visible when servers are detected */}
       <WebPreviewButton />
+
+      {/* Skills Dropdown - Only when Skills is enabled */}
+      {enableSkills && (
+        <DropdownMenu open={skillsOpen} onOpenChange={setSkillsOpen}>
+          <DropdownMenuTrigger asChild>
+            <div className="flex items-center justify-center h-8 w-8 rounded-lg ring-1 ring-primary/50 bg-primary/10 cursor-pointer">
+              <BookOpen size={16} className="text-foreground" />
+            </div>
+          </DropdownMenuTrigger>
+          <DropdownMenuContent align="start" className="w-96 max-h-[70vh] overflow-hidden p-0">
+            <SkillsPanel projectId={projectId} />
+          </DropdownMenuContent>
+        </DropdownMenu>
+      )}
 
       {/* 4. Tools Dropdown (Wrench icon) - Only when MCP is enabled */}
       {enableMCP && (

--- a/src/renderer/locales/en/chat.json
+++ b/src/renderer/locales/en/chat.json
@@ -111,6 +111,17 @@
       "select_directory_hint": "Select a directory for coding tools",
       "missing_directory_warning": "Cowork is enabled but no working directory is selected. Coding tools are disabled."
     },
+    "skills": {
+      "label": "Skills",
+      "show_in_chat": "Show skills in chat",
+      "panel_title": "Skills",
+      "enabled": "Enabled",
+      "disabled": "Disabled",
+      "empty_enabled": "No enabled skills",
+      "empty_disabled": "No disabled skills",
+      "scope_global": "global",
+      "scope_project": "project"
+    },
     "enabled": "Enabled",
     "no_enabled_servers": "No enabled servers",
     "disabled_servers_info": "Toggle to enable",

--- a/src/renderer/locales/es/chat.json
+++ b/src/renderer/locales/es/chat.json
@@ -111,6 +111,17 @@
       "select_directory_hint": "Selecciona una carpeta para las herramientas de código",
       "missing_directory_warning": "Cowork está activado pero no hay carpeta de trabajo seleccionada. Las herramientas de código están desactivadas."
     },
+    "skills": {
+      "label": "Skills",
+      "show_in_chat": "Mostrar skills en chat",
+      "panel_title": "Skills",
+      "enabled": "Habilitadas",
+      "disabled": "Deshabilitadas",
+      "empty_enabled": "No hay skills habilitadas",
+      "empty_disabled": "No hay skills deshabilitadas",
+      "scope_global": "global",
+      "scope_project": "proyecto"
+    },
     "enabled": "Habilitados",
     "no_enabled_servers": "No hay servidores habilitados",
     "disabled_servers_info": "Activa para habilitar",

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -50,6 +50,7 @@ const ChatPage = () => {
   const { t } = useTranslation('chat');
   const [input, setInput] = useState('');
   const [enableMCP, setEnableMCP] = usePreference('enableMCP');
+  const [enableSkills, setEnableSkills] = usePreference('enableSkills');
   const [coworkMode, setCoworkMode] = usePreference('coworkMode');
   const [coworkModeCwd, setCoworkModeCwd] = usePreference('coworkModeCwd');
   const [userName, setUserName] = useState<string>(t('welcome.default_user_name'));
@@ -1062,6 +1063,9 @@ const ChatPage = () => {
                     onCoworkModeCwdChange={handleCoworkModeCwdChange}
                     coworkModeCwdSource={resolvedCoworkCwd.source}
                     onResetCoworkModeCwdOverride={currentSession ? handleResetCoworkModeCwdOverride : undefined}
+                    enableSkills={enableSkills ?? true}
+                    onSkillsChange={setEnableSkills}
+                    projectId={currentSession?.project_id ?? null}
                     model={model}
                     onModelChange={handleModelChange}
                     availableModels={filteredAvailableModels}
@@ -1131,6 +1135,9 @@ const ChatPage = () => {
                   onCoworkModeCwdChange={handleCoworkModeCwdChange}
                   coworkModeCwdSource={resolvedCoworkCwd.source}
                   onResetCoworkModeCwdOverride={currentSession ? handleResetCoworkModeCwdOverride : undefined}
+                  enableSkills={enableSkills ?? true}
+                  onSkillsChange={setEnableSkills}
+                  projectId={currentSession?.project_id ?? null}
                   model={model}
                   onModelChange={handleModelChange}
                   availableModels={filteredAvailableModels}

--- a/src/renderer/stores/__tests__/skillsStore.test.ts
+++ b/src/renderer/stores/__tests__/skillsStore.test.ts
@@ -12,6 +12,7 @@ const mockLevante = {
     uninstall: vi.fn(),
     listInstalled: vi.fn(),
     isInstalled: vi.fn(),
+    setUserInvocable: vi.fn(),
   },
 };
 
@@ -136,6 +137,59 @@ describe('skillsStore', () => {
       expect(state.installedSkills[0].scope).toBe('project');
       expect(state.installedScopedKeys.has('global:global:test/skill-one')).toBe(false);
       expect(state.installedScopedKeys.has('project:proj_1:test/skill-one')).toBe(true);
+    });
+  });
+
+  describe('loadInstalledForChat', () => {
+    it('uses project-and-global mode when projectId exists', async () => {
+      mockLevante.skills.listInstalled.mockResolvedValue({ success: true, data: [] });
+
+      await act(async () => {
+        await useSkillsStore.getState().loadInstalledForChat('proj_1');
+      });
+
+      expect(mockLevante.skills.listInstalled).toHaveBeenCalledWith({
+        mode: 'project-and-global',
+        projectId: 'proj_1',
+      });
+    });
+
+    it('uses global mode when no projectId', async () => {
+      mockLevante.skills.listInstalled.mockResolvedValue({ success: true, data: [] });
+
+      await act(async () => {
+        await useSkillsStore.getState().loadInstalledForChat(null);
+      });
+
+      expect(mockLevante.skills.listInstalled).toHaveBeenCalledWith({ mode: 'global' });
+    });
+  });
+
+  describe('toggleUserInvocable', () => {
+    it('optimistically updates and keeps API result', async () => {
+      const skill = makeInstalledSkill({ userInvocable: true });
+      const updated = { ...skill, userInvocable: false };
+
+      useSkillsStore.setState({
+        installedSkills: [skill],
+        installedScopedKeys: new Set([skill.scopedKey]),
+      });
+
+      mockLevante.skills.setUserInvocable.mockResolvedValue({
+        success: true,
+        data: updated,
+      });
+
+      await act(async () => {
+        await useSkillsStore.getState().toggleUserInvocable(skill, false);
+      });
+
+      const state = useSkillsStore.getState();
+      expect(state.installedSkills[0].userInvocable).toBe(false);
+      expect(mockLevante.skills.setUserInvocable).toHaveBeenCalledWith(skill.id, false, {
+        scope: skill.scope,
+        projectId: skill.projectId,
+      });
     });
   });
 

--- a/src/renderer/stores/skillsStore.ts
+++ b/src/renderer/stores/skillsStore.ts
@@ -25,8 +25,10 @@ interface SkillsStore {
   loadCatalog: () => Promise<void>;
   loadCategories: () => Promise<void>;
   loadInstalled: (options?: ListInstalledSkillsOptions) => Promise<void>;
+  loadInstalledForChat: (projectId?: string | null) => Promise<void>;
   installSkill: (skill: SkillDescriptor, options?: InstallSkillOptions) => Promise<void>;
   uninstallSkill: (skillId: string, options: UninstallSkillOptions) => Promise<void>;
+  toggleUserInvocable: (skill: InstalledSkill, enabled: boolean) => Promise<void>;
 
   // Legacy compatibility: checks if installed globally
   isInstalled: (skillId: string) => boolean;
@@ -104,6 +106,53 @@ export const useSkillsStore = create<SkillsStore>((set, get) => ({
         isLoadingInstalled: false,
         error: error instanceof Error ? error.message : String(error),
       });
+    }
+  },
+
+  loadInstalledForChat: async (projectId?: string | null) => {
+    if (projectId) {
+      await get().loadInstalled({ mode: 'project-and-global', projectId });
+      return;
+    }
+    await get().loadInstalled({ mode: 'global' });
+  },
+
+  toggleUserInvocable: async (skill: InstalledSkill, enabled: boolean) => {
+    const previous = get().installedSkills.find((s) => s.scopedKey === skill.scopedKey);
+    if (!previous) return;
+
+    // Optimistic update
+    set((state) => ({
+      installedSkills: state.installedSkills.map((s) =>
+        s.scopedKey === skill.scopedKey ? { ...s, userInvocable: enabled } : s
+      ),
+    }));
+
+    try {
+      const result = await window.levante.skills.setUserInvocable(skill.id, enabled, {
+        scope: skill.scope,
+        projectId: skill.projectId,
+      });
+
+      if (!result.success) {
+        throw new Error(result.error);
+      }
+
+      const updated = result.data;
+      set((state) => ({
+        installedSkills: state.installedSkills.map((s) =>
+          s.scopedKey === skill.scopedKey ? updated : s
+        ),
+      }));
+    } catch (error) {
+      // Rollback
+      set((state) => ({
+        installedSkills: state.installedSkills.map((s) =>
+          s.scopedKey === skill.scopedKey ? previous : s
+        ),
+        error: error instanceof Error ? error.message : String(error),
+      }));
+      throw error;
     }
   },
 

--- a/src/types/preferences.ts
+++ b/src/types/preferences.ts
@@ -89,6 +89,8 @@ export interface UIPreferences {
   mcp?: MCPPreferences;
   /** Enable MCP tools in chat */
   enableMCP: boolean;
+  /** Enable Skills panel in chat */
+  enableSkills: boolean;
   /** Enable Cowork mode (coding tools) in chat */
   coworkMode: boolean;
   /** Working directory for Cowork mode (coding tools) */
@@ -161,6 +163,7 @@ export const DEFAULT_PREFERENCES: UIPreferences = {
   },
   mcp: DEFAULT_MCP_PREFERENCES,
   enableMCP: true,
+  enableSkills: true,
   coworkMode: false,
   coworkModeCwd: null
 };

--- a/src/types/skills.ts
+++ b/src/types/skills.ts
@@ -60,7 +60,12 @@ export interface UninstallSkillOptions {
   projectId?: string; // requerido si scope === 'project'
 }
 
-export type ListInstalledMode = 'global' | 'project-merged' | 'all-scopes';
+export interface SetUserInvocableOptions {
+  scope: SkillScope;
+  projectId?: string; // requerido si scope === 'project'
+}
+
+export type ListInstalledMode = 'global' | 'project-merged' | 'project-and-global' | 'all-scopes';
 
 export interface ListInstalledSkillsOptions {
   mode?: ListInstalledMode; // default 'global'


### PR DESCRIPTION
## Summary

- Nuevo botón **Skills** (icono libro) en la barra del chat, con el mismo estilo resaltado que el botón de MCP tools
- Panel de skills filtra por contexto: con proyecto muestra `project + global`, sin proyecto solo `global`
- Toggle por skill persiste `user-invocable` en `skill.md` vía IPC con actualización optimista y rollback
- Toggle **Show skills in chat** en el gear de Settings (preferencia `enableSkills`, default `true`)
- Etiqueta de source (`GLOBAL`) eliminada del indicador Cowork en la barra (sigue visible en el dropdown de settings)

## Cambios principales

| Capa | Cambios |
|------|---------|
| Types | `ListInstalledMode` + `'project-and-global'`, nuevo `SetUserInvocableOptions` |
| Service | `setUserInvocable()`, modo `project-and-global` en `listInstalledSkills` |
| IPC | Handler `levante/skills:setUserInvocable` |
| Preload | `skills.setUserInvocable` expuesto + tipado en `LevanteAPI` |
| Store | `loadInstalledForChat()`, `toggleUserInvocable()` con optimistic update |
| Preferences | `enableSkills: boolean` (default `true`) |
| UI | `SkillsPanel.tsx` (nuevo), `ToolsMenu`, `ChatPromptInput`, `ChatPage` |
| Locales | `en/chat.json` + `es/chat.json` con claves de skills |
| Tests | 23 tests unitarios pasando |

## Test plan

- [ ] Abrir chat sin proyecto → Skills panel muestra solo skills `global`
- [ ] Abrir chat con proyecto → Skills panel muestra skills `project` + `global`
- [ ] Toggle de skill → persiste tras cerrar y reabrir el panel
- [ ] Desactivar skill → no aparece en contexto del agente
- [ ] Toggle `Show skills in chat` en gear → botón Skills aparece/desaparece
- [ ] Indicador Cowork en barra: no muestra etiqueta GLOBAL/project/session
- [ ] `pnpm tsc --noEmit` y `pnpm vitest run` sin errores

🤖 Generated with [Claude Code](https://claude.com/claude-code)