### PR TITLE
feat(ui): project-scoped chat history and UI improvements

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -577,6 +577,7 @@ function App() {
             project={selectedProject}
             onSessionSelect={handleLoadSession}
             onNewSessionInProject={handleNewSessionInProject}
+            onDeleteSession={deleteSession}
           />
         ) : <ChatPage />
       case 'settings': return <SettingsPage />

--- a/src/renderer/components/chat/ChatListContent.tsx
+++ b/src/renderer/components/chat/ChatListContent.tsx
@@ -168,15 +168,21 @@ export function ChatListContent({
               variant="ghost"
               size="sm"
               className="opacity-0 group-hover:opacity-100 transition-opacity h-6 w-6 p-0"
+              onPointerDown={(e) => e.stopPropagation()}
               onClick={(e) => e.stopPropagation()}
             >
               <MoreVertical size={14} />
             </Button>
           </DropdownMenuTrigger>
-          <DropdownMenuContent align="end">
+          <DropdownMenuContent
+            align="end"
+            onPointerDown={(e) => e.stopPropagation()}
+            onClick={(e) => e.stopPropagation()}
+          >
             <DropdownMenuItem
               onSelect={(e) => {
                 e.preventDefault();
+                e.stopPropagation();
                 handleRenameStart(session);
               }}
             >
@@ -184,7 +190,10 @@ export function ChatListContent({
               {t('chat_list.rename_chat')}
             </DropdownMenuItem>
             <DropdownMenuItem
-              onSelect={() => onDeleteChat(session.id)}
+              onSelect={(e) => {
+                e.stopPropagation();
+                onDeleteChat(session.id);
+              }}
               className="text-destructive focus:text-destructive"
             >
               <Trash2 size={14} className="mr-2" />

--- a/src/renderer/components/chat/ToolsMenu.tsx
+++ b/src/renderer/components/chat/ToolsMenu.tsx
@@ -22,7 +22,7 @@ import {
 import { Tabs, TabsList, TabsTrigger, TabsContent } from '@/components/ui/tabs';
 import { ToolsWarning } from '@/components/settings/ToolsWarning';
 import { SkillsPanel } from '@/components/chat/SkillsPanel';
-import type { Tool } from '@/types/mcp';
+import type { Tool, MCPConnectionStatus } from '@/types/mcp';
 
 interface ToolsMenuProps {
   enableMCP: boolean;
@@ -332,7 +332,7 @@ export function ToolsMenu({
                           serverId={server.id}
                           serverName={server.name || server.id}
                           serverEnabled={server.enabled !== false}
-                          isConnected={connectionStatus[server.id] === 'connected'}
+                          connectionStatus={connectionStatus[server.id]}
                           onServerToggle={(enabled) => enabled ? enableServer(server.id) : disableServer(server.id)}
                           isExpanded={expandedServers[server.id] || false}
                           onToggleExpand={() => toggleServerExpansion(server.id)}
@@ -365,7 +365,7 @@ export function ToolsMenu({
                           serverId={server.id}
                           serverName={server.name || server.id}
                           serverEnabled={server.enabled !== false}
-                          isConnected={connectionStatus[server.id] === 'connected'}
+                          connectionStatus={connectionStatus[server.id]}
                           onServerToggle={(enabled) => enabled ? enableServer(server.id) : disableServer(server.id)}
                           isExpanded={expandedServers[server.id] || false}
                           onToggleExpand={() => toggleServerExpansion(server.id)}
@@ -403,7 +403,7 @@ interface ServerToolsSectionProps {
   serverId: string;
   serverName: string;
   serverEnabled: boolean;
-  isConnected: boolean;
+  connectionStatus: MCPConnectionStatus | undefined;
   onServerToggle: (enabled: boolean) => void;
   isExpanded: boolean;
   onToggleExpand: () => void;
@@ -419,7 +419,7 @@ interface ServerToolsSectionProps {
 function ServerToolsSection({
   serverName,
   serverEnabled,
-  isConnected,
+  connectionStatus,
   onServerToggle,
   isExpanded,
   onToggleExpand,
@@ -433,18 +433,20 @@ function ServerToolsSection({
 }: ServerToolsSectionProps) {
   const { t } = useTranslation('chat');
 
+  const isConnected = connectionStatus === 'connected';
+  const isConnecting = connectionStatus === 'connecting';
   const allEnabled = tools.length > 0 && enabledCount === tools.length;
   const someEnabled = enabledCount > 0 && enabledCount < tools.length;
 
   return (
     <Collapsible open={isExpanded && serverEnabled} onOpenChange={onToggleExpand}>
-      <div className={cn("border rounded-md", !serverEnabled && "opacity-60")}>
+      <div className={cn("border rounded-md", !serverEnabled && !isConnecting && "opacity-60")}>
         <div className="flex items-center justify-between p-2">
           {/* Left side - clickable to expand */}
           <CollapsibleTrigger asChild>
             <div className={cn(
               "flex items-center gap-2 flex-1 cursor-pointer hover:bg-accent rounded-md p-1 -m-1",
-              !serverEnabled && "cursor-default hover:bg-transparent"
+              !serverEnabled && !isConnecting && "cursor-default hover:bg-transparent"
             )}>
               {serverEnabled ? (
                 isExpanded ? (
@@ -455,15 +457,21 @@ function ServerToolsSection({
               ) : (
                 <ChevronRight className="h-4 w-4 text-muted-foreground" />
               )}
-              <span className={cn("text-sm font-medium", !serverEnabled && "text-muted-foreground")}>
+              <span className={cn("text-sm font-medium", !serverEnabled && !isConnecting && "text-muted-foreground")}>
                 {serverName}
               </span>
+              {isConnecting && (
+                <Badge variant="outline" className="text-xs">
+                  <RefreshCw className="h-3 w-3 animate-spin mr-1" />
+                  {t('tools_menu.connecting', 'connecting...')}
+                </Badge>
+              )}
               {serverEnabled && isConnected && (
                 <Badge variant="secondary" className="text-xs">
                   {enabledCount}/{tools.length}
                 </Badge>
               )}
-              {!serverEnabled && (
+              {!serverEnabled && !isConnecting && (
                 <Badge variant="outline" className="text-xs text-muted-foreground">
                   {t('tools_menu.disabled', 'disabled')}
                 </Badge>
@@ -487,6 +495,7 @@ function ServerToolsSection({
             <Switch
               checked={serverEnabled}
               onCheckedChange={onServerToggle}
+              disabled={isConnecting}
               className="scale-75"
             />
           </div>

--- a/src/renderer/pages/ProjectPage.tsx
+++ b/src/renderer/pages/ProjectPage.tsx
@@ -1,16 +1,25 @@
 import { useState, useEffect } from 'react';
-import { FolderOpen, ArrowUp } from 'lucide-react';
+import { FolderOpen, ArrowUp, MoreVertical, Trash2 } from 'lucide-react';
 import { ChatSession, Project } from '../../types/database';
 import { modelService } from '@/services/modelService';
 import { ModelSearchableSelect } from '@/components/ai-elements/model-searchable-select';
+import { Button } from '@/components/ui/button';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
 import { usePreference } from '@/hooks/usePreferences';
 import { usePlatformStore } from '@/stores/platformStore';
+import { useTranslation } from 'react-i18next';
 import type { Model } from '../../types/models';
 
 interface ProjectPageProps {
   project: Project;
   onSessionSelect: (sessionId: string) => void;
   onNewSessionInProject: (projectId: string, initialMessage?: string, modelId?: string) => void;
+  onDeleteSession: (sessionId: string) => Promise<boolean>;
 }
 
 function formatDate(timestamp: number): string {
@@ -22,7 +31,8 @@ function formatDate(timestamp: number): string {
   return date.toLocaleDateString('es-ES', { day: 'numeric', month: 'short' });
 }
 
-export function ProjectPage({ project, onSessionSelect, onNewSessionInProject }: ProjectPageProps) {
+export function ProjectPage({ project, onSessionSelect, onNewSessionInProject, onDeleteSession }: ProjectPageProps) {
+  const { t } = useTranslation('chat');
   const [sessions, setSessions] = useState<ChatSession[]>([]);
   const [loading, setLoading] = useState(true);
   const [input, setInput] = useState('');
@@ -71,6 +81,13 @@ export function ProjectPage({ project, onSessionSelect, onNewSessionInProject }:
     e.preventDefault();
     if (!input.trim() || !selectedModel) return;
     onNewSessionInProject(project.id, input.trim(), selectedModel);
+  };
+
+  const handleDeleteChat = async (sessionId: string) => {
+    const success = await onDeleteSession(sessionId);
+    if (success) {
+      setSessions((prev) => prev.filter((s) => s.id !== sessionId));
+    }
   };
 
   return (
@@ -141,7 +158,7 @@ export function ProjectPage({ project, onSessionSelect, onNewSessionInProject }:
                 .map((session, index) => (
                   <div key={session.id}>
                     <div
-                      className="py-3 cursor-pointer hover:bg-accent/20 rounded-lg px-2 -mx-2 transition-colors"
+                      className="group py-3 cursor-pointer hover:bg-accent/20 rounded-lg px-2 -mx-2 transition-colors"
                       onClick={() => onSessionSelect(session.id)}
                     >
                       <div className="flex items-start justify-between gap-4">
@@ -153,8 +170,41 @@ export function ProjectPage({ project, onSessionSelect, onNewSessionInProject }:
                             {session.model}
                           </div>
                         </div>
-                        <div className="text-xs text-muted-foreground shrink-0 mt-0.5">
-                          {formatDate(session.updated_at)}
+                        <div className="flex items-center gap-2 shrink-0 mt-0.5">
+                          <div className="text-xs text-muted-foreground">
+                            {formatDate(session.updated_at)}
+                          </div>
+                          <DropdownMenu>
+                            <DropdownMenuTrigger asChild>
+                              <Button
+                                variant="ghost"
+                                size="sm"
+                                className="opacity-0 group-hover:opacity-100 transition-opacity h-6 w-6 p-0"
+                                onPointerDown={(e) => e.stopPropagation()}
+                                onClick={(e) => e.stopPropagation()}
+                              >
+                                <MoreVertical size={14} />
+                              </Button>
+                            </DropdownMenuTrigger>
+                            <DropdownMenuContent
+                              align="end"
+                              onPointerDown={(e) => e.stopPropagation()}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <DropdownMenuItem
+                                onPointerDown={(e) => e.stopPropagation()}
+                                onClick={(e) => e.stopPropagation()}
+                                onSelect={(e) => {
+                                  e.stopPropagation();
+                                  void handleDeleteChat(session.id);
+                                }}
+                                className="text-destructive focus:text-destructive"
+                              >
+                                <Trash2 size={14} className="mr-2" />
+                                {t('chat_list.delete_chat')}
+                              </DropdownMenuItem>
+                            </DropdownMenuContent>
+                          </DropdownMenu>
                         </div>
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- **Project-scoped chat history**: Show chat sessions filtered by project in the sidebar when a project is selected
- **Delete chats in project page**: Add dropdown menu with delete action for chat sessions in the ProjectPage view
- **Fix dropdown event propagation**: Prevent click events on chat list dropdown menus from triggering session selection
- **MCP connecting state**: Show "connecting..." badge with spinner for MCP servers and disable toggle while connecting
- **File panel copy button**: Change copy button behavior to copy file content instead of file path

## Test plan
- [ ] Verify project-scoped chat history shows only relevant sessions in sidebar
- [ ] Verify deleting a chat from ProjectPage removes it from the list
- [ ] Verify dropdown menus in chat list don't trigger navigation when clicking menu items
- [ ] Verify MCP servers show "connecting..." state with spinner during connection
- [ ] Verify file panel copy button copies file content

🤖 Generated with [Claude Code](https://claude.com/claude-code)