### PR TITLE
fix(compaction): staged fallback for context_too_long deadlock

### DIFF
--- a/src/main/services/__tests__/compactionService.test.ts
+++ b/src/main/services/__tests__/compactionService.test.ts
@@ -1,0 +1,255 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { Message } from '../../../types/database';
+import { CompactionService, COMPACTION_STAGES } from '../compactionService';
+
+// Mock dependencies
+vi.mock('../chatService', () => ({
+  chatService: {
+    getMessagesForContext: vi.fn(),
+    createMessage: vi.fn(),
+  },
+}));
+
+vi.mock('../logging', () => ({
+  getLogger: () => ({
+    aiSdk: {
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+      debug: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock('../ai/streamingErrorClassifier', () => ({
+  classifyStreamingError: vi.fn((error: unknown) => {
+    const msg = error instanceof Error ? error.message : String(error);
+    if (msg.includes('context_too_long')) {
+      return { category: 'context_too_long', originalMessage: msg };
+    }
+    if (msg.includes('unauthorized')) {
+      return { category: 'unauthorized', originalMessage: msg };
+    }
+    return { category: 'unknown', originalMessage: msg };
+  }),
+}));
+
+function makeMessage(overrides: Partial<Message> = {}): Message {
+  return {
+    id: overrides.id || `msg-${Math.random().toString(36).slice(2)}`,
+    session_id: 'session-1',
+    role: overrides.role || 'user',
+    content: overrides.content || 'Hello world',
+    tool_calls: overrides.tool_calls,
+    reasoningText: overrides.reasoningText,
+    created_at: new Date().toISOString(),
+    ...overrides,
+  } as Message;
+}
+
+function makeAnchorMessage(): Message {
+  return makeMessage({
+    id: 'anchor-1',
+    role: 'system',
+    content: '[COMPACTION_SUMMARY]\n\nPrevious summary content here.',
+  });
+}
+
+describe('CompactionService', () => {
+  let service: CompactionService;
+
+  beforeEach(() => {
+    service = new CompactionService();
+    vi.clearAllMocks();
+  });
+
+  describe('truncateContent', () => {
+    it('returns content unchanged if within limit', () => {
+      expect(service.truncateContent('short', 100)).toBe('short');
+    });
+
+    it('truncates with head+tail when exceeding limit', () => {
+      const content = 'a'.repeat(200);
+      const result = service.truncateContent(content, 100);
+      expect(result).toContain('[... 100 characters truncated ...]');
+      expect(result.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('isCompactionSummaryMessage', () => {
+    it('returns true for a compaction summary message', () => {
+      expect(service.isCompactionSummaryMessage(makeAnchorMessage())).toBe(true);
+    });
+
+    it('returns false for a regular message', () => {
+      expect(service.isCompactionSummaryMessage(makeMessage())).toBe(false);
+    });
+  });
+
+  describe('applyStage', () => {
+    it('stage 1: keeps all messages and truncates large tool_calls', () => {
+      const largeToolCalls = JSON.stringify({ data: 'x'.repeat(10000) });
+      const messages = [
+        makeMessage({ content: 'Hello' }),
+        makeMessage({ role: 'assistant', content: 'World', tool_calls: largeToolCalls }),
+      ];
+
+      const result = service.applyStage(messages, COMPACTION_STAGES[0]);
+
+      expect(result).toHaveLength(2);
+      // tool_calls should be truncated (original is ~10000 chars = ~2500 tokens, limit is 500)
+      expect(result[1].tool_calls).toContain('Tool output truncated');
+    });
+
+    it('stage 3: eliminates tool_calls entirely', () => {
+      const messages = [
+        makeMessage({ tool_calls: '{"small": true}' }),
+        makeMessage({ role: 'assistant', content: 'Reply' }),
+      ];
+
+      const result = service.applyStage(messages, COMPACTION_STAGES[2]);
+
+      expect(result[0].tool_calls).toBeUndefined();
+    });
+
+    it('stage 4: eliminates reasoningText', () => {
+      const messages = [
+        makeMessage({ reasoningText: 'Some reasoning here' }),
+        makeMessage({ role: 'assistant', content: 'Reply', reasoningText: 'More reasoning' }),
+      ];
+
+      const result = service.applyStage(messages, COMPACTION_STAGES[3]);
+
+      expect(result[0].reasoningText).toBeUndefined();
+      expect(result[1].reasoningText).toBeUndefined();
+    });
+
+    it('preserves anchor message even with messagePercentage = 0.25', () => {
+      const anchor = makeAnchorMessage();
+      const messages = [
+        anchor,
+        makeMessage({ content: 'msg1' }),
+        makeMessage({ content: 'msg2' }),
+        makeMessage({ content: 'msg3' }),
+        makeMessage({ content: 'msg4' }),
+      ];
+
+      const result = service.applyStage(messages, COMPACTION_STAGES[4]); // stage 5, 0.25
+
+      expect(result[0]).toBe(anchor);
+      expect(result.length).toBeGreaterThanOrEqual(2); // anchor + at least 1
+      expect(service.isCompactionSummaryMessage(result[0])).toBe(true);
+    });
+
+    it('guarantees anchor + 1 message minimum', () => {
+      const anchor = makeAnchorMessage();
+      const messages = [anchor, makeMessage({ content: 'only one' })];
+
+      const result = service.applyStage(messages, COMPACTION_STAGES[4]); // stage 5, 0.25
+
+      expect(result).toHaveLength(2);
+      expect(result[0]).toBe(anchor);
+    });
+
+    it('guarantees minimum 2 messages without anchor', () => {
+      const messages = [
+        makeMessage({ content: 'msg1' }),
+        makeMessage({ content: 'msg2' }),
+      ];
+
+      const result = service.applyStage(messages, COMPACTION_STAGES[4]); // stage 5, 0.25
+
+      expect(result).toHaveLength(2);
+    });
+
+    it('stage 1: preserves reasoningText within limit', () => {
+      const messages = [
+        makeMessage({ reasoningText: 'Short reasoning' }),
+      ];
+
+      const result = service.applyStage(messages, COMPACTION_STAGES[0]); // reasoningMaxChars: 1200
+
+      expect(result[0].reasoningText).toBe('Short reasoning');
+    });
+
+    it('stage 2: truncates reasoningText exceeding limit', () => {
+      const longReasoning = 'r'.repeat(2000);
+      const messages = [makeMessage({ reasoningText: longReasoning })];
+
+      const result = service.applyStage(messages, COMPACTION_STAGES[1]); // reasoningMaxChars: 600
+
+      expect(result[0].reasoningText!.length).toBeLessThan(longReasoning.length);
+      expect(result[0].reasoningText).toContain('characters truncated');
+    });
+  });
+
+  describe('compact – staged retry', () => {
+    let chatService: any;
+
+    beforeEach(async () => {
+      const chatMod = await import('../chatService');
+      chatService = chatMod.chatService;
+    });
+
+    it('retries through stages on context_too_long and succeeds at stage 3', async () => {
+      chatService.getMessagesForContext.mockResolvedValue({
+        success: true,
+        data: [makeMessage(), makeMessage({ role: 'assistant', content: 'Reply' })],
+      });
+      chatService.createMessage.mockResolvedValue({
+        success: true,
+        data: { id: 'summary-1' },
+      });
+
+      let callCount = 0;
+      const generateSpy = vi.spyOn(service as any, 'generateSummary').mockImplementation(async () => {
+        callCount++;
+        if (callCount <= 2) {
+          throw new Error('context_too_long: prompt exceeds limit');
+        }
+        return 'Compacted summary';
+      });
+
+      const result = await service.compact({ sessionId: 'sess-1', model: 'test-model' });
+
+      expect(result.success).toBe(true);
+      expect(result.stage).toBe(3);
+      expect(generateSpy).toHaveBeenCalledTimes(3);
+    });
+
+    it('returns exhaustedStages when all stages fail with context_too_long', async () => {
+      chatService.getMessagesForContext.mockResolvedValue({
+        success: true,
+        data: [makeMessage(), makeMessage({ role: 'assistant', content: 'Reply' })],
+      });
+
+      vi.spyOn(service as any, 'generateSummary').mockRejectedValue(
+        new Error('context_too_long: prompt exceeds limit')
+      );
+
+      const result = await service.compact({ sessionId: 'sess-1', model: 'test-model' });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCategory).toBe('context_too_long');
+      expect(result.exhaustedStages).toBe(true);
+    });
+
+    it('aborts immediately on non-retryable error without trying next stage', async () => {
+      chatService.getMessagesForContext.mockResolvedValue({
+        success: true,
+        data: [makeMessage(), makeMessage({ role: 'assistant', content: 'Reply' })],
+      });
+
+      const generateSpy = vi.spyOn(service as any, 'generateSummary').mockRejectedValue(
+        new Error('unauthorized: invalid API key')
+      );
+
+      const result = await service.compact({ sessionId: 'sess-1', model: 'test-model' });
+
+      expect(result.success).toBe(false);
+      expect(result.errorCategory).toBe('unauthorized');
+      expect(result.exhaustedStages).toBe(false);
+      expect(generateSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/src/main/services/ai/__tests__/streamingErrorClassifier.test.ts
+++ b/src/main/services/ai/__tests__/streamingErrorClassifier.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from 'vitest';
+import { classifyStreamingError } from '../streamingErrorClassifier';
+
+describe('classifyStreamingError – context_too_long', () => {
+  it('classifies OpenAI maximum context length error', () => {
+    const error = new Error(
+      "This model's maximum context length is 128000 tokens. However, you requested 150000 tokens"
+    );
+    const result = classifyStreamingError(error);
+    expect(result.category).toBe('context_too_long');
+  });
+
+  it('classifies Anthropic prompt too long error', () => {
+    const error = new Error(
+      'The prompt is too long. Please reduce the number of messages.'
+    );
+    const result = classifyStreamingError(error);
+    expect(result.category).toBe('context_too_long');
+  });
+
+  it('classifies HTTP 413 as context_too_long', () => {
+    const error = Object.assign(new Error('Request entity too large'), {
+      statusCode: 413,
+    });
+    const result = classifyStreamingError(error);
+    expect(result.category).toBe('context_too_long');
+  });
+
+  it('classifies HTTP 400 with context-related message as context_too_long', () => {
+    const error = Object.assign(new Error('maximum context length exceeded'), {
+      statusCode: 400,
+    });
+    const result = classifyStreamingError(error);
+    expect(result.category).toBe('context_too_long');
+  });
+
+  it('does NOT false-positive on HTTP 400 with unrelated message', () => {
+    const error = Object.assign(new Error('Invalid request body'), {
+      statusCode: 400,
+    });
+    const result = classifyStreamingError(error);
+    expect(result.category).not.toBe('context_too_long');
+  });
+
+  it('classifies "tokens exceed" pattern', () => {
+    const error = new Error('input tokens exceed the maximum allowed');
+    const result = classifyStreamingError(error);
+    expect(result.category).toBe('context_too_long');
+  });
+
+  it('classifies "conversation too long" pattern', () => {
+    const error = new Error('conversation too long');
+    const result = classifyStreamingError(error);
+    expect(result.category).toBe('context_too_long');
+  });
+
+  it('classifies via nested data.error.message', () => {
+    const error = {
+      message: 'API error',
+      data: {
+        error: {
+          message: "This model's maximum context length is 128000 tokens",
+        },
+      },
+    };
+    const result = classifyStreamingError(error);
+    expect(result.category).toBe('context_too_long');
+  });
+
+  it('classifies via responseBody', () => {
+    const error = Object.assign(new Error('Bad request'), {
+      responseBody: '{"error": "prompt is too long for this model"}',
+    });
+    const result = classifyStreamingError(error);
+    expect(result.category).toBe('context_too_long');
+  });
+});

--- a/src/main/services/ai/streamingErrorClassifier.ts
+++ b/src/main/services/ai/streamingErrorClassifier.ts
@@ -8,6 +8,7 @@ export type StreamingErrorCategory =
   | 'quota_exceeded'
   | 'unauthorized'
   | 'model_not_available'
+  | 'context_too_long'
   | 'unknown';
 
 export interface ClassifiedStreamingError {
@@ -68,6 +69,27 @@ const ERROR_PATTERNS: Array<{ category: StreamingErrorCategory; patterns: string
       'model does not exist',
     ],
     statusCodes: [404],
+  },
+  {
+    category: 'context_too_long',
+    patterns: [
+      'maximum context length',
+      'context length',
+      'context window',
+      'prompt is too long',
+      'prompt too long',
+      'input tokens exceed',
+      'input is too long',
+      'requested too many tokens',
+      'tokens exceed',
+      'too many tokens',
+      'request too large',
+      'request entity too large',
+      'payload size exceeds',
+      'content length exceeds',
+      'conversation too long',
+    ],
+    statusCodes: [413],
   },
 ];
 

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -2157,9 +2157,16 @@ export class AIService {
         }
       }
 
-      throw new Error(
+      const wrapped = new Error(
         error instanceof Error ? error.message : "Unknown error occurred"
       );
+
+      (wrapped as any).statusCode = (error as any)?.statusCode;
+      (wrapped as any).responseBody = (error as any)?.responseBody;
+      (wrapped as any).data = (error as any)?.data;
+      (wrapped as any).url = (error as any)?.url;
+
+      throw wrapped;
     }
   }
 }

--- a/src/main/services/compactionService.ts
+++ b/src/main/services/compactionService.ts
@@ -2,9 +2,11 @@ import type { UIMessage } from 'ai';
 import type { Message } from '../../types/database';
 import { chatService } from './chatService';
 import { getLogger } from './logging';
+import { classifyStreamingError } from './ai/streamingErrorClassifier';
 
 const COMPACTION_MARKER = '[COMPACTION_SUMMARY]';
 const CHARS_PER_TOKEN = 4;
+
 export interface CompactInput {
   sessionId: string;
   model: string;
@@ -13,8 +15,27 @@ export interface CompactInput {
 export interface CompactResult {
   success: boolean;
   summaryMessageId?: string;
+  stage?: number;
   error?: string;
+  errorCategory?: string;
+  exhaustedStages?: boolean;
 }
+
+export interface CompactionStage {
+  stage: number;
+  toolCallTokenLimit: number | null;
+  contentMaxChars: number | null;
+  reasoningMaxChars: number | null;
+  messagePercentage: number;
+}
+
+export const COMPACTION_STAGES: CompactionStage[] = [
+  { stage: 1, toolCallTokenLimit: 500,  contentMaxChars: null,  reasoningMaxChars: 1200, messagePercentage: 1.0  },
+  { stage: 2, toolCallTokenLimit: 100,  contentMaxChars: 2000,  reasoningMaxChars: 600,  messagePercentage: 1.0  },
+  { stage: 3, toolCallTokenLimit: null, contentMaxChars: 600,   reasoningMaxChars: 300,  messagePercentage: 1.0  },
+  { stage: 4, toolCallTokenLimit: null, contentMaxChars: 300,   reasoningMaxChars: null, messagePercentage: 0.5  },
+  { stage: 5, toolCallTokenLimit: null, contentMaxChars: 200,   reasoningMaxChars: null, messagePercentage: 0.25 },
+];
 
 export class CompactionService {
   private logger = getLogger();
@@ -23,24 +44,100 @@ export class CompactionService {
     return Math.max(0, Math.round((text || '').length / CHARS_PER_TOKEN));
   }
 
-  private estimateMessageTokens(message: Message): number {
-    const contentTokens = this.estimateTokens(message.content || '');
-    const toolTokens = message.tool_calls ? this.estimateTokens(message.tool_calls) : 0;
-    const reasoningTokens = message.reasoningText ? this.estimateTokens(message.reasoningText) : 0;
-    return contentTokens + toolTokens + reasoningTokens;
+  truncateContent(content: string, maxChars: number): string {
+    if (content.length <= maxChars) return content;
+
+    const headSize = Math.floor(maxChars * 0.66);
+    const tailSize = maxChars - headSize;
+    const truncated = content.length - maxChars;
+
+    const head = content.slice(0, headSize);
+    const tail = content.slice(content.length - tailSize);
+
+    return `${head}\n[... ${truncated} characters truncated ...]\n${tail}`;
   }
 
-  private prepareMessagesForSummary(messages: Message[]): Message[] {
-    return messages.map((m) => {
-      if (!m.tool_calls) return m;
-      const toolTokens = this.estimateTokens(m.tool_calls);
-      if (toolTokens <= 500) return m;
+  isCompactionSummaryMessage(message: Message): boolean {
+    return (
+      message.role === 'system' &&
+      typeof message.content === 'string' &&
+      message.content.startsWith(COMPACTION_MARKER)
+    );
+  }
 
-      return {
-        ...m,
-        tool_calls: JSON.stringify([{ summary: `[Tool output truncated: ~${toolTokens} tokens]` }]),
-      };
-    });
+  applyStage(messages: Message[], stage: CompactionStage): Message[] {
+    // 1. Detect anchor
+    let anchorMessage: Message | null = null;
+    let rest: Message[];
+
+    if (messages.length > 0 && this.isCompactionSummaryMessage(messages[0])) {
+      anchorMessage = messages[0];
+      rest = messages.slice(1);
+    } else {
+      rest = [...messages];
+    }
+
+    // 2. Apply messagePercentage to rest
+    if (stage.messagePercentage < 1.0) {
+      const targetCount = Math.max(
+        anchorMessage ? 1 : 2,
+        Math.ceil(rest.length * stage.messagePercentage),
+      );
+      // Keep the last N messages (most recent)
+      rest = rest.slice(rest.length - targetCount);
+    }
+
+    // 3. Guarantee minimums
+    if (anchorMessage && rest.length === 0 && messages.length > 1) {
+      rest = [messages[messages.length - 1]];
+    }
+    if (!anchorMessage && rest.length < 2 && messages.length >= 2) {
+      rest = messages.slice(messages.length - 2);
+    }
+
+    // 4. Apply reduction to each message
+    const reduced = rest.map((m) => this.reduceMessage(m, stage));
+
+    // 5. Rebuild with anchor
+    if (anchorMessage) {
+      return [anchorMessage, ...reduced];
+    }
+    return reduced;
+  }
+
+  private reduceMessage(message: Message, stage: CompactionStage): Message {
+    const result = { ...message };
+
+    // tool_calls reduction
+    if (result.tool_calls) {
+      if (stage.toolCallTokenLimit === null) {
+        result.tool_calls = undefined;
+      } else {
+        const toolTokens = this.estimateTokens(result.tool_calls);
+        if (toolTokens > stage.toolCallTokenLimit) {
+          result.tool_calls = JSON.stringify([{ summary: `[Tool output truncated: ~${toolTokens} tokens]` }]);
+        }
+      }
+    }
+
+    // content reduction
+    if (result.content && stage.contentMaxChars !== null) {
+      result.content = this.truncateContent(result.content, stage.contentMaxChars);
+    }
+
+    // reasoningText reduction
+    if (stage.reasoningMaxChars === null) {
+      result.reasoningText = undefined;
+    } else if (result.reasoningText && result.reasoningText.length > stage.reasoningMaxChars) {
+      result.reasoningText = this.truncateContent(result.reasoningText, stage.reasoningMaxChars);
+    }
+
+    return result;
+  }
+
+  private isContextTooLongError(error: unknown): boolean {
+    const { category } = classifyStreamingError(error);
+    return category === 'context_too_long';
   }
 
   private serializeMessage(message: Message): string {
@@ -133,39 +230,87 @@ Rules:
       }
 
       const contextMessages = contextResult.data;
-      if (contextMessages.length === 0) {
+      if (!contextMessages || contextMessages.length === 0) {
         return { success: false, error: 'No messages to compact' };
       }
 
-      const prepared = this.prepareMessagesForSummary(contextMessages);
-      const summary = await this.generateSummary({
-        messages: prepared,
-        model: input.model,
-      });
+      for (const stageConfig of COMPACTION_STAGES) {
+        this.logger.aiSdk.info('Attempting compaction stage', {
+          sessionId: input.sessionId,
+          stage: stageConfig.stage,
+        });
 
-      const saved = await chatService.createMessage({
-        session_id: input.sessionId,
-        role: 'system',
-        content: `${COMPACTION_MARKER}\n\n${summary}`,
-      });
+        const prepared = this.applyStage(contextMessages, stageConfig);
 
-      if (!saved.success) {
-        return {
-          success: false,
-          error: saved.error || 'Failed to persist compaction summary',
-        };
+        try {
+          const summary = await this.generateSummary({
+            messages: prepared,
+            model: input.model,
+          });
+
+          const saved = await chatService.createMessage({
+            session_id: input.sessionId,
+            role: 'system',
+            content: `${COMPACTION_MARKER}\n\n${summary}`,
+          });
+
+          if (!saved.success) {
+            return {
+              success: false,
+              error: saved.error || 'Failed to persist compaction summary',
+            };
+          }
+
+          this.logger.aiSdk.info('Manual compaction completed', {
+            sessionId: input.sessionId,
+            stage: stageConfig.stage,
+            sourceMessages: contextMessages.length,
+            sentToSummarizer: prepared.length,
+            summaryLength: summary.length,
+          });
+
+          return {
+            success: true,
+            summaryMessageId: saved.data?.id,
+            stage: stageConfig.stage,
+          };
+        } catch (error) {
+          if (this.isContextTooLongError(error)) {
+            this.logger.aiSdk.warn('Compaction stage failed with context_too_long, trying next stage', {
+              sessionId: input.sessionId,
+              stage: stageConfig.stage,
+            });
+            continue;
+          }
+
+          // Non-retryable error — abort immediately
+          const classified = classifyStreamingError(error);
+          this.logger.aiSdk.error('Compaction failed with non-retryable error', {
+            sessionId: input.sessionId,
+            stage: stageConfig.stage,
+            errorCategory: classified.category,
+            error: classified.originalMessage,
+          });
+
+          return {
+            success: false,
+            error: classified.originalMessage,
+            errorCategory: classified.category,
+            exhaustedStages: false,
+          };
+        }
       }
 
-      this.logger.aiSdk.info('Manual compaction completed', {
+      // All stages exhausted
+      this.logger.aiSdk.error('Compaction failed after all reduction stages', {
         sessionId: input.sessionId,
-        sourceMessages: contextMessages.length,
-        sentToSummarizer: prepared.length,
-        summaryLength: summary.length,
       });
 
       return {
-        success: true,
-        summaryMessageId: saved.data?.id,
+        success: false,
+        error: 'Compaction failed after all reduction stages',
+        errorCategory: 'context_too_long',
+        exhaustedStages: true,
       };
     } catch (error) {
       this.logger.aiSdk.error('Manual compaction failed', {

--- a/src/preload/api/compaction.ts
+++ b/src/preload/api/compaction.ts
@@ -8,7 +8,10 @@ export interface CompactRequest {
 export interface CompactResponse {
   success: boolean;
   summaryMessageId?: string;
+  stage?: number;
   error?: string;
+  errorCategory?: string;
+  exhaustedStages?: boolean;
 }
 
 export const compactionApi = {

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -1006,7 +1006,10 @@ export interface LevanteAPI {
     }) => Promise<{
       success: boolean;
       summaryMessageId?: string;
+      stage?: number;
       error?: string;
+      errorCategory?: string;
+      exhaustedStages?: boolean;
     }>;
   };
 

--- a/src/renderer/locales/en/chat.json
+++ b/src/renderer/locales/en/chat.json
@@ -278,6 +278,8 @@
     "tokens_remaining": "Tokens remaining",
     "context_unknown": "Context window unknown for this model/provider",
     "compact_success": "Conversation compacted",
-    "compact_error": "Could not compact"
+    "compact_success_degraded": "Conversation compacted (reduced mode, some details may have been summarized)",
+    "compact_error": "Could not compact",
+    "compact_error_context_too_long": "Could not compact: the conversation still exceeds the model limit after all reduction stages. Consider starting a new session."
   }
 }

--- a/src/renderer/locales/es/chat.json
+++ b/src/renderer/locales/es/chat.json
@@ -278,6 +278,8 @@
     "tokens_remaining": "Tokens restantes",
     "context_unknown": "Context window desconocida para este modelo/proveedor",
     "compact_success": "Conversación compactada",
-    "compact_error": "No se pudo compactar"
+    "compact_success_degraded": "Conversación compactada en modo reducido; algunos detalles pueden haberse resumido",
+    "compact_error": "No se pudo compactar",
+    "compact_error_context_too_long": "No se pudo compactar: la conversación sigue excediendo el límite del modelo incluso tras todas las etapas de reducción. Considera iniciar una nueva sesión."
   }
 }

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -681,13 +681,21 @@ const ChatPage = () => {
       });
 
       if (!result.success) {
-        throw new Error(result.error || 'Compaction failed');
+        if (result.errorCategory === 'context_too_long' && result.exhaustedStages) {
+          throw new Error(t('context_usage.compact_error_context_too_long'));
+        }
+
+        throw new Error(result.error || t('context_usage.compact_error'));
       }
 
       const historical = await loadHistoricalMessages(currentSession.id);
       setMessages(historical);
 
-      toast.success(t('context_usage.compact_success'));
+      if (result.stage && result.stage > 1) {
+        toast.success(t('context_usage.compact_success_degraded'));
+      } else {
+        toast.success(t('context_usage.compact_success'));
+      }
     } catch (error) {
       toast.error(error instanceof Error ? error.message : t('context_usage.compact_error'));
     } finally {


### PR DESCRIPTION
## Summary
- Adds 5 progressive reduction stages to `CompactionService` so compaction retries automatically when the model rejects due to context exceeding its limit (#236)
- Extends `streamingErrorClassifier` with `context_too_long` category (15 text patterns + HTTP 413)
- Preserves error metadata (`statusCode`, `responseBody`, `data`) in `sendSingleMessage()` so the classifier can detect the error type
- Previous `COMPACTION_SUMMARY` is always preserved as an anchor across all stages
- `reasoningText` is progressively reduced/eliminated alongside `content` and `tool_calls`
- Renderer now shows differentiated feedback: normal success, degraded success (stage > 1), and exhausted-stages error
- i18n keys added for both EN and ES

## Test plan
- [x] `pnpm typecheck` passes
- [x] 9 new classifier tests pass (OpenAI, Anthropic, HTTP 413, 400 with/without context text, nested data, responseBody)
- [x] 15 new compaction tests pass (truncation, anchor preservation, stage reduction, staged retry, exhaustion, non-retryable abort)
- [ ] Manual: trigger compaction on a long conversation and verify toast messages

Closes #236

🤖 Generated with [Claude Code](https://claude.com/claude-code)