### PR TITLE
fix(oauth): store tokens in plaintext instead of keychain

### DIFF
--- a/src/main/services/oauth/OAuthService.ts
+++ b/src/main/services/oauth/OAuthService.ts
@@ -517,7 +517,7 @@ export class OAuthService {
     }
 
     /**
-     * Save client credentials to preferences (encrypted)
+     * Save client credentials to preferences (plaintext)
      *
      * @param serverId - MCP server ID
      * @param credentials - Client credentials from Dynamic Registration
@@ -526,26 +526,15 @@ export class OAuthService {
         serverId: string,
         credentials: OAuthClientCredentials
     ): Promise<void> {
-        // Encrypt sensitive fields
+        // Store in plaintext — file is in ~/levante/ with user-only access
         const toSave = {
             ...credentials,
-            clientSecret: credentials.clientSecret
-                ? `ENCRYPTED:${safeStorage
-                    .encryptString(credentials.clientSecret)
-                    .toString('base64')}`
-                : undefined,
+            clientSecret: credentials.clientSecret || undefined,
             registrationMetadata: credentials.registrationMetadata
                 ? {
                     ...credentials.registrationMetadata,
-                    registration_access_token: credentials
-                        .registrationMetadata.registration_access_token
-                        ? `ENCRYPTED:${safeStorage
-                            .encryptString(
-                                credentials.registrationMetadata
-                                    .registration_access_token
-                            )
-                            .toString('base64')}`
-                        : undefined,
+                    registration_access_token:
+                        credentials.registrationMetadata.registration_access_token || undefined,
                 }
                 : undefined,
         };
@@ -562,7 +551,8 @@ export class OAuthService {
     }
 
     /**
-     * Get client credentials from preferences (decrypted)
+     * Get client credentials from preferences
+     * Handles legacy ENCRYPTED: values via safeStorage migration
      *
      * @param serverId - MCP server ID
      * @returns Client credentials or null if not found
@@ -578,42 +568,43 @@ export class OAuthService {
             return null;
         }
 
-        // Decrypt sensitive fields
-        return {
+        // Read values, handling legacy ENCRYPTED: prefix via safeStorage migration
+        const decryptIfLegacy = (value: string | undefined): string | undefined => {
+            if (!value) return undefined;
+            if (!value.startsWith('ENCRYPTED:')) return value;
+            try {
+                return safeStorage.decryptString(
+                    Buffer.from(value.replace('ENCRYPTED:', ''), 'base64')
+                );
+            } catch {
+                logger.oauth.error('Failed to decrypt legacy client credential');
+                return undefined;
+            }
+        };
+
+        const result: OAuthClientCredentials = {
             ...stored,
-            clientSecret:
-                stored.clientSecret &&
-                    stored.clientSecret.startsWith('ENCRYPTED:')
-                    ? safeStorage.decryptString(
-                        Buffer.from(
-                            stored.clientSecret.replace('ENCRYPTED:', ''),
-                            'base64'
-                        )
-                    )
-                    : stored.clientSecret,
+            clientSecret: decryptIfLegacy(stored.clientSecret),
             registrationMetadata: stored.registrationMetadata
                 ? {
                     ...stored.registrationMetadata,
-                    registration_access_token:
-                        stored.registrationMetadata
-                            .registration_access_token &&
-                            stored.registrationMetadata.registration_access_token.startsWith(
-                                'ENCRYPTED:'
-                            )
-                            ? safeStorage.decryptString(
-                                Buffer.from(
-                                    stored.registrationMetadata.registration_access_token.replace(
-                                        'ENCRYPTED:',
-                                        ''
-                                    ),
-                                    'base64'
-                                )
-                            )
-                            : stored.registrationMetadata
-                                .registration_access_token,
+                    registration_access_token: decryptIfLegacy(
+                        stored.registrationMetadata.registration_access_token
+                    ),
                 }
                 : undefined,
         };
+
+        // Re-save as plaintext if any legacy encrypted values were found
+        const hadEncrypted =
+            stored.clientSecret?.startsWith('ENCRYPTED:') ||
+            stored.registrationMetadata?.registration_access_token?.startsWith('ENCRYPTED:');
+        if (hadEncrypted) {
+            logger.oauth.info('Migrating legacy encrypted client credentials to plaintext', { serverId });
+            await this.saveClientCredentials(serverId, result);
+        }
+
+        return result;
     }
 
     /**

--- a/src/main/services/oauth/OAuthTokenStore.ts
+++ b/src/main/services/oauth/OAuthTokenStore.ts
@@ -10,8 +10,8 @@ import { OAuthTokenStoreError as TokenStoreError } from './types';
 /**
  * OAuthTokenStore
  *
- * Gestión segura de tokens OAuth con encriptación automática
- * usando electron.safeStorage (Keychain/DPAPI/libsecret)
+ * Gestión de tokens OAuth almacenados en plaintext en ~/levante/ui-preferences.json.
+ * Soporta lectura de tokens legacy encriptados con safeStorage para migración transparente.
  */
 export class OAuthTokenStore {
     private logger = getLogger();
@@ -20,62 +20,34 @@ export class OAuthTokenStore {
     constructor(private preferencesService: PreferencesService) { }
 
     /**
-     * Encripta un valor usando safeStorage de Electron
+     * Desencripta un valor legacy encriptado con safeStorage.
+     * Solo se usa para migrar tokens existentes.
      */
-    private encrypt(value: string): string {
-        try {
-            if (!safeStorage.isEncryptionAvailable()) {
-                this.logger.oauth.warn('Encryption not available, storing in plaintext');
-                throw new TokenStoreError(
-                    'Encryption not available on this system',
-                    'ENCRYPTION_FAILED'
-                );
-            }
-
-            const encrypted = safeStorage.encryptString(value);
-            const base64 = encrypted.toString('base64');
-
-            return `${this.ENCRYPTED_PREFIX}${base64}`;
-        } catch (error) {
-            this.logger.oauth.error('Failed to encrypt token', {
-                error: error instanceof Error ? error.message : error,
-            });
-            if (error instanceof TokenStoreError) {
-                throw error;
-            }
-            throw new TokenStoreError(
-                'Failed to encrypt token',
-                'ENCRYPTION_FAILED'
-            );
-        }
+    private decryptLegacy(value: string): string {
+        const base64Data = value.replace(this.ENCRYPTED_PREFIX, '');
+        const buffer = Buffer.from(base64Data, 'base64');
+        return safeStorage.decryptString(buffer);
     }
 
     /**
-     * Desencripta un valor previamente encriptado
+     * Lee un valor de token, manejando tanto plaintext como legacy encriptado.
+     * Si el valor tiene prefijo ENCRYPTED: intenta desencriptar con safeStorage.
      */
-    private decrypt(encrypted: string): string {
+    private readTokenValue(value: string): string {
+        if (!value.startsWith(this.ENCRYPTED_PREFIX)) {
+            return value;
+        }
+
+        // Legacy encrypted token — decrypt and let caller re-save as plaintext
         try {
-            if (!encrypted.startsWith(this.ENCRYPTED_PREFIX)) {
-                throw new TokenStoreError(
-                    'Invalid encrypted format - missing ENCRYPTED: prefix',
-                    'INVALID_FORMAT'
-                );
-            }
-
-            const base64Data = encrypted.replace(this.ENCRYPTED_PREFIX, '');
-            const buffer = Buffer.from(base64Data, 'base64');
-
-            const decrypted = safeStorage.decryptString(buffer);
-            return decrypted;
+            this.logger.oauth.info('Migrating legacy encrypted token to plaintext');
+            return this.decryptLegacy(value);
         } catch (error) {
-            this.logger.oauth.error('Failed to decrypt token', {
+            this.logger.oauth.error('Failed to decrypt legacy token', {
                 error: error instanceof Error ? error.message : error,
             });
-            if (error instanceof TokenStoreError) {
-                throw error;
-            }
             throw new TokenStoreError(
-                'Failed to decrypt token',
+                'Failed to decrypt legacy token',
                 'DECRYPTION_FAILED'
             );
         }
@@ -83,25 +55,21 @@ export class OAuthTokenStore {
 
     /**
      * Guarda tokens OAuth para un servidor específico
-     * Los tokens se encriptan automáticamente antes de guardar
+     * Los tokens se guardan en plaintext en ~/levante/ui-preferences.json
      */
     async saveTokens(serverId: string, tokens: OAuthTokens): Promise<void> {
         try {
             this.logger.oauth.info('Saving OAuth tokens', { serverId });
 
-            // Encriptar tokens sensibles
             const stored: StoredOAuthTokens = {
-                accessToken: this.encrypt(tokens.accessToken),
-                refreshToken: tokens.refreshToken
-                    ? this.encrypt(tokens.refreshToken)
-                    : undefined,
+                accessToken: tokens.accessToken,
+                refreshToken: tokens.refreshToken || undefined,
                 expiresAt: tokens.expiresAt,
                 tokenType: tokens.tokenType,
                 scope: tokens.scope,
                 issuedAt: Date.now(),
             };
 
-            // Guardar en preferences
             await this.preferencesService.set(`oauthTokens.${serverId}`, stored);
 
             this.logger.oauth.debug('OAuth tokens saved successfully', {
@@ -120,7 +88,7 @@ export class OAuthTokenStore {
 
     /**
      * Obtiene tokens OAuth para un servidor específico
-     * Los tokens se desencriptan automáticamente
+     * Soporta lectura de tokens legacy encriptados (migración transparente)
      */
     async getTokens(serverId: string): Promise<OAuthTokens | null> {
         try {
@@ -133,16 +101,27 @@ export class OAuthTokenStore {
                 return null;
             }
 
-            // Desencriptar tokens
+            const accessToken = this.readTokenValue(stored.accessToken);
+            const refreshToken = stored.refreshToken
+                ? this.readTokenValue(stored.refreshToken)
+                : undefined;
+
             const tokens: OAuthTokens = {
-                accessToken: this.decrypt(stored.accessToken),
-                refreshToken: stored.refreshToken
-                    ? this.decrypt(stored.refreshToken)
-                    : undefined,
+                accessToken,
+                refreshToken,
                 expiresAt: stored.expiresAt,
                 tokenType: stored.tokenType,
                 scope: stored.scope,
             };
+
+            // If legacy encrypted tokens were found, re-save as plaintext
+            if (
+                stored.accessToken.startsWith(this.ENCRYPTED_PREFIX) ||
+                (stored.refreshToken && stored.refreshToken.startsWith(this.ENCRYPTED_PREFIX))
+            ) {
+                this.logger.oauth.info('Re-saving migrated tokens as plaintext', { serverId });
+                await this.saveTokens(serverId, tokens);
+            }
 
             this.logger.oauth.debug('OAuth tokens retrieved', {
                 serverId,
@@ -257,12 +236,5 @@ export class OAuthTokenStore {
             });
             return 0;
         }
-    }
-
-    /**
-     * Verifica si safeStorage está disponible en el sistema
-     */
-    isEncryptionAvailable(): boolean {
-        return safeStorage.isEncryptionAvailable();
     }
 }

--- a/src/main/services/oauth/__tests__/OAuthTokenStore.test.ts
+++ b/src/main/services/oauth/__tests__/OAuthTokenStore.test.ts
@@ -93,7 +93,7 @@ describe('OAuthTokenStore', () => {
     });
 
     describe('saveTokens', () => {
-        it('should encrypt and save tokens', async () => {
+        it('should save tokens in plaintext', async () => {
             const serverId = 'test-server-1';
             const tokens = createMockTokens();
 
@@ -101,8 +101,8 @@ describe('OAuthTokenStore', () => {
 
             const stored = await mockPreferences.get(`oauthTokens.${serverId}`);
             expect(stored).toBeDefined();
-            expect((stored as any).accessToken).toMatch(/^ENCRYPTED:/);
-            expect((stored as any).refreshToken).toMatch(/^ENCRYPTED:/);
+            expect((stored as any).accessToken).toBe(tokens.accessToken);
+            expect((stored as any).refreshToken).toBe(tokens.refreshToken);
             expect((stored as any).expiresAt).toBe(tokens.expiresAt);
             expect((stored as any).tokenType).toBe('Bearer');
         });
@@ -297,42 +297,38 @@ describe('OAuthTokenStore', () => {
         });
     });
 
-    describe('isEncryptionAvailable', () => {
-        it('should return true when safeStorage is available', () => {
-            expect(tokenStore.isEncryptionAvailable()).toBe(true);
-        });
-
-        it('should return false when safeStorage is not available', () => {
-            vi.mocked(safeStorage.isEncryptionAvailable).mockReturnValueOnce(false);
-            expect(tokenStore.isEncryptionAvailable()).toBe(false);
-        });
-    });
-
-    describe('encryption errors', () => {
-        it('should throw when encryption is not available', async () => {
-            vi.mocked(safeStorage.isEncryptionAvailable).mockReturnValueOnce(false);
-
-            const serverId = 'test-server';
-            const tokens = createMockTokens();
-
-            await expect(tokenStore.saveTokens(serverId, tokens)).rejects.toThrow(
-                OAuthTokenStoreError
-            );
-        });
-
-        it('should throw on invalid encrypted format during decryption', async () => {
+    describe('legacy encrypted token migration', () => {
+        it('should read legacy ENCRYPTED: tokens and re-save as plaintext', async () => {
             const serverId = 'test-server';
 
-            // Manually insert invalid encrypted data
+            // Simulate legacy encrypted token (mock safeStorage returns the utf8 string)
+            const legacyAccessToken = `ENCRYPTED:${Buffer.from('test-access-token', 'utf8').toString('base64')}`;
             await mockPreferences.set(`oauthTokens.${serverId}`, {
-                accessToken: 'INVALID_NO_PREFIX',
+                accessToken: legacyAccessToken,
                 expiresAt: Date.now() + 3600000,
                 tokenType: 'Bearer',
             });
 
-            await expect(tokenStore.getTokens(serverId)).rejects.toThrow(
-                OAuthTokenStoreError
-            );
+            const retrieved = await tokenStore.getTokens(serverId);
+            expect(retrieved).toBeDefined();
+            expect(retrieved!.accessToken).toBe('test-access-token');
+
+            // Verify it was re-saved as plaintext
+            const stored = await mockPreferences.get(`oauthTokens.${serverId}`);
+            expect((stored as any).accessToken).toBe('test-access-token');
+        });
+
+        it('should read plaintext tokens without migration', async () => {
+            const serverId = 'test-server';
+            await mockPreferences.set(`oauthTokens.${serverId}`, {
+                accessToken: 'plain-token',
+                expiresAt: Date.now() + 3600000,
+                tokenType: 'Bearer',
+            });
+
+            const retrieved = await tokenStore.getTokens(serverId);
+            expect(retrieved).toBeDefined();
+            expect(retrieved!.accessToken).toBe('plain-token');
         });
     });
 


### PR DESCRIPTION
Replace safeStorage encryption with plaintext storage in ~/levante/ui-preferences.json for OAuth tokens and client credentials. Existing ENCRYPTED: values are transparently migrated on first read and re-saved as plaintext.