### PR TITLE
feat(mcp): canonicalize tool results and offload images to disk

### DIFF
--- a/docs/HANDOFF_MCP_IMAGE_RESIZE_STATUS.md
+++ b/docs/HANDOFF_MCP_IMAGE_RESIZE_STATUS.md
@@ -1,0 +1,517 @@
+# Handoff — Estado de implementación de `PLAN_MCP_IMAGE_RESIZE`
+
+**Fecha:** 2026-04-14  
+**Objetivo de este documento:** dar a otra IA el contexto suficiente para retomar la corrección sin tener que reconstruir el análisis previo.
+
+## Resumen ejecutivo
+
+El plan de resize/entrega multimodal de imágenes MCP está **mayormente implementado**, pero **todavía no debe considerarse cerrado**.
+
+La mayor parte del trabajo estructural ya está hecha:
+
+- `sharp` añadido y cableado en packaging.
+- normalización compartida del resultado MCP creada.
+- resizer y validation safety-net creados.
+- `mcpToolsAdapter` ya convierte imágenes MCP en `image-data`.
+- `toolOutputSanitizer` compartido entre main y renderer.
+- tests unitarios principales añadidos.
+
+Sin embargo, siguen quedando **dos problemas funcionales importantes** y **un problema de validación/test**:
+
+1. `processToolResult()` pierde `structuredContent` al devolver outputs saneados con `uiResources` o `images`.
+2. `validateImagesForAPI()` solo hace `warn`; no bloquea ni corrige payloads oversized.
+3. `imageResizer.test.ts` termina con error global por el logger real escribiendo fuera del workspace.
+
+## Plan fuente
+
+El runbook que se intentó implementar es:
+
+- [docs/PLAN_MCP_IMAGE_RESIZE.md](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/docs/PLAN_MCP_IMAGE_RESIZE.md)
+
+## Archivos ya modificados
+
+Estado visible por `git status` / `git diff --stat` durante esta revisión:
+
+- `forge.config.js`
+- `package.json`
+- `pnpm-lock.yaml`
+- `src/main/services/ai/__tests__/toolMessageSanitizer.test.ts`
+- `src/main/services/ai/mcpToolsAdapter.ts`
+- `src/main/services/ai/toolMessageSanitizer.ts`
+- `src/main/services/aiService.ts`
+- `src/main/services/mcp/mcpLegacyService.ts`
+- `src/main/services/mcp/mcpUseService.ts`
+- `src/main/types/mcp.ts`
+- `src/renderer/stores/chatStore.ts`
+- `vite.main.config.ts`
+- nuevos directorios:
+  - `src/main/services/image/`
+  - `src/main/services/mcp/shared/`
+  - `src/shared/`
+  - tests asociados
+
+## Qué sí está implementado
+
+### 1. Packaging de `sharp`
+
+Se añadió `sharp` a dependencias:
+
+- [package.json](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/package.json)
+
+Vite lo deja como `external`:
+
+- [vite.main.config.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/vite.main.config.ts:39)
+
+Forge copia `sharp` y `@img/*`, y amplía `asar.unpack`:
+
+- [forge.config.js](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/forge.config.js:146)
+- [forge.config.js](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/forge.config.js:188)
+
+### 2. Normalización MCP compartida
+
+Existe el helper:
+
+- [src/main/services/mcp/shared/normalizeToolResult.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/shared/normalizeToolResult.ts:1)
+
+Y ambos servicios MCP lo usan:
+
+- [src/main/services/mcp/mcpUseService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/mcpUseService.ts:446)
+- [src/main/services/mcp/mcpLegacyService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/mcpLegacyService.ts:211)
+
+Esto corrige el bug original donde `structuredContent` pisaba `content[]`.
+
+### 3. Sanitizer compartido main/renderer
+
+Existe el helper compartido:
+
+- [src/shared/toolOutputSanitizer.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/shared/toolOutputSanitizer.ts:1)
+
+Contiene:
+
+- `stripInlineImagesFromContent(...)`
+- `sanitizeToolOutput(...)`
+
+El renderer ya lo usa al persistir `tool_calls.result`:
+
+- [src/renderer/stores/chatStore.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/renderer/stores/chatStore.ts:507)
+
+### 4. Resizer y límites
+
+Se añadieron:
+
+- [src/main/services/image/providerImageLimits.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/providerImageLimits.ts)
+- [src/main/services/image/imageResizer.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageResizer.ts:1)
+- [src/main/services/image/imageValidation.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageValidation.ts:1)
+
+### 5. Integración en `mcpToolsAdapter`
+
+`mcpToolsAdapter` ya:
+
+- recibe `supportsVision`;
+- convierte imágenes MCP inline;
+- usa `image-data` en `toModelOutput`;
+- degrada a texto si no hay visión.
+
+Referencias:
+
+- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:487)
+- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:499)
+- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:519)
+
+### 6. Integración en `aiService`
+
+`aiService` ya:
+
+- pasa `supportsVision` a `getMCPTools(...)`;
+- ejecuta `validateImagesForAPI(...)` antes de `convertToModelMessages(...)`;
+- lo hace tanto en streaming como en `generateText()`.
+
+Referencias:
+
+- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:1156)
+- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:1297)
+- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:2066)
+- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:2109)
+
+## Problemas pendientes
+
+### Problema 1 — `structuredContent` se pierde en `processToolResult()`
+
+**Impacto:** alto
+
+En [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:1248), cuando hay `uiResources` o `imageParts`, se hace:
+
+```ts
+return sanitizeToolOutput({
+  text,
+  content: result.content,
+  ...(uiResources.length > 0 ? { uiResources } : {}),
+  ...(imageParts.length > 0 ? { images: imageParts } : {}),
+});
+```
+
+Falta `structuredContent`.
+
+Esto es inconsistente con:
+
+- el plan, que exige preservarlo;
+- `sanitizeToolOutput(...)`, que sí sabe preservarlo si se le pasa;
+- el comportamiento esperado de widgets y de outputs estructurados en turnos siguientes.
+
+**Corrección esperada:**
+
+En ese bloque, añadir:
+
+```ts
+...(result.structuredContent ? { structuredContent: result.structuredContent } : {}),
+```
+
+### Problema 2 — el safety-net no bloquea el envío
+
+**Impacto:** alto
+
+En [src/main/services/image/imageValidation.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageValidation.ts:89) el comentario dice explícitamente que el safety-net “does not throw”.
+
+La implementación actual en [imageValidation.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageValidation.ts:107) solo hace `logger.aiSdk.warn(...)`.
+
+Eso significa que si una imagen oversized se escapa del pipeline:
+
+- se registra;
+- pero igual se envía al provider;
+- el fix no garantiza evitar `prompt too long`.
+
+**Decisión pendiente para la siguiente IA:**
+
+Elegir una de estas dos rutas y aplicarla de forma consistente:
+
+1. `validateImagesForAPI()` debe lanzar `ImagePayloadTooLargeError`.
+2. `validateImagesForAPI()` debe intentar una remediación real antes de lanzar.
+
+La opción más directa para cerrar el fix es la 1.
+
+Si se cambia a `throw`, revisar también:
+
+- cómo se presenta el error al usuario;
+- si `streamChat` y `generateText` ya lo convertirán en mensaje usable o si hace falta mapearlo.
+
+### Problema 3 — test del resizer con error global del logger
+
+**Impacto:** medio
+
+`pnpm vitest run src/main/services/image/__tests__/imageResizer.test.ts` ejecuta los asserts correctamente, pero termina con error global:
+
+- `EPERM: operation not permitted, open '/Users/saulgomezjimenez/levante/levante-2026-04-14.log'`
+
+El origen es que [imageResizer.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageResizer.ts:2) importa el logger real, y durante el test intenta escribir fuera del workspace permitido.
+
+**Opciones razonables de corrección:**
+
+1. Mockear `../logging` en `imageResizer.test.ts`.
+2. Configurar logger en modo no-file para tests.
+3. Introducir lazy logger o shim test-safe.
+
+La opción más barata aquí es la 1.
+
+## Verificaciones realizadas
+
+### Typecheck
+
+Ejecutado:
+
+```bash
+pnpm typecheck
+```
+
+Resultado:
+
+- pasa
+
+### Tests que pasan
+
+Ejecutados y observados como correctos:
+
+- `src/main/services/mcp/shared/__tests__/normalizeToolResult.test.ts`
+- `src/shared/__tests__/toolOutputSanitizer.test.ts`
+- `src/main/services/ai/__tests__/toolMessageSanitizer.test.ts`
+- `src/main/services/image/__tests__/imageValidation.test.ts`
+- `src/main/services/ai/__tests__/mcpToolsAdapter.image.test.ts`
+
+### Test que no está limpio aún
+
+Ejecutado:
+
+```bash
+pnpm vitest run src/main/services/image/__tests__/imageResizer.test.ts
+```
+
+Resultado:
+
+- los 5 tests pasan;
+- Vitest termina con error global por el logger;
+- por tanto no debe contarse como “verde”.
+
+## Riesgo adicional a vigilar
+
+### `validateImagesForAPI.test.ts` está alineado con el comportamiento actual, no con el objetivo final
+
+Los tests actuales de [imageValidation.test.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/__tests__/imageValidation.test.ts:1) verifican que se haga `warn`, no que se lance error.
+
+Si se cambia `validateImagesForAPI()` para cerrar el fix de verdad, habrá que actualizar estos tests.
+
+## Próximos pasos recomendados
+
+### Paso 1
+
+Corregir [mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:1248) para preservar `structuredContent` en el objeto que pasa por `sanitizeToolOutput()`.
+
+### Paso 2
+
+Cambiar [imageValidation.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageValidation.ts:96) para que deje de hacer solo logging y bloquee realmente el envío cuando haya payload oversized.
+
+### Paso 3
+
+Actualizar tests de `imageValidation` a ese nuevo contrato.
+
+### Paso 4
+
+Mockear el logger en `imageResizer.test.ts` para eliminar el error global y dejar la suite realmente verde.
+
+### Paso 5
+
+Volver a ejecutar como mínimo:
+
+```bash
+pnpm typecheck
+pnpm vitest run src/main/services/mcp/shared/__tests__/normalizeToolResult.test.ts
+pnpm vitest run src/shared/__tests__/toolOutputSanitizer.test.ts
+pnpm vitest run src/main/services/ai/__tests__/toolMessageSanitizer.test.ts
+pnpm vitest run src/main/services/image/__tests__/imageValidation.test.ts
+pnpm vitest run src/main/services/image/__tests__/imageResizer.test.ts
+pnpm vitest run src/main/services/ai/__tests__/mcpToolsAdapter.image.test.ts
+```
+
+## Criterio para considerar el trabajo terminado
+
+La siguiente IA debería considerar este fix “cerrado” solo si se cumplen estas condiciones:
+
+1. `structuredContent` ya no se pierde en `processToolResult()`.
+2. `validateImagesForAPI()` bloquea o remedia de verdad payloads oversized.
+3. `imageResizer.test.ts` queda sin errores globales.
+4. `pnpm typecheck` pasa.
+5. La suite focalizada de tests queda completamente verde.
+
+## Actualización posterior — diagnóstico empírico con logs temporales
+
+### Estado de este bloque
+
+Este bloque se añade después de la primera ronda de correcciones y después de introducir logs temporales en `aiService.ts` para inspeccionar:
+
+- `sanitizedMessages`
+- `modelMessages`
+- mayores strings
+- payloads de imagen detectados
+
+Los logs se añadieron temporalmente en:
+
+- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts)
+
+### Qué se observó en producción
+
+#### Caso 1 — screenshot fallido por Chrome no disponible
+
+Se registró un caso en el que `chrome-devtools_take_screenshot` falló al conectar con Chrome.
+
+Los logs relevantes mostraron:
+
+- `imagePayloads: []` en `sanitizedMessages`
+- `imagePayloads: []` en `modelMessages`
+
+Los strings dominantes eran:
+
+- output de `skill_execute`
+- mensajes de error del tipo:
+  - `Could not connect to Chrome. Check if Chrome is running.`
+
+Conclusión de ese caso:
+
+- no había imagen real en contexto;
+- ese intento no explica el `prompt too long`.
+
+#### Caso 2 — screenshot exitoso con imagen real
+
+En un intento posterior, los logs mostraron claramente la imagen problemática.
+
+En `sanitizedMessages` apareció:
+
+- `sanitizedMessages[1].parts[3].output.images[0].data`
+- longitud aproximada: `920992`
+
+En `modelMessages` apareció:
+
+- `modelMessages[2].content[2].output.value.images[0].data`
+- longitud aproximada: `920992`
+
+Además, el `tool result` logueado tiene esta forma:
+
+```json
+{
+  "text": "Took a screenshot of the current page's viewport.\n[Image received from take_screenshot]",
+  "content": [
+    {
+      "type": "text",
+      "text": "Took a screenshot of the current page's viewport."
+    },
+    {
+      "type": "image",
+      "mimeType": "image/png",
+      "omitted": true
+    }
+  ],
+  "images": [
+    {
+      "data": "iVBORw.....",
+      "mediaType": "image/png"
+    }
+  ]
+}
+```
+
+### Qué queda descartado con bastante confianza
+
+A partir de esos logs, ya no parece probable que el problema principal sea alguno de estos:
+
+1. **Base64 colándose como texto vía `content[]` legacy**
+   - `content[]` ya aparece saneado con:
+     - `type: "image"`
+     - `omitted: true`
+   - no se ve el base64 raw ahí.
+
+2. **`resource.blob` o `resource.text` enormes**
+   - el payload dominante detectado está en `images[0].data`.
+
+3. **El output de `skill_execute`**
+   - el skill ocupa ~8921 chars, muy inferior al screenshot.
+
+4. **El prompt del usuario**
+   - ~442 chars, irrelevante comparado con la imagen.
+
+### Hipótesis principal actual
+
+La hipótesis dominante ahora mismo es esta:
+
+**la imagen sí se detecta y se redimensiona, pero en el paso hacia `modelMessages` sigue encapsulada como `output.value.images[0].data` en un `tool-result`, en lugar de estar convertida al formato multimodal final que el provider espera.**
+
+La pista más fuerte es esta ruta de log:
+
+- `modelMessages[2].content[2].output.value.images[0].data`
+
+Eso sugiere que el resultado del tool llega al provider todavía como una estructura JSON parecida a:
+
+```ts
+{
+  text: "...",
+  images: [...]
+}
+```
+
+en lugar de como un resultado multimodal ya materializado, por ejemplo:
+
+```ts
+{
+  type: "content",
+  value: [
+    { type: "text", text: "..." },
+    { type: "image-data", data: "...", mediaType: "image/png" }
+  ]
+}
+```
+
+### Qué significa esto técnicamente
+
+Si esta hipótesis es correcta, entonces el problema ya no estaría en:
+
+- `processToolResult()`
+- `sanitizeToolOutput()`
+- el shape saneado persistible
+
+Sino en uno de estos puntos:
+
+1. `toModelOutput` existe pero no se está ejecutando en el camino real de `convertToModelMessages(...)`.
+2. `convertToModelMessages(...)` no está recibiendo el mapa de tools necesario para aplicar `toModelOutput`.
+3. el `tool-result.output` se está quedando como `json` con `{ text, images }` en lugar de producir `content` con parts multimodales.
+
+### Qué revisar a continuación
+
+La siguiente IA debe comprobar, con logs adicionales o lectura directa del SDK, lo siguiente:
+
+1. En `modelMessages`, para el `tool-result` del screenshot:
+   - `output.type`
+   - `toolName`
+   - estructura completa de `output`
+
+2. Verificar si el `toolName` del `tool-result` coincide exactamente con la key del tool en el mapa `tools`.
+   - el AI SDK necesita encontrar el tool correcto para aplicar `toModelOutput`.
+
+3. Verificar si `convertToModelMessages(...)` se está llamando con:
+   - solo los mensajes, o
+   - mensajes + tools
+
+Si no se pasa el mapa de tools al conversor, esa sería una explicación directa de por qué `toModelOutput` no se aplica.
+
+### Instrumentación temporal sugerida para el siguiente paso
+
+Añadir logs que impriman, para cada `tool-result` en `modelMessages`:
+
+- `toolName`
+- `output.type`
+- keys de `output.value` si `output` es objeto
+- si aparece `images`
+- si aparece `image-data`
+
+Ejemplo de lo que interesa inspeccionar:
+
+```ts
+for (const msg of modelMessages) {
+  if (msg.role !== "tool" || !Array.isArray((msg as any).content)) continue;
+
+  for (const item of (msg as any).content) {
+    if (item?.type !== "tool-result") continue;
+
+    this.logger.aiSdk.info("[CTX_TOOL_RESULT_DIAGNOSTICS]", {
+      toolName: item.toolName,
+      outputType: item.output?.type,
+      outputKeys:
+        item.output && typeof item.output === "object"
+          ? Object.keys(item.output)
+          : null,
+      outputValueKeys:
+        item.output?.value && typeof item.output.value === "object"
+          ? Object.keys(item.output.value)
+          : null,
+      hasImagesArray: Array.isArray(item.output?.value?.images),
+    });
+  }
+}
+```
+
+### Nuevo estado de la investigación
+
+Con la evidencia actual:
+
+- **sí** se ha corregido el leak de base64 textual en `content[]`;
+- **sí** se ha identificado empíricamente que la imagen del screenshot es el payload dominante;
+- **no** está demostrado todavía que el problema restante sea el tamaño visual/dimensional de la imagen;
+- la hipótesis más fuerte ahora es que **`toModelOutput` no está siendo aplicado en el camino real de serialización hacia el provider**.
+
+### Prioridad actual para la siguiente IA
+
+La prioridad ya no es seguir tocando el resizer a ciegas.
+
+La prioridad correcta ahora es:
+
+1. confirmar si `toModelOutput` se aplica o no;
+2. confirmar el `output.type` real del `tool-result` en `modelMessages`;
+3. solo después decidir si el siguiente fix debe ir en:
+   - `convertToModelMessages` / wiring de tools,
+   - `toModelOutput`,
+   - o una segunda reducción de tamaño/dimensiones de imagen.

--- a/docs/HANDOFF_MCP_IMAGE_RESIZE_STATUS.md
+++ b/docs/HANDOFF_MCP_IMAGE_RESIZE_STATUS.md
@@ -26,7 +26,7 @@ Sin embargo, siguen quedando **dos problemas funcionales importantes** y **un pr
 
 El runbook que se intentó implementar es:
 
-- [docs/PLAN_MCP_IMAGE_RESIZE.md](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/docs/PLAN_MCP_IMAGE_RESIZE.md)
+- [docs/PLAN_MCP_IMAGE_RESIZE.md](docs/PLAN_MCP_IMAGE_RESIZE.md)
 
 ## Archivos ya modificados
 
@@ -56,27 +56,27 @@ Estado visible por `git status` / `git diff --stat` durante esta revisión:
 
 Se añadió `sharp` a dependencias:
 
-- [package.json](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/package.json)
+- [package.json](package.json)
 
 Vite lo deja como `external`:
 
-- [vite.main.config.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/vite.main.config.ts:39)
+- [vite.main.config.ts](vite.main.config.ts:39)
 
 Forge copia `sharp` y `@img/*`, y amplía `asar.unpack`:
 
-- [forge.config.js](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/forge.config.js:146)
-- [forge.config.js](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/forge.config.js:188)
+- [forge.config.js](forge.config.js:146)
+- [forge.config.js](forge.config.js:188)
 
 ### 2. Normalización MCP compartida
 
 Existe el helper:
 
-- [src/main/services/mcp/shared/normalizeToolResult.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/shared/normalizeToolResult.ts:1)
+- [src/main/services/mcp/shared/normalizeToolResult.ts](src/main/services/mcp/shared/normalizeToolResult.ts:1)
 
 Y ambos servicios MCP lo usan:
 
-- [src/main/services/mcp/mcpUseService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/mcpUseService.ts:446)
-- [src/main/services/mcp/mcpLegacyService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/mcpLegacyService.ts:211)
+- [src/main/services/mcp/mcpUseService.ts](src/main/services/mcp/mcpUseService.ts:446)
+- [src/main/services/mcp/mcpLegacyService.ts](src/main/services/mcp/mcpLegacyService.ts:211)
 
 Esto corrige el bug original donde `structuredContent` pisaba `content[]`.
 
@@ -84,7 +84,7 @@ Esto corrige el bug original donde `structuredContent` pisaba `content[]`.
 
 Existe el helper compartido:
 
-- [src/shared/toolOutputSanitizer.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/shared/toolOutputSanitizer.ts:1)
+- [src/shared/toolOutputSanitizer.ts](src/shared/toolOutputSanitizer.ts:1)
 
 Contiene:
 
@@ -93,15 +93,15 @@ Contiene:
 
 El renderer ya lo usa al persistir `tool_calls.result`:
 
-- [src/renderer/stores/chatStore.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/renderer/stores/chatStore.ts:507)
+- [src/renderer/stores/chatStore.ts](src/renderer/stores/chatStore.ts:507)
 
 ### 4. Resizer y límites
 
 Se añadieron:
 
-- [src/main/services/image/providerImageLimits.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/providerImageLimits.ts)
-- [src/main/services/image/imageResizer.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageResizer.ts:1)
-- [src/main/services/image/imageValidation.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageValidation.ts:1)
+- [src/main/services/image/providerImageLimits.ts](src/main/services/image/providerImageLimits.ts)
+- [src/main/services/image/imageResizer.ts](src/main/services/image/imageResizer.ts:1)
+- [src/main/services/image/imageValidation.ts](src/main/services/image/imageValidation.ts:1)
 
 ### 5. Integración en `mcpToolsAdapter`
 
@@ -114,9 +114,9 @@ Se añadieron:
 
 Referencias:
 
-- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:487)
-- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:499)
-- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:519)
+- [src/main/services/ai/mcpToolsAdapter.ts](src/main/services/ai/mcpToolsAdapter.ts:487)
+- [src/main/services/ai/mcpToolsAdapter.ts](src/main/services/ai/mcpToolsAdapter.ts:499)
+- [src/main/services/ai/mcpToolsAdapter.ts](src/main/services/ai/mcpToolsAdapter.ts:519)
 
 ### 6. Integración en `aiService`
 
@@ -128,10 +128,10 @@ Referencias:
 
 Referencias:
 
-- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:1156)
-- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:1297)
-- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:2066)
-- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:2109)
+- [src/main/services/aiService.ts](src/main/services/aiService.ts:1156)
+- [src/main/services/aiService.ts](src/main/services/aiService.ts:1297)
+- [src/main/services/aiService.ts](src/main/services/aiService.ts:2066)
+- [src/main/services/aiService.ts](src/main/services/aiService.ts:2109)
 
 ## Problemas pendientes
 
@@ -139,7 +139,7 @@ Referencias:
 
 **Impacto:** alto
 
-En [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:1248), cuando hay `uiResources` o `imageParts`, se hace:
+En [src/main/services/ai/mcpToolsAdapter.ts](src/main/services/ai/mcpToolsAdapter.ts:1248), cuando hay `uiResources` o `imageParts`, se hace:
 
 ```ts
 return sanitizeToolOutput({
@@ -170,9 +170,9 @@ En ese bloque, añadir:
 
 **Impacto:** alto
 
-En [src/main/services/image/imageValidation.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageValidation.ts:89) el comentario dice explícitamente que el safety-net “does not throw”.
+En [src/main/services/image/imageValidation.ts](src/main/services/image/imageValidation.ts:89) el comentario dice explícitamente que el safety-net “does not throw”.
 
-La implementación actual en [imageValidation.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageValidation.ts:107) solo hace `logger.aiSdk.warn(...)`.
+La implementación actual en [imageValidation.ts](src/main/services/image/imageValidation.ts:107) solo hace `logger.aiSdk.warn(...)`.
 
 Eso significa que si una imagen oversized se escapa del pipeline:
 
@@ -202,7 +202,7 @@ Si se cambia a `throw`, revisar también:
 
 - `EPERM: operation not permitted, open '/Users/saulgomezjimenez/levante/levante-2026-04-14.log'`
 
-El origen es que [imageResizer.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageResizer.ts:2) importa el logger real, y durante el test intenta escribir fuera del workspace permitido.
+El origen es que [imageResizer.ts](src/main/services/image/imageResizer.ts:2) importa el logger real, y durante el test intenta escribir fuera del workspace permitido.
 
 **Opciones razonables de corrección:**
 
@@ -254,7 +254,7 @@ Resultado:
 
 ### `validateImagesForAPI.test.ts` está alineado con el comportamiento actual, no con el objetivo final
 
-Los tests actuales de [imageValidation.test.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/__tests__/imageValidation.test.ts:1) verifican que se haga `warn`, no que se lance error.
+Los tests actuales de [imageValidation.test.ts](src/main/services/image/__tests__/imageValidation.test.ts:1) verifican que se haga `warn`, no que se lance error.
 
 Si se cambia `validateImagesForAPI()` para cerrar el fix de verdad, habrá que actualizar estos tests.
 
@@ -262,11 +262,11 @@ Si se cambia `validateImagesForAPI()` para cerrar el fix de verdad, habrá que a
 
 ### Paso 1
 
-Corregir [mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:1248) para preservar `structuredContent` en el objeto que pasa por `sanitizeToolOutput()`.
+Corregir [mcpToolsAdapter.ts](src/main/services/ai/mcpToolsAdapter.ts:1248) para preservar `structuredContent` en el objeto que pasa por `sanitizeToolOutput()`.
 
 ### Paso 2
 
-Cambiar [imageValidation.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/image/imageValidation.ts:96) para que deje de hacer solo logging y bloquee realmente el envío cuando haya payload oversized.
+Cambiar [imageValidation.ts](src/main/services/image/imageValidation.ts:96) para que deje de hacer solo logging y bloquee realmente el envío cuando haya payload oversized.
 
 ### Paso 3
 
@@ -313,7 +313,7 @@ Este bloque se añade después de la primera ronda de correcciones y después de
 
 Los logs se añadieron temporalmente en:
 
-- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts)
+- [src/main/services/aiService.ts](src/main/services/aiService.ts)
 
 ### Qué se observó en producción
 

--- a/docs/PLAN_MCP_CANONICAL_TOOL_RESULTS.md
+++ b/docs/PLAN_MCP_CANONICAL_TOOL_RESULTS.md
@@ -1,0 +1,934 @@
+# Runbook de implementación — Canonicalización de tool results MCP con imágenes
+
+**Fecha:** 2026-04-14  
+**Estado del documento:** listo para implementar  
+**Objetivo:** eliminar el doble formato de resultados de tools MCP con imágenes, evitar persistir base64 en historial y hacer que la misma conversión a formato de modelo se use tanto en ejecución viva como en replay desde historial.
+
+## 1. Principio de ejecución
+
+Este documento es el runbook completo de implementación.  
+Si una tarea no aparece aquí, **no forma parte del trabajo**.
+
+El fix debe cumplir simultáneamente estas condiciones:
+
+1. Un resultado de tool MCP con imágenes se transforma **una sola vez** al entrar al historial.
+2. El historial persistido **no contiene base64 raw** de imágenes MCP.
+3. La conversión a formato para provider/modelo usa **una sola fuente de verdad**.
+4. El replay desde historial y la ejecución viva producen el **mismo `ToolResultOutput` efectivo**.
+5. Los historiales ya persistidos con el formato legacy que aún contenga `images[]` siguen funcionando y se normalizan sin romper conversaciones existentes.
+6. La solución no depende de “arreglar en caliente” el replay con una segunda implementación del resize.
+
+## 2. Diagnóstico verificado en el repositorio
+
+### 2.1. El bug no está en el origen MCP, está en la persistencia y el replay
+
+Hoy `chrome-devtools_take_screenshot` sí entra por `getMCPTools(...)` en:
+
+- `src/main/services/aiService.ts`
+
+Y el adapter MCP sí sabe producir salida multimodal válida para AI SDK en:
+
+- `src/main/services/ai/mcpToolsAdapter.ts`
+
+`createAISDKTool(...).toModelOutput(...)` ya convierte el formato transitorio rico actual a:
+
+```ts
+{
+  type: "content",
+  value: [
+    { type: "text", text: "..." },
+    { type: "image-data", data: "...", mediaType: "image/png" },
+  ],
+}
+```
+
+### 2.2. El replay actual esquiva `toModelOutput()`
+
+En `aiService` se llama hoy:
+
+```ts
+const modelMessages = await convertToModelMessages(sanitizedMessages);
+```
+
+sin pasar `options.tools`.
+
+Eso hace que `convertToModelMessages()` no use `tool.toModelOutput(...)` para los `tool-result` históricos y caiga al fallback string/json del AI SDK.
+
+Archivo afectado:
+
+- `src/main/services/aiService.ts`
+
+### 2.3. El historial sigue guardando imágenes raw en `tool_calls`
+
+Hoy el renderer persiste:
+
+- `part.output` casi tal cual
+- solo limpia `content[].image`
+- **no limpia `images[].data`**
+
+Esto ocurre en:
+
+- `src/renderer/stores/chatStore.ts`
+- `src/shared/toolOutputSanitizer.ts`
+
+Efecto:
+
+1. la DB puede contener base64 enorme;
+2. al rehidratar mensajes desde DB, ese payload vuelve a `part.output`;
+3. el siguiente turno puede reinyectarlo al modelo.
+
+### 2.4. La rehidratación desde DB reconstruye `tool-{name}` genérico
+
+Al leer historial, `chatStore` hace:
+
+```ts
+parts.push({
+  type: `tool-${tc.name}`,
+  toolCallId: tc.id,
+  toolName: tc.name,
+  input: tc.arguments,
+  output: tc.result,
+  state: 'output-available',
+});
+```
+
+Archivo afectado:
+
+- `src/renderer/stores/chatStore.ts`
+
+Esto es válido como contenedor UI, pero exige que `tc.result` ya sea un formato persistido limpio y canónico.
+
+### 2.5. La raíz del problema es la coexistencia de dos formatos
+
+Hoy conviven estos dos formatos:
+
+1. **Formato transitorio de ejecución viva del adapter MCP**: objeto rico con texto y lista derivada de imágenes.
+2. **Formato persistido/replayado**: `tool-{name}` genérico con `output` serializado.
+
+El adapter MCP solo actúa en la ruta viva.  
+El replay usa el `output` persistido como fuente y por eso reinyecta base64.
+
+## 3. Decisión de diseño
+
+La implementación correcta para Levante será esta:
+
+1. **Introducir un formato canónico interno de tool result persistido**.
+2. **Persistir imágenes MCP a disco por handle determinista**, no en `tool_calls`.
+3. **Hacer que `toModelOutput()` sea la única fuente de verdad** para convertir el resultado canónico a `ToolResultOutput`.
+4. **Pasar siempre `tools` a `convertToModelMessages(...)`**, para que el replay use el mismo `toModelOutput()` que la ejecución viva.
+5. **Mantener compatibilidad temporal con outputs legacy que aún contengan `images[]`**, pero solo como lectura/transición.
+6. **Eliminar `images[]` del formato nuevo**, tanto en persistencia como en el contrato interno compartido.
+7. **Normalizar perezosamente** historiales legacy al leerlos y al volver a persistirlos.
+
+Consecuencia de diseño:
+
+- `images[]` deja de existir como salida nueva de `processToolResult()`.
+- `images[]` deja de existir como contrato compartido entre main, renderer y replay.
+- solo se acepta como forma legacy de entrada durante la migración.
+
+### 3.1. Qué NO se va a hacer
+
+No se va a:
+
+- reimplementar resize en `sanitizeMessagesForModel()`;
+- mantener `images[]` como formato nuevo del proyecto;
+- hacer un “si aparece una lista legacy de imágenes entonces convierto a image-data aquí mismo” duplicando lógica;
+- persistir `ContentBlockParam[]` provider-específico;
+- guardar rutas absolutas o base64 raw en DB.
+
+## 4. Formato canónico exacto
+
+Se añade un formato versionado y provider-agnostic:
+
+**Archivo nuevo:**
+
+- `src/shared/canonicalToolResult.ts`
+
+```ts
+export const CANONICAL_TOOL_RESULT_VERSION = 1 as const;
+
+export interface CanonicalImageAssetRef {
+  kind: "image-ref";
+  assetId: string;          // sha256 estable
+  mediaType: string;        // image/png, image/jpeg...
+  byteSize: number;         // bytes reales del fichero
+  base64Length: number;     // tamaño equivalente si se rehidrata
+  sha256: string;
+  width?: number;
+  height?: number;
+}
+
+export type CanonicalToolModelPart =
+  | {
+      type: "text";
+      text: string;
+    }
+  | CanonicalImageAssetRef;
+
+export type CanonicalToolModelOutput =
+  | {
+      type: "text";
+      value: string;
+    }
+  | {
+      type: "json";
+      value: unknown;
+    }
+  | {
+      type: "content";
+      value: CanonicalToolModelPart[];
+    };
+
+export interface CanonicalToolResultV1 {
+  __levanteToolResult: 1;
+  text?: string; // resumen para UI / fallback sin visión
+  structuredContent?: Record<string, unknown>;
+  uiResources?: unknown[];
+  content?: unknown[]; // content[] saneado, nunca base64 raw
+  modelOutput: CanonicalToolModelOutput;
+}
+```
+
+### 4.1. Invariantes del formato canónico
+
+1. `modelOutput` es la representación semántica canónica del resultado.
+2. `content` solo existe para compatibilidad/render/widget y jamás lleva base64 raw.
+3. `uiResources` sigue disponible para widgets.
+4. Las imágenes no viajan como `images[].data` persistido.
+5. `images[]` queda prohibido como salida nueva; solo puede aparecer como input legacy a migrar.
+6. El único lugar donde reaparece base64 de imagen es en la materialización final a `image-data` para el provider.
+7. `text` es siempre fallback útil para UI y modelos sin visión.
+
+## 5. Alcance exacto
+
+### 5.1. Archivos nuevos
+
+- `docs/PLAN_MCP_CANONICAL_TOOL_RESULTS.md`
+- `src/shared/canonicalToolResult.ts`
+- `src/main/services/toolResults/toolResultAssetStore.ts`
+- `src/main/services/toolResults/canonicalToolResultService.ts`
+- `src/main/services/toolResults/historicalToolReplayTools.ts`
+- `src/main/services/toolResults/__tests__/toolResultAssetStore.test.ts`
+- `src/main/services/toolResults/__tests__/canonicalToolResultService.test.ts`
+- `src/main/services/ai/__tests__/historicalToolReplay.test.ts`
+
+### 5.2. Archivos modificados
+
+- `src/main/services/ai/mcpToolsAdapter.ts`
+- `src/main/services/ai/toolMessageSanitizer.ts`
+- `src/main/services/aiService.ts`
+- `src/main/services/chatService.ts`
+- `src/types/database.ts`
+- `src/renderer/stores/chatStore.ts`
+- `src/shared/toolOutputSanitizer.ts`
+- `src/main/services/compactionService.ts`
+- `src/main/services/ai/__tests__/mcpToolsAdapter.image.test.ts`
+- `src/main/services/ai/__tests__/toolMessageSanitizer.test.ts`
+
+### 5.3. Fuera de alcance
+
+- migración SQL de esquema: `tool_calls` sigue siendo `TEXT`;
+- rediseño de widgets MCP-UI;
+- preview visual de screenshots en chat;
+- migración offline de toda la base histórica en una sola pasada al arrancar.
+
+## 6. Estrategia general de implementación
+
+La solución tendrá cuatro capas:
+
+1. **Canonicalización** del resultado rico en main.
+2. **Persistencia a disco** de imágenes por handle.
+3. **Materialización a `ToolResultOutput`** con un helper único.
+4. **Replay con `convertToModelMessages(..., { tools })`** usando tools reales o adapters históricos.
+
+## 7. Paso a paso
+
+### Paso 1 — Añadir el schema canónico compartido
+
+**Archivo nuevo:**
+
+- `src/shared/canonicalToolResult.ts`
+
+**Implementar:**
+
+1. Tipos `CanonicalToolResultV1`, `CanonicalImageAssetRef`, `CanonicalToolModelOutput`.
+2. Guards:
+
+```ts
+export function isCanonicalToolResult(value: unknown): value is CanonicalToolResultV1;
+export function isCanonicalImageRef(value: unknown): value is CanonicalImageAssetRef;
+```
+
+3. Helpers de legacy:
+
+```ts
+export function looksLikeLegacyRichToolOutput(value: unknown): boolean;
+export function extractLegacyImages(value: unknown): Array<{ data: string; mediaType: string }>;
+```
+
+**Objetivo:** que todo el código deje de adivinar por forma informal si un output es canónico o legacy.
+
+### Paso 2 — Crear el store de assets para imágenes MCP
+
+**Archivo nuevo:**
+
+- `src/main/services/toolResults/toolResultAssetStore.ts`
+
+**Responsabilidad:**
+
+- persistir bytes redimensionados a disco con nombre determinista;
+- leerlos para rehidratación;
+- borrar assets huérfanos conocidos.
+
+**Ubicación en disco:**
+
+```ts
+app.getPath("userData") + "/tool-result-assets/images"
+```
+
+**API a implementar:**
+
+```ts
+export interface PersistedImageAsset {
+  assetId: string; // sha256
+  sha256: string;
+  mediaType: string;
+  byteSize: number;
+  base64Length: number;
+  width?: number;
+  height?: number;
+}
+
+export async function persistImageAsset(params: {
+  dataBase64: string;
+  mediaType: string;
+}): Promise<PersistedImageAsset>;
+
+export async function readImageAsset(params: {
+  assetId: string;
+  mediaType: string;
+}): Promise<{ dataBase64: string; mediaType: string }>;
+
+export async function deleteImageAssetsIfUnused(assetIds: string[]): Promise<void>;
+```
+
+**Reglas obligatorias:**
+
+1. usar `sha256(bytes)` como `assetId`;
+2. escribir con `flag: "wx"` o estrategia equivalente idempotente;
+3. no guardar path absoluto en DB;
+4. deduplicar automáticamente si ya existe el asset;
+5. mapear extensión a partir de `mediaType`.
+
+### Paso 3 — Crear el servicio único de canonicalización y materialización
+
+**Archivo nuevo:**
+
+- `src/main/services/toolResults/canonicalToolResultService.ts`
+
+**Responsabilidad:**
+
+1. convertir outputs ricos legacy a formato canónico;
+2. materializar formato canónico a `ToolResultOutput`;
+3. mantener compatibilidad de lectura con outputs legacy que aún tengan `images[]`.
+
+**API a implementar:**
+
+```ts
+import type { ToolResultOutput } from "@ai-sdk/provider-utils";
+import type { CanonicalToolResultV1 } from "../../../shared/canonicalToolResult";
+
+export async function canonicalizeRichToolOutput(params: {
+  text?: string;
+  structuredContent?: Record<string, unknown>;
+  uiResources?: unknown[];
+  content?: unknown[];
+  legacyImages?: Array<{ data: string; mediaType: string }>;
+}): Promise<CanonicalToolResultV1>;
+
+export async function normalizeToolCallResultForStorage(
+  value: unknown,
+): Promise<{ normalized: unknown; changed: boolean; assetIds: string[] }>;
+
+export async function materializeToolResultForModel(params: {
+  output: unknown;
+  supportsVision: boolean;
+}): Promise<ToolResultOutput>;
+```
+
+**Reglas de `materializeToolResultForModel(...)`:**
+
+1. Si el output es canónico con `modelOutput.type === "content"` y `supportsVision === true`:
+
+```ts
+return {
+  type: "content",
+  value: [
+    { type: "text", text: "..." },
+    { type: "image-data", data: "...", mediaType: "image/png" },
+  ],
+};
+```
+
+2. Si es canónico y `supportsVision === false`:
+
+```ts
+return {
+  type: "text",
+  value: output.text || "[Tool returned images, but the active model does not support vision.]",
+};
+```
+
+3. Si el output es legacy y aún trae `images[]`, convertirlo temporalmente con la misma semántica.
+4. Si es `structuredContent`/`json`, devolver `type: "json"`.
+5. Si es string, devolver `type: "text"`.
+
+**Importante:**  
+La compatibilidad legacy solo materializa.  
+La canonicalización/storage debe reescribir legacy a canónico cuando toque persistir.
+
+### Paso 4 — Cambiar `mcpToolsAdapter` para producir formato canónico
+
+**Archivo modificado:**
+
+- `src/main/services/ai/mcpToolsAdapter.ts`
+
+**Cambios obligatorios:**
+
+1. Dejar de devolver cualquier objeto nuevo que exponga `images[]`.
+2. Después de construir `text`, `uiResources`, `structuredContent`, `content` saneado e `imageParts`, llamar a:
+
+```ts
+return await canonicalizeRichToolOutput({
+  text,
+  content: result.content,
+  structuredContent: result.structuredContent,
+  ...(uiResources.length > 0 ? { uiResources } : {}),
+  ...(imageParts.length > 0 ? { legacyImages: imageParts } : {}),
+});
+```
+
+3. Reemplazar la lógica actual de `toModelOutput(...)` por delegación al helper único:
+
+```ts
+toModelOutput: async ({ output }) => {
+  return materializeToolResultForModel({
+    output,
+    supportsVision,
+  });
+},
+```
+
+4. Mantener el TODO de budget fuera de este PR solo si no se toca; si se mantiene, documentarlo como deuda separada y no mezclarlo con esta implementación.
+
+**Resultado esperado:**
+
+- la ejecución viva y el replay usan la misma ruta de materialización;
+- `processToolResult()` deja de emitir base64 persistible.
+
+### Paso 5 — Hacer que `convertToModelMessages()` use realmente las tools
+
+**Archivo modificado:**
+
+- `src/main/services/aiService.ts`
+
+**Cambios obligatorios:**
+
+Reemplazar:
+
+```ts
+const modelMessages = await convertToModelMessages(sanitizedMessages);
+```
+
+por:
+
+```ts
+const replayTools = await buildHistoricalReplayTools({
+  messages: sanitizedMessages,
+  liveTools: tools,
+  supportsVision: modelInfo?.capabilities?.supportsVision === true,
+});
+
+const modelMessages = await convertToModelMessages(sanitizedMessages, {
+  tools: replayTools,
+});
+```
+
+Y análogamente en `sendSingleMessage(...)`:
+
+```ts
+const singleMsgReplayTools = await buildHistoricalReplayTools({
+  messages: singleMsgSanitized,
+  liveTools: allSingleMsgTools,
+  supportsVision: modelInfo?.capabilities?.supportsVision === true,
+});
+
+const singleMsgModelMessages = await convertToModelMessages(singleMsgSanitized, {
+  tools: singleMsgReplayTools,
+});
+```
+
+### Paso 6 — Añadir adapters históricos para tools ausentes
+
+**Archivo nuevo:**
+
+- `src/main/services/toolResults/historicalToolReplayTools.ts`
+
+**Motivación:**
+
+Si un historial contiene un tool result canónico pero la tool ya no está disponible, `convertToModelMessages(..., { tools })` no podrá llamar al `toModelOutput()` original.
+
+**API:**
+
+```ts
+export async function buildHistoricalReplayTools(params: {
+  messages: Array<{ role: string; parts?: unknown[] }>;
+  liveTools: Record<string, any>;
+  supportsVision: boolean;
+}): Promise<Record<string, any>>;
+```
+
+**Comportamiento:**
+
+1. clonar `liveTools`;
+2. escanear `messages` buscando `tool-*` / `tool-invocation` con `output-available`;
+3. si `toolName` no existe en `liveTools` y el output es canónico o legacy rico, registrar un adapter mínimo:
+
+```ts
+tools[toolName] = {
+  type: "dynamic",
+  description: "Historical tool replay adapter",
+  inputSchema: jsonSchema({ type: "object", additionalProperties: true }),
+  async toModelOutput({ output }) {
+    return materializeToolResultForModel({
+      output,
+      supportsVision: params.supportsVision,
+    });
+  },
+};
+```
+
+**Objetivo:**  
+Que el replay no dependa de que la tool MCP siga conectada para reconstruir outputs históricos.
+
+### Paso 7 — Reducir `toolMessageSanitizer` a limpieza, no transformación semántica
+
+**Archivo modificado:**
+
+- `src/main/services/ai/toolMessageSanitizer.ts`
+
+**Cambio de criterio:**
+
+`sanitizeMessagesForModel()` ya no debe “interpretar” imágenes.  
+Su trabajo será:
+
+1. normalizar estados de tool (`approval-requested`, `output-error`, etc.);
+2. retirar `providerMetadata` problemática;
+3. preservar `CanonicalToolResultV1` intacto;
+4. dejar compatibilidad legacy mínima sin introducir una segunda ruta semántica.
+
+**Cambios obligatorios:**
+
+1. Si `part.output` es canónico, **devolverlo sin modificar**.
+2. Si `part.output` es legacy con `uiResources` o `images[]`, mantener solo una ruta de compatibilidad temporal:
+   - conservar `text`;
+   - conservar `structuredContent`;
+   - conservar `uiResources`;
+   - no producir ni persistir un formato nuevo con `images[]`;
+   - **no** inventar `image-data` aquí.
+3. Añadir comentario explícito:
+
+```ts
+// IMPORTANT:
+// Tool output semantic conversion happens in materializeToolResultForModel()
+// via tool.toModelOutput(). This sanitizer must not duplicate image handling.
+```
+
+### Paso 8 — Mover la normalización persistida al main process
+
+**Archivo modificado:**
+
+- `src/main/services/chatService.ts`
+
+**Objetivo:**  
+Garantizar que la DB nunca guarde nuevo base64 raw aunque un caller siga enviando formato legacy.
+
+**Cambios obligatorios en `createMessage(...)`:**
+
+Antes de `JSON.stringify(input.tool_calls)`:
+
+```ts
+const normalizedToolCalls = input.tool_calls
+  ? await normalizeToolCallsForStorage(input.tool_calls)
+  : null;
+```
+
+Y persistir `normalizedToolCalls.value`.
+
+**Cambios obligatorios en `updateMessage(...)`:**
+
+1. normalizar `tool_calls` nuevos;
+2. calcular assets candidatos a borrar comparando old/new;
+3. tras update, borrar assets ya no referenciados si quedaron huérfanos.
+
+**Cambios obligatorios en `getMessages(...)` y `searchMessages(...)`:**
+
+1. parsear `tool_calls`;
+2. si contienen formato legacy rico, normalizarlos a canónico;
+3. reescribir la fila en DB si hubo cambios;
+4. devolver al renderer el JSON ya reescrito.
+
+**Importante:**  
+Esto sustituye la necesidad de una migración SQL/DDL.  
+La migración será **lazy, idempotente y en main process**.
+
+### Paso 9 — Ajustar tipos de DB
+
+**Archivo modificado:**
+
+- `src/types/database.ts`
+
+**Cambios obligatorios:**
+
+Introducir tipos explícitos para `tool_calls`:
+
+```ts
+export interface PersistedToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+  result?: unknown;
+  status: string;
+}
+
+export interface CreateMessageInput {
+  ...
+  tool_calls?: PersistedToolCall[] | null;
+}
+
+export interface UpdateMessageInput {
+  ...
+  tool_calls?: PersistedToolCall[];
+}
+```
+
+**Objetivo:**  
+Dejar de tratar `tool_calls` como `object[]` sin contrato.
+
+### Paso 10 — Ajustar persistencia en renderer para no volver a mutar el formato canónico
+
+**Archivo modificado:**
+
+- `src/renderer/stores/chatStore.ts`
+
+**Cambios obligatorios:**
+
+1. Al persistir `tool_calls`, si `part.output` es canónico, guardarlo tal cual.
+2. Mantener `sanitizeToolOutput(...)` solo como compatibilidad para outputs legacy no canónicos.
+3. Añadir comentario:
+
+```ts
+// New rich tool results are canonicalized in main before hitting the DB.
+// Renderer must not re-shape canonical outputs or reintroduce inline base64.
+```
+
+4. En la rehidratación desde DB, seguir reconstruyendo:
+
+```ts
+{
+  type: `tool-${tc.name}`,
+  ...
+  output: tc.result,
+}
+```
+
+sin reinterpretar el contenido. El `output` ya debe venir limpio/canónico desde `chatService`.
+
+### Paso 11 — Mantener `toolOutputSanitizer.ts` solo para compatibilidad legacy
+
+**Archivo modificado:**
+
+- `src/shared/toolOutputSanitizer.ts`
+
+**Cambios obligatorios:**
+
+1. Mantener `stripInlineImagesFromContent(...)`.
+2. Documentar `sanitizeToolOutput(...)` como helper legacy/transicional.
+3. No usar `sanitizeToolOutput(...)` como formato persistido nuevo.
+
+**Comentario a añadir:**
+
+```ts
+// Legacy helper:
+// kept only to neutralize old raw MCP content[] image blocks.
+// New rich tool outputs must use CanonicalToolResultV1 instead.
+```
+
+### Paso 12 — Revisión mínima de compaction
+
+**Archivo modificado:**
+
+- `src/main/services/compactionService.ts`
+
+**Cambio requerido:**
+
+No cambiar la estrategia de compaction, pero sí asegurar que la serialización no vuelva a expandir payloads.
+
+Añadir un helper:
+
+```ts
+function summarizeToolCallsForCompaction(toolCallsJson: string): string
+```
+
+Reglas:
+
+1. Si detecta `CanonicalToolResultV1` con `image-ref`, serializar una forma breve:
+   - tool name
+   - `text`
+   - número de imágenes
+2. Nunca reinyectar bytes ni base64.
+
+**Motivo:**  
+Evitar que el contexto de compaction vuelva a inflarse por el JSON completo del resultado canónico.
+
+### Paso 13 — Actualizar diagnósticos de contexto
+
+**Archivo modificado:**
+
+- `src/main/services/aiService.ts`
+
+**Cambio requerido:**
+
+Ampliar `collectImagePayloads(...)` para distinguir:
+
+1. `tool-images` legacy con base64;
+2. `tool-image-ref` canónico sin base64.
+
+**Objetivo:**  
+Que los logs posteriores permitan comprobar visualmente que:
+
+- ya no aparecen `output.images[].data` en flujos nuevos;
+- sí aparecen `image-ref` con `assetId`.
+
+## 8. Código exacto a introducir en los puntos críticos
+
+### 8.1. Forma final de `toModelOutput()` en `mcpToolsAdapter`
+
+```ts
+toModelOutput: async ({ output }) => {
+  return materializeToolResultForModel({
+    output,
+    supportsVision,
+  });
+},
+```
+
+### 8.2. Forma final de `convertToModelMessages()` en `aiService`
+
+```ts
+const replayTools = await buildHistoricalReplayTools({
+  messages: sanitizedMessages,
+  liveTools: tools,
+  supportsVision: modelInfo?.capabilities?.supportsVision === true,
+});
+
+const modelMessages = await convertToModelMessages(sanitizedMessages, {
+  tools: replayTools,
+});
+```
+
+### 8.3. Forma final del resultado rico persistido
+
+```ts
+{
+  __levanteToolResult: 1,
+  text: "Took a screenshot of the current page's viewport.",
+  content: [
+    { type: "text", text: "Took a screenshot of the current page's viewport." },
+    { type: "image", mimeType: "image/png", omitted: true },
+  ],
+  modelOutput: {
+    type: "content",
+    value: [
+      { type: "text", text: "Took a screenshot of the current page's viewport." },
+      {
+        kind: "image-ref",
+        assetId: "8d1c...",
+        mediaType: "image/png",
+        byteSize: 690744,
+        base64Length: 920992,
+        sha256: "8d1c...",
+        width: 1568,
+        height: 876,
+      },
+    ],
+  },
+}
+```
+
+### 8.4. Forma final materializada para el modelo
+
+```ts
+{
+  type: "content",
+  value: [
+    { type: "text", text: "Took a screenshot of the current page's viewport." },
+    { type: "image-data", data: "<rehydrated-base64>", mediaType: "image/png" },
+  ],
+}
+```
+
+## 9. Compatibilidad hacia atrás
+
+### 9.1. Historial legacy ya existente
+
+Debe seguir funcionando sin migración destructiva.
+
+Ruta obligatoria:
+
+1. `chatService.getMessages()` detecta rows legacy;
+2. las canonicaliza si puede;
+3. reescribe la row;
+4. devuelve ya el formato nuevo.
+
+### 9.2. Si el tool ya no existe
+
+`buildHistoricalReplayTools(...)` debe crear un adapter histórico mínimo para el replay.
+
+### 9.3. Si un output legacy aparece en memoria antes de persistirse
+
+`materializeToolResultForModel()` debe soportar temporalmente outputs legacy que aún incluyan `images[]`.
+
+## 10. Gestión de orfandad de assets
+
+Para no dejar deuda técnica, esta implementación debe incluir limpieza básica.
+
+### 10.1. Casos a cubrir
+
+1. update de mensaje que reemplaza `tool_calls`;
+2. borrado de mensajes tras edición;
+3. borrado de sesión;
+4. migración lazy de rows legacy.
+
+### 10.2. Estrategia
+
+1. extraer `assetId`s antes y después del cambio;
+2. calcular diferencia candidata;
+3. comprobar si siguen referenciados en alguna otra row;
+4. borrar solo los no referenciados.
+
+**Nota:** no hace falta un GC global en este PR si estos cuatro casos quedan cubiertos.
+
+## 11. Tests obligatorios
+
+### 11.1. `toolResultAssetStore.test.ts`
+
+Casos:
+
+1. persiste asset nuevo y devuelve metadata correcta;
+2. segunda escritura con mismo contenido reutiliza el mismo `assetId`;
+3. `readImageAsset()` rehidrata el mismo base64;
+4. `deleteImageAssetsIfUnused()` no borra si sigue referenciado;
+5. borra si ya no existe referencia.
+
+### 11.2. `canonicalToolResultService.test.ts`
+
+Casos:
+
+1. `canonicalizeRichToolOutput()` convierte un output legacy con `images[]` en `CanonicalToolResultV1`;
+2. `materializeToolResultForModel()` devuelve `image-data` con visión;
+3. degrada a `text` sin visión;
+4. soporta input legacy con `images[]`;
+5. soporta output canónico ya persistido sin cambiarlo.
+
+### 11.3. `mcpToolsAdapter.image.test.ts`
+
+Actualizar para verificar:
+
+1. `processToolResult()` ya no devuelve `images[]` raw;
+2. devuelve `CanonicalToolResultV1`;
+3. `toModelOutput()` sigue produciendo `image-data`.
+
+### 11.4. `historicalToolReplay.test.ts`
+
+Nuevo test end-to-end mínimo:
+
+1. construir `UIMessage` con part `tool-screenshot` y output canónico;
+2. pasar por `sanitizeMessagesForModel()`;
+3. llamar `convertToModelMessages(..., { tools: replayTools })`;
+4. verificar que el `tool-result.output.type === "content"` y contiene `image-data`.
+
+### 11.5. `toolMessageSanitizer.test.ts`
+
+Actualizar para verificar:
+
+1. output canónico se preserva intacto;
+2. no reescribe `image-ref`;
+3. la compatibilidad legacy sigue funcionando temporalmente.
+
+### 11.6. `chatService` / persistencia
+
+Añadir tests o cobertura equivalente para:
+
+1. `createMessage()` canonicaliza antes de guardar;
+2. `getMessages()` reescribe rows legacy;
+3. `updateMessage()` libera assets huérfanos.
+
+### 11.7. Verificación manual obligatoria
+
+1. conversación nueva con `chrome-devtools_take_screenshot`;
+2. enviar un segundo prompt en la misma conversación;
+3. confirmar en logs:
+   - no aparece `output.images[0].data`;
+   - sí aparece `tool-image-ref` o equivalente;
+4. recargar la conversación desde DB;
+5. reenviar otro prompt;
+6. confirmar que el replay sigue generando `image-data` en `modelMessages`.
+
+## 12. Criterios de aceptación
+
+El trabajo se considera cerrado solo si se cumplen todos:
+
+1. No se persiste base64 raw de imágenes MCP en `messages.tool_calls`.
+2. El replay usa `tool.toModelOutput()` real o adapter histórico equivalente.
+3. `convertToModelMessages()` recibe `tools` en streaming y en `sendSingleMessage()`.
+4. Las imágenes históricas entran al provider como `image-data`, no como JSON con base64.
+5. Los historiales legacy siguen funcionando.
+6. Los widgets MCP-UI siguen renderizando `uiResources`.
+7. No se generan assets huérfanos al editar/borrar mensajes.
+8. Los tests nuevos y existentes relevantes pasan.
+
+## 13. Orden de implementación recomendado
+
+Implementar en este orden exacto:
+
+1. `src/shared/canonicalToolResult.ts`
+2. `src/main/services/toolResults/toolResultAssetStore.ts`
+3. `src/main/services/toolResults/canonicalToolResultService.ts`
+4. `src/main/services/ai/mcpToolsAdapter.ts`
+5. `src/main/services/toolResults/historicalToolReplayTools.ts`
+6. `src/main/services/aiService.ts`
+7. `src/main/services/chatService.ts`
+8. `src/types/database.ts`
+9. `src/renderer/stores/chatStore.ts`
+10. `src/main/services/ai/toolMessageSanitizer.ts`
+11. `src/shared/toolOutputSanitizer.ts`
+12. `src/main/services/compactionService.ts`
+13. tests unitarios
+14. verificación manual con screenshot real
+
+## 14. Resultado esperado final
+
+Tras este cambio, el flujo será:
+
+1. MCP devuelve imagen inline.
+2. `processToolResult()` redimensiona y canonicaliza.
+3. la imagen se guarda en disco por `assetId`.
+4. el historial persiste solo el resultado canónico.
+5. el renderer rehidrata ese resultado sin tocarlo.
+6. `aiService` llama `convertToModelMessages(..., { tools })`.
+7. `toModelOutput()` materializa desde handle a `image-data`.
+8. el provider recibe multimodalidad real, no base64 embebido en JSON.
+
+Ese es el criterio arquitectónico del fix:  
+**un único formato persistido limpio, una única materialización al modelo, cero base64 raw en historial.**

--- a/docs/PLAN_MCP_IMAGE_RESIZE.md
+++ b/docs/PLAN_MCP_IMAGE_RESIZE.md
@@ -1,0 +1,1007 @@
+# Runbook de implementación — Resize y entrega multimodal de imágenes MCP
+
+**Fecha:** 2026-04-14  
+**Estado del documento:** corregido y listo para implementar  
+**Objetivo:** evitar errores `prompt too long` y pérdida de multimodalidad cuando un tool MCP devuelve imágenes inline grandes, sin dejar trabajo implícito fuera de este plan.
+
+## 1. Principio de ejecución
+
+Este documento es el runbook completo de implementación.  
+Si una tarea no aparece aquí, **no se considera parte del trabajo**.
+
+El fix debe cubrir estos casos:
+
+1. Tools MCP estándar que devuelven bloques `content[]` con imágenes inline.
+2. Conversaciones nuevas y recargadas desde historial persistido.
+3. Ambos backends MCP soportados por Levante:
+   - `mcp-use`
+   - `official-sdk`
+4. Ejecución con `streamText()` y con `generateText()`.
+5. Entorno empaquetado Electron + Forge + Vite.
+
+## 2. Diagnóstico verificado en el repositorio
+
+### 2.1. El problema real en `mcpToolsAdapter`
+
+En [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts:963), `processToolResult()`:
+
+1. No tiene rama específica para `item.type === "image"`.
+2. Cualquier bloque desconocido cae en el `else` final y se serializa con `JSON.stringify(...)`.
+3. Si el bloque contiene base64, ese base64 termina convertido en texto para el modelo.
+
+Efecto actual:
+
+- el modelo no recibe la imagen como imagen;
+- el prompt crece con el base64 embebido;
+- la petición puede fallar por contexto excesivo.
+
+### 2.2. `toolMessageSanitizer` no preserva imágenes útiles
+
+En [src/main/services/ai/toolMessageSanitizer.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/toolMessageSanitizer.ts:121), el sanitizer:
+
+- solo trata explícitamente outputs con `uiResources`;
+- reconstruye texto útil desde `content[]`;
+- no tiene ruta explícita para preservar un payload `images` pensado para `toModelOutput`.
+
+Efecto actual:
+
+- si empezamos a devolver imágenes procesadas en `part.output`, hay que preservar esa forma;
+- si no, la recarga histórica romperá la multimodalidad.
+
+### 2.3. Ambos servicios MCP pisan `content` cuando existe `structuredContent`
+
+En [src/main/services/mcp/mcpUseService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/mcpUseService.ts:446) y [src/main/services/mcp/mcpLegacyService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/mcpLegacyService.ts:211), si existe `structuredContent`:
+
+- se reemplaza `content` por un único bloque `text` con `JSON.stringify(structuredContent)`.
+
+Eso es incorrecto para este fix porque:
+
+1. puede ocultar imágenes o recursos embebidos presentes en `content[]`;
+2. impide que `processToolResult()` vea el resultado MCP real;
+3. afecta tanto a `mcp-use` como a `official-sdk`.
+
+### 2.4. La persistencia actual guardaría demasiado payload
+
+En [src/renderer/stores/chatStore.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/renderer/stores/chatStore.ts:500), el store persiste `part.output` entero dentro de `tool_calls.result`.
+
+Si implementamos solo `images` comprimidas pero mantenemos `content` original con base64:
+
+- guardaríamos la imagen original gigante;
+- además guardaríamos la imagen ya comprimida;
+- duplicaríamos tamaño en DB y en memoria;
+- el historial seguiría siendo peligroso.
+
+### 2.5. El empaquetado de `sharp` no está resuelto con tocar solo `asar.unpack`
+
+Levante usa:
+
+- `vite.main.config.ts` con `rollupOptions.external` ([vite.main.config.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/vite.main.config.ts:23));
+- `forge.config.js` con copia manual de dependencias externas en `packageAfterCopy` ([forge.config.js](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/forge.config.js:16)).
+
+Por tanto, añadir `sharp` a `package.json` no basta. Hay que decidir y documentar explícitamente:
+
+1. si `sharp` será `external` en Vite;
+2. cómo se copiarán `sharp` y `@img/*` al paquete;
+3. cómo quedará `asar.unpack`.
+
+### 2.6. El contrato correcto del AI SDK ya está disponible y hay que usarlo bien
+
+La versión instalada es `ai@6.0.105` ([package.json](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/package.json:81)).
+
+Según el SDK local:
+
+- `toModelOutput` recibe `{ toolCallId, input, output }` ([node_modules/@ai-sdk/provider-utils/src/types/tool.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/node_modules/@ai-sdk/provider-utils/src/types/tool.ts:191));
+- el content part correcto para imagen inline es `type: "image-data"` ([node_modules/@ai-sdk/provider-utils/src/types/content-part.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/node_modules/@ai-sdk/provider-utils/src/types/content-part.ts:311));
+- `type: "media"` existe, pero está deprecado ([node_modules/@ai-sdk/provider-utils/src/types/content-part.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/node_modules/@ai-sdk/provider-utils/src/types/content-part.ts:246)).
+
+## 3. Decisión de diseño
+
+La implementación correcta será esta:
+
+1. **Preservar `content[]` original** en los servicios MCP cuando exista.
+   - `structuredContent` se sigue conservando aparte.
+   - Solo se sintetiza texto desde `structuredContent` cuando `content` no exista o llegue vacío.
+
+2. **Redimensionar imágenes MCP solo en el main process**.
+   - Se usará `sharp`.
+   - El resizer opera sobre bloques `{ type: "image", data, mimeType }`.
+
+3. **Entregar las imágenes al modelo como resultado multimodal de tool**.
+   - Se usará `toModelOutput`.
+   - El part será `image-data`.
+
+4. **Persistir solo output saneado**.
+   - Nunca guardar en DB el bloque raw de imagen grande si ya existe una versión comprimida.
+   - El historial debe contener una representación segura y rehidratable.
+
+5. **Aplicar un safety-net pre-request**.
+   - Debe cubrir:
+     - imágenes en outputs de tools;
+     - imágenes de usuario en `file/url` con data URLs base64.
+
+6. **Degradar limpiamente en modelos sin visión**.
+   - Si el modelo activo no soporta visión, el output para modelo debe convertirse a texto placeholder.
+   - La UI e historial pueden seguir mostrando el resultado saneado.
+
+## 4. Alcance exacto de implementación
+
+### 4.1. En alcance
+
+- `package.json`
+- `vite.main.config.ts`
+- `forge.config.js`
+- `src/main/types/mcp.ts`
+- `src/main/services/mcp/mcpUseService.ts`
+- `src/main/services/mcp/mcpLegacyService.ts`
+- `src/main/services/mcp/shared/normalizeToolResult.ts` (nuevo, helper compartido)
+- `src/main/services/image/providerImageLimits.ts` (antes `apiLimits.ts`)
+- `src/main/services/image/imageResizer.ts`
+- `src/main/services/image/imageValidation.ts`
+- `src/main/services/ai/mcpToolsAdapter.ts`
+- `src/shared/toolOutputSanitizer.ts` (nuevo, sanitizer unificado — ubicación única, consumido por main y renderer)
+- `src/main/services/ai/toolMessageSanitizer.ts`
+- `src/main/services/aiService.ts`
+- `src/renderer/stores/chatStore.ts`
+- tests Vitest asociados
+
+### 4.2. Fuera de alcance
+
+- migración retroactiva de la base de datos para recomprimir filas antiguas;
+- soporte genérico para formatos MCP de imagen distintos al bloque inline `{ type:"image", data, mimeType }`;
+- rediseño del sistema de context budget;
+- cambios en widgets MCP-UI fuera de lo necesario para no romper persistencia.
+
+## 5. Runbook paso a paso
+
+### Paso 1 — Añadir `sharp` y cerrar su empaquetado
+
+**Archivos:**
+
+- [package.json](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/package.json)
+- [vite.main.config.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/vite.main.config.ts)
+- [forge.config.js](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/forge.config.js)
+
+**Acciones:**
+
+1. Añadir `sharp` a `dependencies`.
+2. Marcar `sharp` y `@img/*` como `external` en `vite.main.config.ts`.
+3. Extender `packageAfterCopy` para copiar:
+   - `sharp`
+   - `@img/*`
+   - dependencias transitivas necesarias de `sharp`
+4. Ampliar `packagerConfig.asar.unpack` para incluir:
+   - `**/node_modules/sharp/**/*`
+   - `**/node_modules/@img/**/*`
+
+**Decisión explícita de packaging:**
+
+En este proyecto `sharp` debe tratarse como dependencia externa de runtime, igual que hoy se hace con otros módulos sensibles en packaging.  
+No confiar solo en `asar.unpack`.
+
+### Paso 2 — Ampliar tipos MCP para soportar imagen inline
+
+**Archivo:**
+
+- [src/main/types/mcp.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/types/mcp.ts)
+
+**Cambios obligatorios:**
+
+Ampliar `ToolResult.content` para permitir al menos:
+
+```ts
+type MCPContentItem =
+  | {
+      type: "text";
+      text?: string;
+    }
+  | {
+      type: "image";
+      data?: string;
+      mimeType?: string;
+    }
+  | {
+      type: "resource";
+      data?: any;
+      resource?: {
+        uri: string;
+        mimeType?: string;
+        text?: string;
+        blob?: string;
+      };
+    }
+  | {
+      type: string;
+      text?: string;
+      data?: any;
+      mimeType?: string;
+      resource?: {
+        uri: string;
+        mimeType?: string;
+        text?: string;
+        blob?: string;
+      };
+    };
+```
+
+No dejar el tipo antiguo limitado a texto y resource, porque el adapter ya va a procesar imágenes explícitamente.
+
+### Paso 3 — Extraer `normalizeToolResult()` compartido y aplicarlo en ambos servicios MCP
+
+**Motivación:**
+
+El bug original (ambos servicios pisan `content[]` con `structuredContent`) existe **por duplicado** porque la lógica de normalización del result MCP estaba copiada en dos sitios. La corrección no puede repetir esa duplicación: debe extraer un helper compartido y que ambos servicios lo llamen.
+
+**Archivo nuevo:**
+
+- `src/main/services/mcp/shared/normalizeToolResult.ts`
+
+**Archivos modificados:**
+
+- [src/main/services/mcp/mcpUseService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/mcpUseService.ts)
+- [src/main/services/mcp/mcpLegacyService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/mcp/mcpLegacyService.ts)
+
+**Regla nueva:**
+
+1. Si `result.content` es array, preservarlo tal cual.
+2. Si no hay `content[]` pero sí `structuredContent`, generar fallback textual desde `structuredContent`.
+3. Seguir preservando:
+   - `structuredContent`
+   - `_meta`
+
+**Implementación del helper (`normalizeToolResult.ts`):**
+
+```ts
+import type { MCPContentItem } from "../../../types/mcp";
+
+export interface NormalizedToolResult {
+  content: MCPContentItem[];
+  structuredContent?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+  isError?: boolean;
+}
+
+export function normalizeToolResult(result: {
+  content?: unknown;
+  structuredContent?: Record<string, unknown>;
+  _meta?: Record<string, unknown>;
+  isError?: boolean;
+}): NormalizedToolResult {
+  let content: MCPContentItem[];
+
+  if (Array.isArray(result.content)) {
+    content = result.content as MCPContentItem[];
+  } else if (result.content !== undefined && result.content !== null) {
+    content = [{
+      type: "text",
+      text: typeof result.content === "string"
+        ? result.content
+        : JSON.stringify(result.content),
+    }];
+  } else if (result.structuredContent) {
+    content = [{
+      type: "text",
+      text: JSON.stringify(result.structuredContent, null, 2),
+    }];
+  } else {
+    content = [];
+  }
+
+  return {
+    content,
+    structuredContent: result.structuredContent,
+    _meta: result._meta,
+    isError: result.isError,
+  };
+}
+```
+
+**Uso en ambos servicios:**
+
+Reemplazar el bloque actual que pisa `content` por:
+
+```ts
+import { normalizeToolResult } from "./shared/normalizeToolResult";
+
+const normalized = normalizeToolResult(rawResult);
+return normalized;
+```
+
+**Regla:** cualquier corrección futura de normalización del result MCP debe vivir en ese helper, no en los servicios.
+
+### Paso 4 — Crear constantes y resizer de imágenes
+
+**Archivos nuevos:**
+
+- `src/main/services/image/providerImageLimits.ts`
+- `src/main/services/image/imageResizer.ts`
+
+**Requisitos de `providerImageLimits.ts`:**
+
+El archivo se llama así (y **no** `apiLimits.ts`) porque los valores son específicos de lo que aceptan los providers de LLM para imágenes inline. El floor lo fija Anthropic (5MB base64); OpenAI y Google aceptan más, por eso usar el floor es seguro para todos. Si en el futuro se soporta un provider con límite menor, este archivo es el único punto a ajustar.
+
+```ts
+// Floor impuesto por Anthropic (5MB base64). OpenAI (~20MB) y Google aceptan más,
+// por lo que cumplir el floor de Anthropic es suficiente para todos los providers soportados.
+// Si se añade un provider con límite menor, ajustar aquí.
+export const API_IMAGE_MAX_BASE64_SIZE = 5 * 1024 * 1024;
+export const IMAGE_TARGET_RAW_SIZE = Math.floor((API_IMAGE_MAX_BASE64_SIZE * 3) / 4);
+export const IMAGE_MAX_WIDTH = 2000;
+export const IMAGE_MAX_HEIGHT = 2000;
+export const DEFAULT_MAX_MCP_OUTPUT_TOKENS = 25_000;
+export const IMAGE_TOKEN_ESTIMATE = 1_600;
+```
+
+**Requisitos de `imageResizer.ts`:**
+
+1. Importar logger correctamente desde:
+   - `import { getLogger } from "../logging";`
+   - `const logger = getLogger();`
+2. Soportar formatos:
+   - `png`
+   - `jpeg`
+   - `gif`
+   - `webp`
+3. Exponer:
+   - `resizeMCPImage(buffer, ext?)`
+   - `resizeMCPImageBlock({ data, mimeType })`
+4. Cascada:
+   - pass-through si ya cabe;
+   - PNG palette si aplica;
+   - JPEG `80 -> 60 -> 40 -> 20`;
+   - resize `inside` a `2000x2000`;
+   - repetir compresión;
+   - último recurso: `1000px + jpeg q20`.
+5. Si el resize falla pero el base64 original ya cabe, devolver original.
+6. Si no cabe y el resize falla, lanzar `ImageResizeError`.
+
+### Paso 5 — Crear sanitizer unificado (`toolOutputSanitizer`)
+
+**Motivación:**
+
+Había tres sanitizers pensados originalmente (adapter, `toolMessageSanitizer`, `chatStore`) que hacían casi lo mismo: recorrer `content[]` y aligerar bloques `image`. Esa duplicación es deuda y fuente de bugs futuros (arreglas uno, olvidas los otros). Consolidamos en un único helper que se reutiliza desde los tres sitios.
+
+**Archivo nuevo:**
+
+- `src/shared/toolOutputSanitizer.ts`
+
+**Ubicación y reglas de dependencia (decisión única):**
+
+- El helper vive en `src/shared/` porque lo consumen **tanto el main (adapter) como el renderer (chatStore)**. No hay versión "main-only".
+- Código puro TypeScript: **prohibido importar** `fs`, `path`, `electron`, logger del main o cualquier API que no exista en ambos procesos.
+- Tests co-localizados en `src/shared/__tests__/toolOutputSanitizer.test.ts`.
+- Todos los consumidores importan desde `@/shared/toolOutputSanitizer` (main) o la ruta relativa equivalente (renderer). **No se permite redefinir el helper localmente en ningún consumidor.**
+
+**Implementación obligatoria:**
+
+```ts
+export interface ToolOutputShape {
+  text?: string;
+  content?: unknown[];
+  uiResources?: unknown[];
+  structuredContent?: Record<string, unknown>;
+  images?: Array<{ data: string; mediaType: string }>;
+}
+
+/**
+ * Deja una "lápida" (`omitted: true`) en vez del base64 para cada bloque `image`
+ * dentro de `content[]`. No muta el input. Única fuente de verdad sobre cómo
+ * se aligera el output de tool antes de persistir o rehidratar.
+ */
+export function stripInlineImagesFromContent(content: unknown[]): unknown[] {
+  return content.map((item) => {
+    if (
+      item &&
+      typeof item === "object" &&
+      (item as { type?: string }).type === "image"
+    ) {
+      return {
+        type: "image",
+        mimeType: (item as { mimeType?: string }).mimeType,
+        omitted: true,
+      };
+    }
+    return item;
+  });
+}
+
+/**
+ * Sanea un output de tool completo: preserva text/uiResources/structuredContent/images
+ * y aligera `content[]` via `stripInlineImagesFromContent`. Usar este helper tanto
+ * cuando el adapter devuelve el resultado como cuando el renderer va a persistirlo.
+ */
+export function sanitizeToolOutput(output: ToolOutputShape): ToolOutputShape {
+  const cleanContent = Array.isArray(output.content)
+    ? stripInlineImagesFromContent(output.content)
+    : undefined;
+
+  return {
+    ...(output.text ? { text: output.text } : {}),
+    ...(cleanContent ? { content: cleanContent } : {}),
+    ...(output.uiResources ? { uiResources: output.uiResources } : {}),
+    ...(output.structuredContent ? { structuredContent: output.structuredContent } : {}),
+    ...(output.images ? { images: output.images } : {}),
+  };
+}
+```
+
+**Regla:**
+
+- El objeto que salga de `execute()` en el adapter debe pasar por `sanitizeToolOutput()` antes de devolverse (consumido en Paso 6).
+- El renderer en `chatStore` usa el **mismo** helper antes de persistir (consumido en Paso 11) — no redefine un sanitizer local.
+- `toolMessageSanitizer` (Paso 8) reutiliza `stripInlineImagesFromContent` para neutralizar historial legacy.
+- Si mañana cambia el formato del bloque imagen MCP, **se toca un solo archivo**.
+
+### Paso 6 — Integrar imagen inline en `mcpToolsAdapter`
+
+**Archivo:**
+
+- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts)
+
+**Cambios obligatorios:**
+
+1. Añadir imports:
+
+```ts
+import { resizeMCPImageBlock } from "../image/imageResizer.js";
+import {
+  DEFAULT_MAX_MCP_OUTPUT_TOKENS,
+  IMAGE_TOKEN_ESTIMATE,
+} from "../image/providerImageLimits.js";
+```
+
+2. Extender `GetMCPToolsOptions` y `CreateAISDKToolOptions` con:
+
+```ts
+supportsVision?: boolean;
+```
+
+3. Propagar `supportsVision` hasta `createAISDKTool()`.
+
+4. En `processToolResult()`:
+   - declarar `imageParts`;
+   - añadir rama explícita para `item.type === "image"`;
+   - redimensionar con `resizeMCPImageBlock`;
+   - añadir placeholder textual corto;
+   - nunca serializar el base64 original como texto.
+
+**Rama correcta:**
+
+```ts
+} else if (item.type === "image" && typeof item.data === "string") {
+  try {
+    const { data, mediaType } = await resizeMCPImageBlock({
+      data: item.data,
+      mimeType: item.mimeType,
+    });
+
+    imageParts.push({
+      data,
+      mediaType,
+    });
+
+    textParts.push(`[Image received from ${mcpTool.name}]`);
+  } catch (error) {
+    logger.mcp.error("Failed to resize MCP tool image", {
+      serverId,
+      toolName: mcpTool.name,
+      error: error instanceof Error ? error.message : String(error),
+    });
+
+    textParts.push(
+      `[Image from ${mcpTool.name} could not be included because it exceeded API limits.]`,
+    );
+  }
+}
+```
+
+5. Al final de `processToolResult()`:
+   - calcular `text`;
+   - aplicar presupuesto básico de salida (ver abajo);
+   - devolver objeto estructurado cuando haya `uiResources` o `images`;
+   - pasar ese objeto por `sanitizeToolOutput()` (del Paso 5) antes de devolverlo.
+
+**Presupuesto mínimo obligatorio en esta fase:**
+
+```ts
+const maxTokens =
+  Number(process.env.MAX_MCP_OUTPUT_TOKENS) || DEFAULT_MAX_MCP_OUTPUT_TOKENS;
+
+const estTokens =
+  imageParts.length * IMAGE_TOKEN_ESTIMATE + Math.ceil(text.length / 4);
+
+if (estTokens > maxTokens) {
+  // TODO(mcp-image-budget): hoy solo loggea. Un tool que devuelva N imágenes
+  // pasa el filtro por-imagen y puede romper el agregado sin truncado.
+  // Abrir issue para implementar truncado multi-imagen (recortar imageParts
+  // y/o text cuando el estimado supera el presupuesto). No bloquea este fix.
+  logger.mcp.warn("MCP output exceeded token budget", {
+    serverId,
+    toolName: mcpTool.name,
+    estTokens,
+    maxTokens,
+  });
+}
+```
+
+En esta fase no hace falta truncado sofisticado, pero el `TODO` debe estar anotado explícitamente para que no se pierda.
+
+### Paso 7 — Implementar `toModelOutput` con el contrato correcto del SDK
+
+**Archivo:**
+
+- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts)
+
+**No usar la firma antigua.**  
+La firma correcta es:
+
+```ts
+toModelOutput: ({ output }) => { ... }
+```
+
+**Implementación requerida:**
+
+```ts
+toModelOutput: ({ output }) => {
+  if (
+    output &&
+    typeof output === "object" &&
+    "images" in output &&
+    Array.isArray((output as any).images)
+  ) {
+    const o = output as {
+      text?: string;
+      images: Array<{ data: string; mediaType: string }>;
+    };
+
+    if (!supportsVision) {
+      return {
+        type: "text",
+        value:
+          o.text ||
+          "[Tool returned an image, but the active model does not support vision.]",
+      };
+    }
+
+    const parts: Array<
+      | { type: "text"; text: string }
+      | { type: "image-data"; data: string; mediaType: string }
+    > = [];
+
+    if (o.text) {
+      parts.push({ type: "text", text: o.text });
+    }
+
+    for (const image of o.images) {
+      parts.push({
+        type: "image-data",
+        data: image.data,
+        mediaType: image.mediaType,
+      });
+    }
+
+    return {
+      type: "content",
+      value: parts,
+    };
+  }
+
+  if (typeof output === "string") {
+    return { type: "text", value: output };
+  }
+
+  if (output && typeof output === "object") {
+    const o = output as {
+      text?: string;
+      structuredContent?: Record<string, unknown>;
+      uiResources?: unknown[];
+    };
+
+    // IMPORTANTE: uiResources es payload de UI, no debe llegar al modelo.
+    // Si no hay imágenes, solo reenviar lo útil para el LLM.
+    if (o.structuredContent) {
+      return {
+        type: "json",
+        value: o.structuredContent as any,
+      };
+    }
+
+    if (o.text) {
+      return {
+        type: "text",
+        value: o.text,
+      };
+    }
+  }
+
+  return {
+    type: "json",
+    value: output as any,
+  };
+},
+```
+
+**Importante:**
+
+- no usar `type: "media"`;
+- no usar `toModelOutput: (output) => ...`;
+- no dejar que el fallback genérico envíe `uiResources` al modelo;
+- no convertir objetos complejos a string por defecto salvo que sea necesario.
+
+### Paso 8 — Preservar `images` en `toolMessageSanitizer`
+
+**Archivo:**
+
+- [src/main/services/ai/toolMessageSanitizer.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/toolMessageSanitizer.ts)
+
+**Dependencia:** importar `stripInlineImagesFromContent` del Paso 5 para **no reimplementar** la lógica de aligerado de `content[]`. Si aparece un bloque `image` legacy en el historial, se reemplaza por su lápida usando ese helper.
+
+**Cambios obligatorios:**
+
+1. La rama especial debe activarse cuando exista `uiResources` **o** `images`.
+2. Si `output.images` existe, debe preservarse.
+3. Si el output histórico trae `content[]` con bloques `image` legacy y no trae `images`, el sanitizer debe:
+   - extraer solo texto útil;
+   - eliminar el base64 de esos bloques para el modelo (via `stripInlineImagesFromContent`);
+   - dejar placeholder textual.
+
+**Comportamiento requerido:**
+
+```ts
+if (
+  output &&
+  typeof output === "object" &&
+  ("uiResources" in output || "images" in output)
+) {
+  const cleanOutput: Record<string, unknown> = {};
+
+  if ((output as any).structuredContent) {
+    cleanOutput.structuredContent = (output as any).structuredContent;
+  }
+
+  if (Array.isArray((output as any).content)) {
+    const contentTexts = (output as any).content
+      .filter((item: any) => item?.type === "text" && item?.text)
+      .map((item: any) => item.text);
+
+    const hadLegacyImages = (output as any).content.some(
+      (item: any) => item?.type === "image",
+    );
+
+    if (hadLegacyImages) {
+      contentTexts.push("[Legacy MCP image omitted from historical tool output]");
+    }
+
+    if (contentTexts.length > 0) {
+      cleanOutput.text = contentTexts.join("\n");
+    }
+  }
+
+  if (!cleanOutput.text && (output as any).text) {
+    cleanOutput.text = (output as any).text;
+  }
+
+  if (Array.isArray((output as any).images) && (output as any).images.length > 0) {
+    cleanOutput.images = (output as any).images;
+  }
+
+  let outputForModel: unknown;
+
+  if (cleanOutput.images) {
+    outputForModel = {
+      text: cleanOutput.text ?? "",
+      images: cleanOutput.images,
+    };
+  } else if (cleanOutput.structuredContent) {
+    outputForModel = cleanOutput.structuredContent;
+  } else if (cleanOutput.text) {
+    outputForModel = cleanOutput.text;
+  } else {
+    outputForModel = "[Widget rendered]";
+  }
+
+  return {
+    ...part,
+    output: outputForModel,
+  };
+}
+```
+
+### Paso 9 — Añadir validation safety-net pre-request
+
+**Archivo nuevo:**
+
+- `src/main/services/image/imageValidation.ts`
+
+**Archivo modificado:**
+
+- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts)
+
+**Objetivo:**
+
+Detectar imágenes que hayan escapado al pipeline, tanto en:
+
+- outputs de tools;
+- adjuntos de usuario convertidos a `file` con data URL base64.
+
+**Implementación requerida:**
+
+1. Crear `validateImagesForAPI(messages)` que recorra recursivamente los mensajes saneados.
+2. Detectar estos casos:
+   - `{ type: "image-data", data }`
+   - `{ type: "image", data }`
+   - `{ type: "file", url }` con `url` tipo `data:image/...;base64,...`
+   - objetos `images[]` dentro de outputs de tool antes de `convertToModelMessages`
+3. Validar tamaño sobre el payload base64 real.
+
+**Helper recomendado:**
+
+```ts
+function getBase64SizeFromDataUrl(url: string): number | null {
+  const match = /^data:[^;]+;base64,(.*)$/.exec(url);
+  return match ? match[1].length : null;
+}
+```
+
+**Puntos de invocación obligatorios:**
+
+1. flujo streaming:
+   - justo después de `sanitizeMessagesForModel(updatedMessages)`
+   - antes de `convertToModelMessages(...)`
+   - en [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:1295)
+
+2. flujo single-shot:
+   - antes de `convertToModelMessages(...)`
+   - en [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts:2098)
+
+### Paso 10 — Propagar `supportsVision` desde `aiService`
+
+**Archivos:**
+
+- [src/main/services/aiService.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/aiService.ts)
+- [src/main/services/ai/mcpToolsAdapter.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/mcpToolsAdapter.ts)
+
+**Cambios obligatorios:**
+
+1. Cuando `aiService` llame a `getMCPTools(...)`, pasar:
+
+```ts
+supportsVision: modelInfo?.capabilities?.supportsVision === true
+```
+
+2. Corregir también el call site de `generateText()` para que use el mismo objeto de opciones, no un argumento positional incorrecto.
+
+**Regla final:**
+
+Si el modelo no soporta visión:
+
+- el tool puede seguir ejecutándose;
+- la UI puede seguir mostrando un resultado saneado;
+- el modelo debe recibir solo texto fallback.
+
+### Paso 11 — Sanear persistencia en `chatStore`
+
+**Archivo:**
+
+- [src/renderer/stores/chatStore.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/renderer/stores/chatStore.ts)
+
+**Objetivo:**
+
+No persistir un `tool_calls.result` con base64 raw antiguo o duplicado.
+
+**Cambios obligatorios:**
+
+1. **No redefinir un sanitizer local.** Importar `sanitizeToolOutput` desde `src/shared/toolOutputSanitizer.ts` (ubicación única definida en Paso 5).
+
+2. Persistir:
+
+```ts
+import { sanitizeToolOutput } from "@/shared/toolOutputSanitizer";
+
+// ...
+result: sanitizeToolOutput(part.output),
+```
+
+3. Si al implementar aparece un problema de resolución de imports entre main y renderer (alias, tsconfig, bundler), resolverlo **en la configuración de build**, no moviendo el archivo. La ubicación del helper es fija.
+
+**Resultado esperado:**
+
+- el historial nuevo conserva `images` comprimidas;
+- elimina el bloque raw gigante de `content[]`;
+- evita duplicación.
+
+### Paso 12 — Compatibilidad con historial existente
+
+No habrá migración de DB en esta fase.
+
+**Comportamiento requerido para historial legacy:**
+
+1. Si se recarga una conversación antigua con `content[]` que incluya imágenes raw:
+   - el sanitizer debe evitar reenviar el base64 al modelo;
+   - debe reemplazarlo por placeholder textual.
+2. No intentar recomprimir filas antiguas al cargar.
+
+Esto es suficiente para:
+
+- evitar nuevos `prompt too long`;
+- no introducir migraciones de datos en este fix.
+
+## 6. Tests obligatorios
+
+### 6.1. Unit tests del resizer
+
+**Archivo nuevo:**
+
+- `src/main/services/image/__tests__/imageResizer.test.ts`
+
+**Casos mínimos:**
+
+1. imagen pequeña pasa sin cambios;
+2. PNG grande se comprime por debajo del target;
+3. imagen gigante se redimensiona por debajo de `IMAGE_MAX_WIDTH/HEIGHT`;
+4. buffer vacío lanza error;
+5. si el resize falla pero el base64 ya cabe, se devuelve original.
+
+### 6.2. Unit tests del sanitizer
+
+**Archivo existente a ampliar:**
+
+- [src/main/services/ai/__tests__/toolMessageSanitizer.test.ts](/Users/saulgomezjimenez/proyectos/clai/proyectos/levante/levante/src/main/services/ai/__tests__/toolMessageSanitizer.test.ts)
+
+**Casos mínimos:**
+
+1. preserva `images` en output con `uiResources`;
+2. convierte output histórico con `content[].image` legacy a texto placeholder seguro;
+3. no muta el input original;
+4. mantiene `structuredContent` preferente cuando no hay `images`.
+
+### 6.3. Tests del adapter MCP
+
+**Archivo nuevo:**
+
+- `src/main/services/ai/__tests__/mcpToolsAdapter.image.test.ts`
+
+**Casos mínimos:**
+
+1. `processToolResult()` transforma bloque `image` en:
+   - `text` placeholder;
+   - `images[]` comprimidas;
+2. no serializa el base64 raw en `text`;
+3. aplica fallback textual cuando el resize falla;
+4. `toModelOutput` genera `image-data` cuando `supportsVision === true`;
+5. `toModelOutput` degrada a texto cuando `supportsVision === false`.
+
+### 6.4. Tests del sanitizer unificado
+
+**Archivo nuevo:**
+
+- `src/shared/__tests__/toolOutputSanitizer.test.ts`
+
+**Casos mínimos:**
+
+1. `stripInlineImagesFromContent` reemplaza cada bloque `image` por su lápida y preserva bloques `text` y `resource` intactos.
+2. `sanitizeToolOutput` conserva `text`, `uiResources`, `structuredContent` e `images` tal cual.
+3. `sanitizeToolOutput` no muta el input.
+4. Output sin `content` ni `images` se devuelve sin propiedades basura.
+
+### 6.5. Tests del normalizador MCP
+
+**Archivo nuevo:**
+
+- `src/main/services/mcp/shared/__tests__/normalizeToolResult.test.ts`
+
+**Casos mínimos:**
+
+1. Preserva `content[]` cuando viene como array.
+2. Convierte `content` string a bloque `text`.
+3. Genera fallback textual desde `structuredContent` cuando `content` está ausente.
+4. Preserva `_meta` y `structuredContent` en paralelo al `content`.
+
+### 6.6. Tests de validación pre-request
+
+**Archivo nuevo:**
+
+- `src/main/services/image/__tests__/imageValidation.test.ts`
+
+**Casos mínimos:**
+
+1. acepta `images[]` pequeñas;
+2. rechaza `image-data` demasiado grande;
+3. rechaza `file.url` con data URL base64 demasiado grande;
+4. ignora URLs no data URL.
+
+## 7. Orden exacto de implementación
+
+1. Añadir `sharp` y cerrar packaging en `package.json`, `vite.main.config.ts` y `forge.config.js`.
+2. Ampliar tipos en `src/main/types/mcp.ts`.
+3. Crear `normalizeToolResult.ts` y aplicarlo en `mcpUseService.ts` y `mcpLegacyService.ts`.
+4. Crear `providerImageLimits.ts` y `imageResizer.ts`.
+5. Crear `src/shared/toolOutputSanitizer.ts` (ubicación fija, consumido por main y renderer).
+6. Integrar imagen inline y `toModelOutput` correcto en `mcpToolsAdapter.ts` (consume `sanitizeToolOutput`).
+7. Actualizar `toolMessageSanitizer.ts` (consume `stripInlineImagesFromContent`).
+8. Añadir `imageValidation.ts` e invocarlo en ambos caminos de `aiService.ts`.
+9. Pasar `supportsVision` desde `aiService.ts` a `getMCPTools(...)`.
+10. Sanear persistencia en `chatStore.ts` (consume `sanitizeToolOutput`).
+11. Añadir y ejecutar tests.
+12. Hacer verificación manual.
+
+## 8. Verificación manual obligatoria
+
+### Escenario A — modelo con visión
+
+1. Arrancar app en local.
+2. Conectar MCP `chrome-devtools`.
+3. Ejecutar screenshot grande, por ejemplo:
+   - viewport HiDPI
+   - `fullPage: true`
+4. Verificar en logs:
+   - resize aplicado;
+   - sin `prompt too long`;
+   - sin serialización textual del base64.
+5. Verificar que el modelo describe correctamente la imagen.
+
+### Escenario B — modelo sin visión
+
+1. Repetir el mismo tool call con un modelo textual.
+2. Verificar:
+   - no hay error de provider por imagen no soportada;
+   - el modelo recibe placeholder textual;
+   - la conversación continúa.
+
+### Escenario C — recarga histórica
+
+1. Ejecutar el tool.
+2. Persistir conversación.
+3. Recargar la app.
+4. Verificar:
+   - el tool output sigue renderizando;
+   - no reaparece base64 raw en el historial;
+   - al continuar la conversación no se produce `prompt too long`.
+
+## 9. Checklist de aceptación
+
+- `mcp-use` preserva `content[]` real.
+- `official-sdk` preserva `content[]` real.
+- `processToolResult()` ya no serializa imágenes como texto raw.
+- `toModelOutput` usa la firma correcta del SDK.
+- las imágenes se emiten como `image-data`.
+- los modelos sin visión degradan a texto.
+- el historial persistido no guarda base64 raw gigante en `content[]`.
+- `validateImagesForAPI()` corre en `streamText()` y en `generateText()`.
+- `sharp` funciona en `dev`, `package` y `make`.
+- tests verdes.
+
+## 10. Riesgos y decisiones explícitas
+
+### Riesgo 1 — `sharp` y ABI nativa de Electron
+
+Mitigación:
+
+- tratar `sharp` como dependencia externa de runtime;
+- copiar `sharp` y `@img/*` en `packageAfterCopy`;
+- incluir sus paths en `asar.unpack`.
+
+### Riesgo 2 — conversaciones antiguas ya contaminadas
+
+Mitigación:
+
+- no migrar DB en esta fase;
+- neutralizar esos payloads en `toolMessageSanitizer`.
+
+### Riesgo 3 — modelos sin visión
+
+Mitigación:
+
+- pasar `supportsVision` al crear tools;
+- degradar en `toModelOutput`.
+
+### Riesgo 4 — el presupuesto MCP siga siendo alto
+
+Mitigación:
+
+- logging del estimate ahora;
+- truncado más fino queda fuera de este fix.
+
+## 11. No implementar nada fuera de este runbook
+
+La implementación debe limitarse a los archivos, pasos, tests y verificaciones descritos aquí.  
+No asumir trabajos laterales, refactors adicionales ni migraciones no incluidas.

--- a/docs/PLAN_MCP_OUTPUT_BUDGET.md
+++ b/docs/PLAN_MCP_OUTPUT_BUDGET.md
@@ -1,0 +1,400 @@
+# Plan: presupuesto de tokens para outputs MCP
+
+Replica en Levante el patrón de Claude Code descrito por el arquitecto: dos capas (MCP-específica + genérica por-turno), persistir>truncar, estimación barata con fallback a count exacto, declarativo por-tool, con bypass por nombre y por contenido (imágenes).
+
+## Resumen de decisiones
+
+- **Dónde:** en `processToolResult` (adapter MCP), antes de que el output entre al historial. No en el sanitizer pre-provider.
+- **Dos modos:** persistir a disco (default) con preview + schema inferido; truncado inline como fallback.
+- **Medición:** chars/4 como filtro barato. Sin llamada a `countTokens` externa (Levante es multi-provider, no hay API común); `estTokens = ceil(chars/4) + imageParts*IMAGE_TOKEN_ESTIMATE`. Umbral al 100% (no 50%) porque no hay double-check API.
+- **Declarativo:** cap por tool vía `maxResultSizeChars` en el wrapper; clamp global; override por env / settings MCP. `Infinity` = opt-out duro.
+- **Por turno:** cap agregado `MAX_TOOL_RESULTS_PER_MESSAGE_CHARS` con poda "los mayores primero". Aplica sobre los resultados que se construyen en un mismo `generate`/`stream`.
+- **Bypass:** por contenido (si hay imágenes → solo truncar texto, no persistir JSON con base64), por nombre de tool (ej. futuras tools "IDE-like"), y por `Infinity` declarado.
+- **Telemetría:** `logger.mcp.info("mcp_large_result_handled", {outcome, reason, toolName, serverId, sizeEstimateTokens, persistedSizeChars?})`.
+
+## Paso 1 — Constantes y configuración
+
+**Archivo:** `src/main/services/image/providerImageLimits.ts` (renombrable a `mcpBudgetLimits.ts` en un PR posterior; hoy ya contiene `DEFAULT_MAX_MCP_OUTPUT_TOKENS`, lo ampliamos).
+
+```ts
+// añadir al final del archivo existente
+export const DEFAULT_MAX_RESULT_SIZE_CHARS = 50_000;      // clamp global por tool
+export const MCP_TOOL_DEFAULT_CAP_CHARS = 100_000;        // techo declarativo para tools MCP genéricos
+export const MAX_TOOL_RESULTS_PER_MESSAGE_CHARS = 200_000; // presupuesto agregado por turno
+export const TOKEN_CHARS_RATIO = 4;                        // 1 token ≈ 4 chars (heurística)
+```
+
+**Nuevo archivo:** `src/main/services/mcp/budget/mcpBudgetConfig.ts`
+
+```ts
+import {
+  DEFAULT_MAX_MCP_OUTPUT_TOKENS,
+  DEFAULT_MAX_RESULT_SIZE_CHARS,
+  MCP_TOOL_DEFAULT_CAP_CHARS,
+  MAX_TOOL_RESULTS_PER_MESSAGE_CHARS,
+  TOKEN_CHARS_RATIO,
+} from "../../image/providerImageLimits";
+
+export function getMaxMcpOutputTokens(): number {
+  const env = Number(process.env.MAX_MCP_OUTPUT_TOKENS);
+  return Number.isFinite(env) && env > 0 ? env : DEFAULT_MAX_MCP_OUTPUT_TOKENS;
+}
+
+export function getMaxResultSizeCharsForTool(
+  toolName: string,
+  declared: number | undefined,
+  overrides: Record<string, number> | undefined,
+): number {
+  if (declared === Infinity) return Infinity;              // hard opt-out
+  const override = overrides?.[toolName];
+  if (typeof override === "number" && override > 0) return override;
+  if (typeof declared === "number" && declared > 0) return declared;
+  return DEFAULT_MAX_RESULT_SIZE_CHARS;
+}
+
+export function isPersistenceEnabled(): boolean {
+  return process.env.ENABLE_MCP_LARGE_OUTPUT_FILES !== "false";
+}
+
+export {
+  MCP_TOOL_DEFAULT_CAP_CHARS,
+  MAX_TOOL_RESULTS_PER_MESSAGE_CHARS,
+  TOKEN_CHARS_RATIO,
+};
+```
+
+## Paso 2 — Store en disco con `wx` y schema inference
+
+**Nuevo archivo:** `src/main/services/mcp/budget/mcpOutputStore.ts`
+
+```ts
+import { app } from "electron";
+import { promises as fs, existsSync } from "node:fs";
+import path from "node:path";
+import crypto from "node:crypto";
+import { getLogger } from "../../logging";
+
+const logger = getLogger();
+
+function baseDir(): string {
+  return path.join(app.getPath("userData"), "mcp-tool-results");
+}
+
+export interface PersistResult {
+  filePath: string;
+  originalSize: number;
+  sha256: string;
+  schema?: string;
+}
+
+function stableId(serverId: string, toolName: string, payload: string): string {
+  const hash = crypto
+    .createHash("sha256")
+    .update(payload)
+    .digest("hex")
+    .slice(0, 12);
+  const ts = Date.now();
+  return `${serverId}-${toolName}-${ts}-${hash}`.replace(/[^a-zA-Z0-9._-]/g, "_");
+}
+
+// Signature inference (simplified port of inferCompactSchema):
+// arrays → `[<T>]`, objects → `{k1: T1, k2: T2}`, primitives → typeof.
+export function inferCompactSchema(value: unknown, depth = 0): string {
+  if (depth > 3) return "...";
+  if (value === null) return "null";
+  if (Array.isArray(value)) {
+    if (value.length === 0) return "[]";
+    return `[${inferCompactSchema(value[0], depth + 1)}]`;
+  }
+  if (typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .slice(0, 20)
+      .map(([k, v]) => `${k}: ${inferCompactSchema(v, depth + 1)}`);
+    return `{${entries.join(", ")}}`;
+  }
+  return typeof value;
+}
+
+export async function persistToolResult(params: {
+  serverId: string;
+  toolName: string;
+  content: unknown;            // raw MCP content[] (o string)
+  structuredContent?: unknown; // opcional
+}): Promise<PersistResult | null> {
+  try {
+    await fs.mkdir(baseDir(), { recursive: true });
+    const isJson = typeof params.content !== "string";
+    const payload = isJson
+      ? JSON.stringify(params.content, null, 2)
+      : String(params.content);
+    const id = stableId(params.serverId, params.toolName, payload);
+    const ext = isJson ? "json" : "txt";
+    const filePath = path.join(baseDir(), `${id}.${ext}`);
+    const sha256 = crypto.createHash("sha256").update(payload).digest("hex");
+
+    // 'wx' — falla si existe; así los replays de compactación no reescriben.
+    if (!existsSync(filePath)) {
+      await fs.writeFile(filePath, payload, { flag: "wx", encoding: "utf8" });
+    }
+
+    const schema = isJson
+      ? inferCompactSchema(params.structuredContent ?? params.content)
+      : undefined;
+
+    return { filePath, originalSize: payload.length, sha256, schema };
+  } catch (error) {
+    logger.mcp.error("Failed to persist MCP tool result", {
+      serverId: params.serverId,
+      toolName: params.toolName,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+export function largeOutputInstructions(p: PersistResult, sizeTokens: number): string {
+  const schemaLine = p.schema ? `\nFormat: JSON with schema: ${p.schema}` : "";
+  return `Error: result (${p.originalSize} chars, ~${sizeTokens} tokens) exceeds MCP output limit.
+Output has been saved to ${p.filePath}.${schemaLine}
+Use the Read tool (offset/limit) or search within the file. For JSON, jq works against the schema above.
+REQUIREMENTS FOR SUMMARIZATION/ANALYSIS:
+- Read the content in sequential chunks until 100% has been processed.
+- Before producing any summary, explicitly state which portion you have read.`;
+}
+
+export function truncationPlaceholder(maxTokens: number): string {
+  return `[OUTPUT TRUNCATED - exceeded ${maxTokens} token limit]
+
+The tool output was truncated. If this MCP server exposes pagination or filtering,
+use it to retrieve specific portions. Otherwise, inform the user that results are
+incomplete.`;
+}
+```
+
+## Paso 3 — Medición y decisión
+
+**Nuevo archivo:** `src/main/services/mcp/budget/mcpBudget.ts`
+
+```ts
+import {
+  TOKEN_CHARS_RATIO,
+} from "./mcpBudgetConfig";
+import { IMAGE_TOKEN_ESTIMATE } from "../../image/providerImageLimits";
+
+export function estimateTokens(textChars: number, imageCount: number): number {
+  return Math.ceil(textChars / TOKEN_CHARS_RATIO) + imageCount * IMAGE_TOKEN_ESTIMATE;
+}
+
+export function contentContainsImages(content: unknown): boolean {
+  if (!Array.isArray(content)) return false;
+  return content.some(
+    (item: any) => item?.type === "image" && typeof item.data === "string",
+  );
+}
+```
+
+## Paso 4 — Integración en `processToolResult`
+
+**Archivo:** `src/main/services/ai/mcpToolsAdapter.ts`
+
+Reemplazar el bloque "Basic output budget" (líneas ~1226-1243) por el flujo decide→persist→truncate. También añadir el parámetro `budgetOverrides` propagado desde `getMCPTools`.
+
+```ts
+// imports nuevos
+import { estimateTokens, contentContainsImages } from "../mcp/budget/mcpBudget";
+import {
+  getMaxMcpOutputTokens,
+  getMaxResultSizeCharsForTool,
+  isPersistenceEnabled,
+} from "../mcp/budget/mcpBudgetConfig";
+import {
+  persistToolResult,
+  largeOutputInstructions,
+  truncationPlaceholder,
+} from "../mcp/budget/mcpOutputStore";
+```
+
+Dentro de `processToolResult`, justo antes del bloque `if (uiResources.length > 0 || imageParts.length > 0)`:
+
+```ts
+const maxTokens = getMaxMcpOutputTokens();
+const declaredCap = (mcpTool as any)._meta?.maxResultSizeChars as number | undefined;
+const maxChars = getMaxResultSizeCharsForTool(mcpTool.name, declaredCap, undefined);
+
+const estTokens = estimateTokens(text.length, imageParts.length);
+const exceedsTokens = estTokens > maxTokens;
+const exceedsChars = text.length > maxChars;
+
+if (exceedsTokens || exceedsChars) {
+  const reason = exceedsTokens ? "tokens" : "chars";
+  const hasImages = imageParts.length > 0 || contentContainsImages(result.content);
+
+  // Rama A: persistir (solo si no hay imágenes; un JSON con base64 rompe compresión visual)
+  if (isPersistenceEnabled() && !hasImages) {
+    const persisted = await persistToolResult({
+      serverId,
+      toolName: mcpTool.name,
+      content: result.content,
+      structuredContent: result.structuredContent,
+    });
+    if (persisted) {
+      logger.mcp.info("mcp_large_result_handled", {
+        outcome: "persisted",
+        reason,
+        toolName: mcpTool.name,
+        serverId,
+        sizeEstimateTokens: estTokens,
+        persistedSizeChars: persisted.originalSize,
+      });
+      return largeOutputInstructions(persisted, estTokens);
+    }
+    // persistencia falló → cae a truncado
+  }
+
+  // Rama B: truncado inline (preserva imágenes resizeadas)
+  const placeholder = truncationPlaceholder(maxTokens);
+  logger.mcp.info("mcp_large_result_handled", {
+    outcome: "truncated",
+    reason: hasImages ? "contains_images" : reason,
+    toolName: mcpTool.name,
+    serverId,
+    sizeEstimateTokens: estTokens,
+  });
+
+  if (imageParts.length > 0 || uiResources.length > 0) {
+    return sanitizeToolOutput({
+      text: placeholder,
+      content: result.content,
+      ...(uiResources.length > 0 ? { uiResources } : {}),
+      ...(imageParts.length > 0 ? { images: imageParts } : {}),
+    });
+  }
+  return placeholder;
+}
+```
+
+Eliminar el `TODO(mcp-image-budget)` y el `logger.mcp.warn` anteriores — ya cubiertos.
+
+## Paso 5 — Presupuesto agregado por turno
+
+**Nuevo archivo:** `src/main/services/mcp/budget/mcpTurnBudget.ts`
+
+Estructura `AsyncLocalStorage` para acumular el total de chars emitidos por tool-calls en un mismo request. Si al cerrar un tool-call el agregado supera `MAX_TOOL_RESULTS_PER_MESSAGE_CHARS`, podar los mayores.
+
+```ts
+import { AsyncLocalStorage } from "node:async_hooks";
+import { MAX_TOOL_RESULTS_PER_MESSAGE_CHARS } from "./mcpBudgetConfig";
+
+interface TurnEntry { id: string; chars: number; onPrune: () => void }
+interface TurnCtx { entries: TurnEntry[] }
+
+const storage = new AsyncLocalStorage<TurnCtx>();
+
+export function runWithTurnBudget<T>(fn: () => Promise<T>): Promise<T> {
+  return storage.run({ entries: [] }, fn);
+}
+
+export function registerToolResult(entry: TurnEntry): void {
+  const ctx = storage.getStore();
+  if (!ctx) return;
+  ctx.entries.push(entry);
+  let total = ctx.entries.reduce((s, e) => s + e.chars, 0);
+  if (total <= MAX_TOOL_RESULTS_PER_MESSAGE_CHARS) return;
+  // Poda: mayores primero, hasta bajar del presupuesto
+  const sorted = [...ctx.entries].sort((a, b) => b.chars - a.chars);
+  for (const e of sorted) {
+    if (total <= MAX_TOOL_RESULTS_PER_MESSAGE_CHARS) break;
+    e.onPrune();
+    total -= e.chars;
+    e.chars = 0;
+  }
+}
+```
+
+**Archivo:** `src/main/services/aiService.ts` — envolver el cuerpo de `streamText`/`generateText` con `runWithTurnBudget(async () => { ... })` en ambos caminos (líneas ~1303 y ~2110 según el último PR).
+
+**Archivo:** `src/main/services/ai/mcpToolsAdapter.ts` — tras calcular el `text` final (antes de devolver), si no se ha persistido/truncado, registrar para poda diferida:
+
+```ts
+const resultId = `${serverId}:${mcpTool.name}:${Date.now()}`;
+let mutableText = text;
+registerToolResult({
+  id: resultId,
+  chars: mutableText.length,
+  onPrune: () => { mutableText = truncationPlaceholder(maxTokens); },
+});
+// usar mutableText donde antes se usaba text
+```
+
+Nota: como `processToolResult` devuelve sincrónico desde aquí y la poda es reactiva, exponer el resultado a través de un objeto (`{ get text() { return mutableText; } }`) o resolver con una promesa post-poda. El patrón concreto depende de cómo se serializa la respuesta — ver Paso 7 (test) para validar empíricamente antes de comprometerse con una API.
+
+## Paso 6 — Cap declarativo por tool
+
+**Archivo:** `src/main/services/ai/mcpToolsAdapter.ts` — tipo `CreateAISDKToolOptions`:
+
+```ts
+export interface CreateAISDKToolOptions {
+  // ...existente
+  maxResultSizeChars?: number;   // Infinity = opt-out duro
+  budgetOverrides?: Record<string, number>; // por nombre de tool, p. ej. desde settings
+}
+```
+
+Pasar `maxResultSizeChars` al `mcpTool._meta` antes de invocar `processToolResult`, o bien propagarlo explícitamente como parámetro (más limpio):
+
+```ts
+export async function processToolResult(
+  serverId: string,
+  mcpTool: Tool,
+  args: Record<string, unknown>,
+  result: any,
+  protocol: WidgetProtocol = "none",
+  budget?: { maxResultSizeChars?: number; overrides?: Record<string, number> },
+) { /* ... */ }
+```
+
+Y en las dos llamadas actuales (líneas 405, 456) pasar el `budget` derivado de las options del tool.
+
+## Paso 7 — Tests
+
+Nuevos en `src/main/services/mcp/budget/__tests__/`:
+
+- `mcpBudget.test.ts`: `estimateTokens`, `contentContainsImages`.
+- `mcpOutputStore.test.ts`: escribe con `wx`, idempotente ante replay, `inferCompactSchema` sobre objetos/arrays, `largeOutputInstructions` contiene filePath + schema.
+- `mcpBudgetConfig.test.ts`: env override, `Infinity` hard opt-out, precedencia override→declared→default.
+- `mcpTurnBudget.test.ts`: dos entries dentro del presupuesto no podan; tres que suman por encima podan la mayor primero.
+
+Extender `mcpToolsAdapter.image.test.ts`:
+
+- Output de texto > `maxTokens` con persistencia habilitada → devuelve instrucciones con `filePath`.
+- Output de texto > `maxTokens` con `hasImages=true` → devuelve placeholder, preserva `images[]`.
+- `ENABLE_MCP_LARGE_OUTPUT_FILES=false` → siempre truncado.
+- `maxResultSizeChars=Infinity` → no trunca aunque exceda.
+
+Usar `vi.mock("electron", ...)` con `getPath: () => os.tmpdir()` y `vi.mock("../../logging", ...)` (ya es el patrón del repo).
+
+## Paso 8 — Verificación manual
+
+1. `pnpm typecheck` y `pnpm test`.
+2. En dev, conectar `chrome-devtools` MCP y ejecutar `take_snapshot` en una página compleja. Verificar:
+   - Aparece fichero en `<userData>/mcp-tool-results/`.
+   - El mensaje devuelto al modelo contiene `Output has been saved to ...` y `Format: JSON with schema: ...`.
+   - El log `mcp_large_result_handled` con `outcome: "persisted"`.
+3. Forzar `ENABLE_MCP_LARGE_OUTPUT_FILES=false` y repetir: debe aparecer el placeholder `[OUTPUT TRUNCATED ...]`.
+4. Ejecutar una tool que devuelva imagen + texto pequeño: sin cambios (ruta imagen intacta).
+
+## Fuera de alcance (PRs posteriores)
+
+- Settings UI para `budgetOverrides` por tool (por ahora solo env var).
+- `countTokens` exacto via API del provider (hoy solo chars/4).
+- Limpieza de `mcp-tool-results/` por retention policy.
+- Persistencia resiliente entre sesiones (session-scoped dir vs global).
+
+## Orden de commits sugerido
+
+1. Constantes + config (Paso 1).
+2. Store + schema inference + tests (Paso 2).
+3. Budget helpers + tests (Paso 3).
+4. Integración en `processToolResult` + tests de adapter (Paso 4, 6).
+5. Turn budget + hook en `aiService` + tests (Paso 5).
+6. Docs y verificación manual (Paso 8).

--- a/docs/PRD/ISSUES/INDEX.yaml
+++ b/docs/PRD/ISSUES/INDEX.yaml
@@ -49,6 +49,10 @@ issues:
     labels: [mcp, performance, ai-optimization]
     priority: P0
     role: AI Engineer
-
+  - id: 0012
+    title: MCP Tool Results — Remove Legacy `images[]` Format After Canonical Rollout
+    labels: [mcp, technical-debt, replay, persistence, cleanup]
+    priority: P1
+    role: Platform Engineer
 
 

--- a/src/main/services/__tests__/aiService.contextDiagnostics.test.ts
+++ b/src/main/services/__tests__/aiService.contextDiagnostics.test.ts
@@ -1,0 +1,104 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { isEnabledMock, debugMock, infoMock } = vi.hoisted(() => ({
+  isEnabledMock: vi.fn(),
+  debugMock: vi.fn(),
+  infoMock: vi.fn(),
+}));
+
+vi.mock("../logging", () => ({
+  getLogger: () => ({
+    isEnabled: isEnabledMock,
+    aiSdk: {
+      debug: debugMock,
+      info: infoMock,
+    },
+  }),
+}));
+
+import { collectLargestStrings, collectImagePayloads, logContextDiagnostics } from "../ai/contextDiagnostics";
+
+describe("logContextDiagnostics", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("skips all work when ai-sdk debug is disabled", () => {
+    isEnabledMock.mockReturnValue(false);
+
+    const deepObject = {
+      a: "x".repeat(10_000),
+      b: { c: "y".repeat(10_000) },
+    };
+
+    // Wrap collectLargestStrings to spy — but since guard exits early, neither
+    // debugMock nor infoMock should be called and no traversal happens.
+    const mockLogger = { aiSdk: { debug: debugMock, info: infoMock } } as any;
+    logContextDiagnostics(mockLogger, "test", deepObject);
+
+    expect(debugMock).not.toHaveBeenCalled();
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+
+  it("emits via logger.aiSdk.debug (not info) when ai-sdk debug is enabled", () => {
+    isEnabledMock.mockReturnValue(true);
+
+    const payload = { text: "hello world" };
+    const mockLogger = { aiSdk: { debug: debugMock, info: infoMock } } as any;
+
+    logContextDiagnostics(mockLogger, "payload", payload);
+
+    expect(debugMock).toHaveBeenCalledTimes(2);
+    expect(debugMock).toHaveBeenCalledWith(
+      "[CTX_DIAGNOSTICS] Largest strings",
+      expect.objectContaining({ label: "payload" }),
+    );
+    expect(debugMock).toHaveBeenCalledWith(
+      "[CTX_DIAGNOSTICS] Image payloads",
+      expect.objectContaining({ label: "payload" }),
+    );
+    expect(infoMock).not.toHaveBeenCalled();
+  });
+});
+
+describe("collectLargestStrings", () => {
+  it("collects strings from nested objects", () => {
+    const acc: any[] = [];
+    collectLargestStrings({ a: "hello", b: { c: "world" } }, "root", acc);
+    const paths = acc.map((e) => e.path);
+    expect(paths).toContain("root.a");
+    expect(paths).toContain("root.b.c");
+  });
+
+  it("collects strings from arrays", () => {
+    const acc: any[] = [];
+    collectLargestStrings(["foo", "bar"], "arr", acc);
+    expect(acc.some((e) => e.path === "arr[0]")).toBe(true);
+    expect(acc.some((e) => e.path === "arr[1]")).toBe(true);
+  });
+});
+
+describe("collectImagePayloads", () => {
+  it("detects file-type data URI payloads", () => {
+    const acc: any[] = [];
+    collectImagePayloads(
+      { type: "file", url: "data:image/png;base64," + "A".repeat(100) },
+      "root",
+      acc,
+    );
+    expect(acc.length).toBeGreaterThan(0);
+    expect(acc[0].kind).toBe("file-data-url");
+  });
+
+  it("detects image-data payloads", () => {
+    const acc: any[] = [];
+    collectImagePayloads(
+      { type: "image-data", data: "A".repeat(200), mediaType: "image/png" },
+      "root",
+      acc,
+    );
+    expect(acc.length).toBe(1);
+    expect(acc[0].kind).toBe("image-data");
+    expect(acc[0].base64Length).toBe(200);
+  });
+});

--- a/src/main/services/__tests__/chatService.toolResults.test.ts
+++ b/src/main/services/__tests__/chatService.toolResults.test.ts
@@ -93,7 +93,7 @@ describe("ChatService tool result persistence", () => {
     );
   });
 
-  it("rewrites legacy rows lazily when getMessages loads them", async () => {
+  it("normalizes legacy rows in memory without UPDATE when getMessages loads them", async () => {
     normalizeToolCallResultForStorage.mockResolvedValue({
       normalized: { __levanteToolResult: 1, modelOutput: { type: "text", value: "ok" } },
       changed: true,
@@ -124,8 +124,7 @@ describe("ChatService tool result persistence", () => {
           null,
           null,
         ]],
-      })
-      .mockResolvedValueOnce({ rows: [], rowsAffected: 1 });
+      });
 
     const result = await service.getMessages({
       session_id: "session-1",
@@ -143,21 +142,11 @@ describe("ChatService tool result persistence", () => {
         },
       ]),
     );
-    expect(executeMock).toHaveBeenCalledWith(
-      "UPDATE messages SET tool_calls = ? WHERE id = ?",
-      [
-        JSON.stringify([
-          {
-            id: "call-1",
-            name: "screenshot",
-            arguments: {},
-            result: { __levanteToolResult: 1, modelOutput: { type: "text", value: "ok" } },
-            status: "success",
-          },
-        ]),
-        "msg-1",
-      ],
+    // Must NOT have issued an UPDATE — normalization is in-memory only on reads.
+    const updateCalls = executeMock.mock.calls.filter(
+      (args: any[]) => typeof args[0] === "string" && args[0].startsWith("UPDATE messages SET tool_calls"),
     );
+    expect(updateCalls).toHaveLength(0);
   });
 
   it("deletes orphaned image assets when updateMessage replaces tool calls", async () => {

--- a/src/main/services/__tests__/chatService.toolResults.test.ts
+++ b/src/main/services/__tests__/chatService.toolResults.test.ts
@@ -1,0 +1,286 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import type { PersistedToolCall } from "../../../types/database";
+
+const {
+  executeMock,
+  normalizeToolCallResultForStorage,
+  collectToolResultAssetIds,
+  deleteImageAssetsIfUnused,
+} = vi.hoisted(() => ({
+  executeMock: vi.fn(),
+  normalizeToolCallResultForStorage: vi.fn(),
+  collectToolResultAssetIds: vi.fn(),
+  deleteImageAssetsIfUnused: vi.fn(),
+}));
+
+vi.mock("../databaseService", () => ({
+  databaseService: {
+    execute: executeMock,
+  },
+}));
+
+vi.mock("../logging", () => ({
+  getLogger: () => ({
+    database: {
+      debug: vi.fn(),
+      info: vi.fn(),
+      warn: vi.fn(),
+      error: vi.fn(),
+    },
+  }),
+}));
+
+vi.mock("../toolResults/canonicalToolResultService", () => ({
+  normalizeToolCallResultForStorage,
+  collectToolResultAssetIds,
+}));
+
+vi.mock("../toolResults/toolResultAssetStore", () => ({
+  deleteImageAssetsIfUnused,
+}));
+
+import { ChatService } from "../chatService";
+
+describe("ChatService tool result persistence", () => {
+  let service: ChatService;
+
+  beforeEach(() => {
+    service = new ChatService();
+    vi.clearAllMocks();
+  });
+
+  it("canonicalizes tool results before createMessage persists them", async () => {
+    normalizeToolCallResultForStorage.mockResolvedValue({
+      normalized: { __levanteToolResult: 1, modelOutput: { type: "text", value: "ok" } },
+      changed: true,
+      assetIds: [],
+    });
+    executeMock.mockResolvedValue({ rows: [], rowsAffected: 1 });
+
+    const toolCalls: PersistedToolCall[] = [
+      {
+        id: "call-1",
+        name: "screenshot",
+        arguments: {},
+        result: { images: [{ data: "AAAA", mediaType: "image/png" }] },
+        status: "success",
+      },
+    ];
+
+    await service.createMessage({
+      id: "msg-1",
+      session_id: "session-1",
+      role: "assistant",
+      content: "hello",
+      tool_calls: toolCalls,
+    });
+
+    expect(normalizeToolCallResultForStorage).toHaveBeenCalledWith(toolCalls[0].result);
+    expect(executeMock).toHaveBeenCalledWith(
+      expect.stringContaining("INSERT INTO messages"),
+      expect.arrayContaining([
+        expect.any(String),
+        "session-1",
+        "assistant",
+        "hello",
+        JSON.stringify([
+          {
+            ...toolCalls[0],
+            result: { __levanteToolResult: 1, modelOutput: { type: "text", value: "ok" } },
+          },
+        ]),
+      ]),
+    );
+  });
+
+  it("rewrites legacy rows lazily when getMessages loads them", async () => {
+    normalizeToolCallResultForStorage.mockResolvedValue({
+      normalized: { __levanteToolResult: 1, modelOutput: { type: "text", value: "ok" } },
+      changed: true,
+      assetIds: [],
+    });
+
+    executeMock
+      .mockResolvedValueOnce({ rows: [[1]] })
+      .mockResolvedValueOnce({
+        rows: [[
+          "msg-1",
+          "session-1",
+          "assistant",
+          "hello",
+          JSON.stringify([
+            {
+              id: "call-1",
+              name: "screenshot",
+              arguments: {},
+              result: { images: [{ data: "AAAA", mediaType: "image/png" }] },
+              status: "success",
+            },
+          ]),
+          100,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ]],
+      })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 1 });
+
+    const result = await service.getMessages({
+      session_id: "session-1",
+    });
+
+    expect(result.success).toBe(true);
+    expect(result.data.items[0].tool_calls).toBe(
+      JSON.stringify([
+        {
+          id: "call-1",
+          name: "screenshot",
+          arguments: {},
+          result: { __levanteToolResult: 1, modelOutput: { type: "text", value: "ok" } },
+          status: "success",
+        },
+      ]),
+    );
+    expect(executeMock).toHaveBeenCalledWith(
+      "UPDATE messages SET tool_calls = ? WHERE id = ?",
+      [
+        JSON.stringify([
+          {
+            id: "call-1",
+            name: "screenshot",
+            arguments: {},
+            result: { __levanteToolResult: 1, modelOutput: { type: "text", value: "ok" } },
+            status: "success",
+          },
+        ]),
+        "msg-1",
+      ],
+    );
+  });
+
+  it("deletes orphaned image assets when updateMessage replaces tool calls", async () => {
+    collectToolResultAssetIds
+      .mockReturnValueOnce(["asset-old"])
+      .mockReturnValueOnce(["asset-new"]);
+    normalizeToolCallResultForStorage.mockResolvedValue({
+      normalized: {
+        __levanteToolResult: 1,
+        modelOutput: {
+          type: "content",
+          value: [
+            {
+              kind: "image-ref",
+              assetId: "asset-new",
+              mediaType: "image/png",
+              byteSize: 4,
+              base64Length: 4,
+              sha256: "asset-new",
+            },
+          ],
+        },
+      },
+      changed: false,
+      assetIds: ["asset-new"],
+    });
+
+    const oldToolCallsJson = JSON.stringify([
+      {
+        id: "call-1",
+        name: "screenshot",
+        arguments: {},
+        result: {
+          __levanteToolResult: 1,
+          modelOutput: {
+            type: "content",
+            value: [
+              {
+                kind: "image-ref",
+                assetId: "asset-old",
+                mediaType: "image/png",
+                byteSize: 4,
+                base64Length: 4,
+                sha256: "asset-old",
+              },
+            ],
+          },
+        },
+        status: "success",
+      },
+    ]);
+
+    const newToolCallsJson = JSON.stringify([
+      {
+        id: "call-1",
+        name: "screenshot",
+        arguments: {},
+        result: {
+          __levanteToolResult: 1,
+          modelOutput: {
+            type: "content",
+            value: [
+              {
+                kind: "image-ref",
+                assetId: "asset-new",
+                mediaType: "image/png",
+                byteSize: 4,
+                base64Length: 4,
+                sha256: "asset-new",
+              },
+            ],
+          },
+        },
+        status: "success",
+      },
+    ]);
+
+    executeMock
+      .mockResolvedValueOnce({
+        rows: [[
+          "msg-1",
+          "session-1",
+          "assistant",
+          "hello",
+          oldToolCallsJson,
+          100,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ]],
+      })
+      .mockResolvedValueOnce({ rows: [], rowsAffected: 1 })
+      .mockResolvedValueOnce({
+        rows: [[
+          "msg-1",
+          "session-1",
+          "assistant",
+          "hello",
+          newToolCallsJson,
+          100,
+          null,
+          null,
+          null,
+          null,
+          null,
+        ]],
+      });
+
+    await service.updateMessage({
+      id: "msg-1",
+      tool_calls: [
+        {
+          id: "call-1",
+          name: "screenshot",
+          arguments: {},
+          result: { replacement: true },
+          status: "success",
+        },
+      ],
+    });
+
+    expect(deleteImageAssetsIfUnused).toHaveBeenCalledWith(["asset-old"]);
+  });
+});

--- a/src/main/services/__tests__/compactionService.test.ts
+++ b/src/main/services/__tests__/compactionService.test.ts
@@ -1,6 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Message } from '../../../types/database';
-import { CompactionService, COMPACTION_STAGES } from '../compactionService';
+import {
+  CompactionService,
+  COMPACTION_STAGES,
+  summarizeToolCallsForCompaction,
+} from '../compactionService';
 
 // Mock dependencies
 vi.mock('../chatService', () => ({
@@ -180,6 +184,36 @@ describe('CompactionService', () => {
 
       expect(result[0].reasoningText!.length).toBeLessThan(longReasoning.length);
       expect(result[0].reasoningText).toContain('characters truncated');
+    });
+
+    it('summarizes canonical image refs without reintroducing payloads', () => {
+      const summary = summarizeToolCallsForCompaction(JSON.stringify([
+        {
+          name: 'screenshot',
+          status: 'success',
+          result: {
+            __levanteToolResult: 1,
+            text: 'Captured page',
+            modelOutput: {
+              type: 'content',
+              value: [
+                { type: 'text', text: 'Captured page' },
+                {
+                  kind: 'image-ref',
+                  assetId: 'asset-1',
+                  mediaType: 'image/png',
+                  byteSize: 10,
+                  base64Length: 16,
+                  sha256: 'asset-1',
+                },
+              ],
+            },
+          },
+        },
+      ]));
+
+      expect(summary).toContain('"imageCount":1');
+      expect(summary).not.toContain('asset-1');
     });
   });
 

--- a/src/main/services/ai/__tests__/historicalToolReplay.test.ts
+++ b/src/main/services/ai/__tests__/historicalToolReplay.test.ts
@@ -1,0 +1,76 @@
+import { convertToModelMessages, type UIMessage } from "ai";
+import { describe, expect, it, vi } from "vitest";
+import { sanitizeMessagesForModel } from "../toolMessageSanitizer";
+import { buildHistoricalReplayTools } from "../../toolResults/historicalToolReplayTools";
+
+const { readImageAsset } = vi.hoisted(() => ({
+  readImageAsset: vi.fn(async () => ({
+    dataBase64: "AAAA",
+    mediaType: "image/png",
+  })),
+}));
+
+vi.mock("../../toolResults/toolResultAssetStore", () => ({
+  persistImageAsset: vi.fn(),
+  readImageAsset,
+}));
+
+describe("historicalToolReplayTools", () => {
+  it("replays canonical historical tool results through toModelOutput", async () => {
+    const messages: UIMessage[] = [
+      {
+        id: "assistant-1",
+        role: "assistant",
+        parts: [
+          {
+            type: "tool-screenshot",
+            toolCallId: "call-1",
+            toolName: "screenshot",
+            input: {},
+            state: "output-available",
+            providerExecuted: true,
+            output: {
+              __levanteToolResult: 1,
+              text: "Screenshot captured",
+              modelOutput: {
+                type: "content",
+                value: [
+                  { type: "text", text: "Screenshot captured" },
+                  {
+                    kind: "image-ref",
+                    assetId: "asset-1",
+                    mediaType: "image/png",
+                    byteSize: 4,
+                    base64Length: 4,
+                    sha256: "asset-1",
+                  },
+                ],
+              },
+            },
+          } as any,
+        ],
+      },
+    ];
+
+    const sanitized = sanitizeMessagesForModel(messages);
+    const replayTools = await buildHistoricalReplayTools({
+      messages: sanitized,
+      liveTools: {},
+      supportsVision: true,
+    });
+
+    const modelMessages = await convertToModelMessages(sanitized, {
+      tools: replayTools,
+    });
+
+    const toolResult = (modelMessages[0] as any).content.find(
+      (part: any) => part.type === "tool-result",
+    );
+
+    expect(toolResult.output.type).toBe("content");
+    expect(toolResult.output.value).toEqual([
+      { type: "text", text: "Screenshot captured" },
+      { type: "image-data", data: "AAAA", mediaType: "image/png" },
+    ]);
+  });
+});

--- a/src/main/services/ai/__tests__/historicalToolReplay.test.ts
+++ b/src/main/services/ai/__tests__/historicalToolReplay.test.ts
@@ -1,5 +1,5 @@
 import { convertToModelMessages, type UIMessage } from "ai";
-import { describe, expect, it, vi } from "vitest";
+import { describe, expect, it, vi, beforeEach } from "vitest";
 import { sanitizeMessagesForModel } from "../toolMessageSanitizer";
 import { buildHistoricalReplayTools } from "../../toolResults/historicalToolReplayTools";
 
@@ -15,7 +15,46 @@ vi.mock("../../toolResults/toolResultAssetStore", () => ({
   readImageAsset,
 }));
 
+function makeScreenshotMessage(id: string, assetId: string): UIMessage {
+  return {
+    id,
+    role: "assistant",
+    parts: [
+      {
+        type: "tool-screenshot",
+        toolCallId: id,
+        toolName: "screenshot",
+        input: {},
+        state: "output-available",
+        providerExecuted: true,
+        output: {
+          __levanteToolResult: 1,
+          text: `Screenshot ${id}`,
+          modelOutput: {
+            type: "content",
+            value: [
+              { type: "text", text: `Screenshot ${id}` },
+              {
+                kind: "image-ref",
+                assetId,
+                mediaType: "image/png",
+                byteSize: 4,
+                base64Length: 4,
+                sha256: assetId,
+              },
+            ],
+          },
+        },
+      } as any,
+    ],
+  };
+}
+
 describe("historicalToolReplayTools", () => {
+  beforeEach(() => {
+    readImageAsset.mockClear();
+  });
+
   it("replays canonical historical tool results through toModelOutput", async () => {
     const messages: UIMessage[] = [
       {
@@ -72,5 +111,76 @@ describe("historicalToolReplayTools", () => {
       { type: "text", text: "Screenshot captured" },
       { type: "image-data", data: "AAAA", mediaType: "image/png" },
     ]);
+  });
+
+  it("degrades oldest images beyond budget=2 to text, preserving the newest", async () => {
+    // 3 screenshots: oldest → middle → newest
+    const messages: UIMessage[] = [
+      makeScreenshotMessage("call-old", "asset-old"),
+      makeScreenshotMessage("call-mid", "asset-mid"),
+      makeScreenshotMessage("call-new", "asset-new"),
+    ];
+
+    const sanitized = sanitizeMessagesForModel(messages);
+    const replayTools = await buildHistoricalReplayTools({
+      messages: sanitized,
+      liveTools: {},
+      supportsVision: true,
+    });
+
+    const modelMessages = await convertToModelMessages(sanitized, {
+      tools: replayTools,
+    });
+
+    // Extract all tool-result outputs in order
+    const toolResults = (modelMessages as any[]).flatMap((msg: any) =>
+      Array.isArray(msg.content)
+        ? msg.content.filter((p: any) => p.type === "tool-result")
+        : [],
+    );
+
+    expect(toolResults).toHaveLength(3);
+
+    // Oldest (call-old) must be degraded to text — over budget
+    expect(toolResults[0].output.type).toBe("text");
+    expect(toolResults[0].output.value).toContain("Screenshot call-old");
+
+    // Middle and newest must keep image content
+    expect(toolResults[1].output.type).toBe("content");
+    expect(toolResults[1].output.value).toContainEqual(
+      expect.objectContaining({ type: "image-data" }),
+    );
+    expect(toolResults[2].output.type).toBe("content");
+    expect(toolResults[2].output.value).toContainEqual(
+      expect.objectContaining({ type: "image-data" }),
+    );
+  });
+
+  it("passes all images through when total is within budget", async () => {
+    const messages: UIMessage[] = [
+      makeScreenshotMessage("call-1", "asset-1"),
+      makeScreenshotMessage("call-2", "asset-2"),
+    ];
+
+    const sanitized = sanitizeMessagesForModel(messages);
+    const replayTools = await buildHistoricalReplayTools({
+      messages: sanitized,
+      liveTools: {},
+      supportsVision: true,
+    });
+
+    const modelMessages = await convertToModelMessages(sanitized, {
+      tools: replayTools,
+    });
+
+    const toolResults = (modelMessages as any[]).flatMap((msg: any) =>
+      Array.isArray(msg.content)
+        ? msg.content.filter((p: any) => p.type === "tool-result")
+        : [],
+    );
+
+    expect(toolResults).toHaveLength(2);
+    expect(toolResults[0].output.type).toBe("content");
+    expect(toolResults[1].output.type).toBe("content");
   });
 });

--- a/src/main/services/ai/__tests__/mcpToolsAdapter.image.test.ts
+++ b/src/main/services/ai/__tests__/mcpToolsAdapter.image.test.ts
@@ -1,8 +1,21 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
-const { recordSuccess, recordError } = vi.hoisted(() => ({
+const { recordSuccess, recordError, persistImageAsset, readImageAsset } = vi.hoisted(() => ({
   recordSuccess: vi.fn(),
   recordError: vi.fn(),
+  persistImageAsset: vi.fn(async (params: { dataBase64: string; mediaType: string }) => ({
+    assetId: "asset-1",
+    sha256: "asset-1",
+    mediaType: params.mediaType,
+    byteSize: params.dataBase64.length,
+    base64Length: params.dataBase64.length,
+    width: 100,
+    height: 80,
+  })),
+  readImageAsset: vi.fn(async () => ({
+    dataBase64: "AAAA",
+    mediaType: "image/png",
+  })),
 }));
 
 vi.mock("../../../ipc/mcpHandlers", () => ({
@@ -36,12 +49,16 @@ vi.mock("../../logging", () => ({
   },
 }));
 
-// Stub the resizer to avoid native sharp in this unit test.
 vi.mock("../../image/imageResizer.js", () => ({
   resizeMCPImageBlock: vi.fn(async (input: { data: string; mimeType?: string }) => ({
     data: input.data.slice(0, 10),
     mediaType: input.mimeType || "image/png",
   })),
+}));
+
+vi.mock("../../toolResults/toolResultAssetStore", () => ({
+  persistImageAsset,
+  readImageAsset,
 }));
 
 import {
@@ -55,9 +72,11 @@ describe("processToolResult with image blocks", () => {
   beforeEach(() => {
     recordSuccess.mockClear();
     recordError.mockClear();
+    persistImageAsset.mockClear();
+    readImageAsset.mockClear();
   });
 
-  it("transforms image blocks into images[] with placeholder text and does not serialize base64", async () => {
+  it("returns CanonicalToolResultV1 and removes raw images[] output", async () => {
     const big = "A".repeat(2000);
     const output = (await processToolResult(
       "srv",
@@ -71,18 +90,24 @@ describe("processToolResult with image blocks", () => {
       },
     )) as any;
 
-    expect(output).toHaveProperty("images");
-    expect(output.images).toHaveLength(1);
-    expect(output.images[0].mediaType).toBe("image/png");
-    // The placeholder should be in text and the raw base64 must not leak.
+    expect(output.__levanteToolResult).toBe(1);
+    expect(output).not.toHaveProperty("images");
     expect(output.text).toContain("[Image received from screenshot]");
-    expect(output.text).not.toContain(big);
-    // content[] image block is tombstoned by sanitizeToolOutput
+    expect(output.modelOutput.type).toBe("content");
+    expect(output.modelOutput.value).toEqual([
+      { type: "text", text: "header\n[Image received from screenshot]" },
+      expect.objectContaining({
+        kind: "image-ref",
+        assetId: "asset-1",
+        mediaType: "image/png",
+      }),
+    ]);
+
     const imgBlock = output.content.find((c: any) => c.type === "image");
     expect(imgBlock).toMatchObject({ omitted: true });
   });
 
-  it("applies a textual fallback when resize throws", async () => {
+  it("falls back to canonical text when resize throws", async () => {
     const resizer = await import("../../image/imageResizer.js");
     (resizer.resizeMCPImageBlock as any).mockImplementationOnce(async () => {
       throw new Error("boom");
@@ -99,25 +124,41 @@ describe("processToolResult with image blocks", () => {
       },
     )) as any;
 
-    // No images were produced, so plain text is returned.
-    expect(typeof output).toBe("string");
-    expect(output).toContain("could not be included");
+    expect(output.__levanteToolResult).toBe(1);
+    expect(output.modelOutput).toEqual({
+      type: "text",
+      value: "[Image from screenshot could not be included because it exceeded API limits.]",
+    });
   });
 });
 
 describe("createAISDKTool.toModelOutput", () => {
-  it("returns image-data parts when supportsVision is true", () => {
+  it("returns image-data parts when supportsVision is true", async () => {
     const aiTool: any = createAISDKTool("srv", baseTool as any, {
       skipApproval: true,
       supportsVision: true,
     });
 
-    const res = aiTool.toModelOutput({
+    const res = await aiTool.toModelOutput({
       toolCallId: "call_1",
       input: {},
       output: {
+        __levanteToolResult: 1,
         text: "hello",
-        images: [{ data: "AAAA", mediaType: "image/png" }],
+        modelOutput: {
+          type: "content",
+          value: [
+            { type: "text", text: "hello" },
+            {
+              kind: "image-ref",
+              assetId: "asset-1",
+              mediaType: "image/png",
+              byteSize: 4,
+              base64Length: 4,
+              sha256: "asset-1",
+            },
+          ],
+        },
       },
     });
 
@@ -128,18 +169,31 @@ describe("createAISDKTool.toModelOutput", () => {
     ]);
   });
 
-  it("degrades to text when supportsVision is false", () => {
+  it("degrades to text when supportsVision is false", async () => {
     const aiTool: any = createAISDKTool("srv", baseTool as any, {
       skipApproval: true,
       supportsVision: false,
     });
 
-    const res = aiTool.toModelOutput({
+    const res = await aiTool.toModelOutput({
       toolCallId: "call_1",
       input: {},
       output: {
+        __levanteToolResult: 1,
         text: "fallback text",
-        images: [{ data: "AAAA", mediaType: "image/png" }],
+        modelOutput: {
+          type: "content",
+          value: [
+            {
+              kind: "image-ref",
+              assetId: "asset-1",
+              mediaType: "image/png",
+              byteSize: 4,
+              base64Length: 4,
+              sha256: "asset-1",
+            },
+          ],
+        },
       },
     });
 

--- a/src/main/services/ai/__tests__/toolMessageSanitizer.test.ts
+++ b/src/main/services/ai/__tests__/toolMessageSanitizer.test.ts
@@ -234,7 +234,7 @@ describe('sanitizeMessagesForModel', () => {
     expect(part.output.modelOutput.value[1].kind).toBe('image-ref');
   });
 
-  it('keeps legacy outputs as sanitized objects without semantic conversion', () => {
+  it('strips uiResources and images from legacy outputs', () => {
     const output = {
       text: 'txt',
       content: [{ type: 'text', text: 'txt' }],
@@ -251,12 +251,67 @@ describe('sanitizeMessagesForModel', () => {
     const result = sanitizeMessagesForModel(messages);
     const part = result[0].parts[0] as any;
 
-    expect(part.output).toEqual({
-      text: 'txt',
-      content: [{ type: 'text', text: 'txt' }],
+    expect(part.output.uiResources).toBeUndefined();
+    expect(part.output.images).toBeUndefined();
+    expect(part.output.text).toBe('txt');
+    expect(part.output.content).toEqual([{ type: 'text', text: 'txt' }]);
+  });
+
+  it('strips uiResources from non-canonical outputs', () => {
+    const output = {
+      uiResources: [{ type: 'resource' }],
+      text: 'some text',
+    };
+
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart({ state: 'output-available', output }),
+      ]),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+    const part = result[0].parts[0] as any;
+
+    expect(part.output.uiResources).toBeUndefined();
+    expect(part.output.text).toBe('some text');
+  });
+
+  it('preserves uiResources when output is canonical', () => {
+    const output = {
+      __levanteToolResult: 1,
+      text: 'canonical',
+      modelOutput: { type: 'text', value: 'canonical' },
+      uiResources: [{ type: 'resource' }],
+    };
+
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart({ state: 'output-available', output }),
+      ]),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+    const part = result[0].parts[0] as any;
+
+    expect(part.output.uiResources).toEqual([{ type: 'resource' }]);
+  });
+
+  it('falls back to "[Widget rendered]" when legacy output has no recognized fields', () => {
+    const output = {
       uiResources: [{ type: 'resource' }],
       images: [{ data: 'AAAA', mediaType: 'image/png' }],
-    });
+    };
+
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart({ state: 'output-available', output }),
+      ]),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+    const part = result[0].parts[0] as any;
+
+    expect(part.output).toBe('[Widget rendered]');
   });
 
   it('sanitizes legacy content[].image without inventing image-data', () => {
@@ -277,13 +332,11 @@ describe('sanitizeMessagesForModel', () => {
     const result = sanitizeMessagesForModel(messages);
     const part = result[0].parts[0] as any;
 
-    expect(part.output).toEqual({
-      uiResources: [],
-      content: [
-        { type: 'text', text: 'header' },
-        { type: 'image', mimeType: 'image/png', omitted: true },
-      ],
-    });
+    expect(part.output.uiResources).toBeUndefined();
+    expect(part.output.content).toEqual([
+      { type: 'text', text: 'header' },
+      { type: 'image', mimeType: 'image/png', omitted: true },
+    ]);
     expect(JSON.stringify(part.output)).not.toContain('BIGBASE64');
   });
 
@@ -321,10 +374,8 @@ describe('sanitizeMessagesForModel', () => {
     const result = sanitizeMessagesForModel(messages);
     const part = result[0].parts[0] as any;
 
-    expect(part.output).toEqual({
-      structuredContent: { payload: 123 },
-      uiResources: [],
-      content: [{ type: 'text', text: 'hi' }],
-    });
+    expect(part.output.structuredContent).toEqual({ payload: 123 });
+    expect(part.output.content).toEqual([{ type: 'text', text: 'hi' }]);
+    expect(part.output.uiResources).toBeUndefined();
   });
 });

--- a/src/main/services/ai/__tests__/toolMessageSanitizer.test.ts
+++ b/src/main/services/ai/__tests__/toolMessageSanitizer.test.ts
@@ -201,7 +201,40 @@ describe('sanitizeMessagesForModel', () => {
     expect(part.providerMetadata).toBeUndefined();
   });
 
-  it('preserves images[] on tool output with uiResources', () => {
+  it('preserves canonical tool outputs intact', () => {
+    const output = {
+      __levanteToolResult: 1,
+      text: 'canonical',
+      modelOutput: {
+        type: 'content',
+        value: [
+          { type: 'text', text: 'canonical' },
+          {
+            kind: 'image-ref',
+            assetId: 'asset-1',
+            mediaType: 'image/png',
+            byteSize: 4,
+            base64Length: 4,
+            sha256: 'asset-1',
+          },
+        ],
+      },
+    };
+
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart({ state: 'output-available', output }),
+      ]),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+    const part = result[0].parts[0] as any;
+
+    expect(part.output).toEqual(output);
+    expect(part.output.modelOutput.value[1].kind).toBe('image-ref');
+  });
+
+  it('keeps legacy outputs as sanitized objects without semantic conversion', () => {
     const output = {
       text: 'txt',
       content: [{ type: 'text', text: 'txt' }],
@@ -220,11 +253,13 @@ describe('sanitizeMessagesForModel', () => {
 
     expect(part.output).toEqual({
       text: 'txt',
+      content: [{ type: 'text', text: 'txt' }],
+      uiResources: [{ type: 'resource' }],
       images: [{ data: 'AAAA', mediaType: 'image/png' }],
     });
   });
 
-  it('converts legacy content[].image to placeholder text when no images[] exists', () => {
+  it('sanitizes legacy content[].image without inventing image-data', () => {
     const output = {
       uiResources: [],
       content: [
@@ -242,9 +277,13 @@ describe('sanitizeMessagesForModel', () => {
     const result = sanitizeMessagesForModel(messages);
     const part = result[0].parts[0] as any;
 
-    expect(part.output).toBe(
-      'header\n[Legacy MCP image omitted from historical tool output]',
-    );
+    expect(part.output).toEqual({
+      uiResources: [],
+      content: [
+        { type: 'text', text: 'header' },
+        { type: 'image', mimeType: 'image/png', omitted: true },
+      ],
+    });
     expect(JSON.stringify(part.output)).not.toContain('BIGBASE64');
   });
 
@@ -266,7 +305,7 @@ describe('sanitizeMessagesForModel', () => {
     expect(messages).toEqual(snapshot);
   });
 
-  it('keeps structuredContent preferred when no images[] is present', () => {
+  it('keeps structuredContent available on legacy outputs', () => {
     const output = {
       uiResources: [],
       structuredContent: { payload: 123 },
@@ -282,6 +321,10 @@ describe('sanitizeMessagesForModel', () => {
     const result = sanitizeMessagesForModel(messages);
     const part = result[0].parts[0] as any;
 
-    expect(part.output).toEqual({ payload: 123 });
+    expect(part.output).toEqual({
+      structuredContent: { payload: 123 },
+      uiResources: [],
+      content: [{ type: 'text', text: 'hi' }],
+    });
   });
 });

--- a/src/main/services/ai/contextDiagnostics.ts
+++ b/src/main/services/ai/contextDiagnostics.ts
@@ -1,0 +1,145 @@
+import { getLogger } from "../logging";
+
+type ContextStringDiagnostic = {
+  path: string;
+  length: number;
+  preview: string;
+};
+
+type ContextImageDiagnostic = {
+  path: string;
+  kind: "image-data" | "file-data-url" | "tool-images" | "tool-image-ref";
+  base64Length: number;
+  mediaType?: string;
+};
+
+export function collectLargestStrings(
+  value: unknown,
+  path: string,
+  acc: ContextStringDiagnostic[],
+): void {
+  if (typeof value === "string") {
+    acc.push({
+      path,
+      length: value.length,
+      preview: value.slice(0, 120),
+    });
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectLargestStrings(item, `${path}[${index}]`, acc),
+    );
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(
+      value as Record<string, unknown>,
+    )) {
+      collectLargestStrings(child, `${path}.${key}`, acc);
+    }
+  }
+}
+
+export function collectImagePayloads(
+  value: unknown,
+  path: string,
+  acc: ContextImageDiagnostic[],
+): void {
+  if (!value || typeof value !== "object") return;
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectImagePayloads(item, `${path}[${index}]`, acc),
+    );
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const type = typeof obj.type === "string" ? obj.type : undefined;
+
+  if (type === "image-data" && typeof obj.data === "string") {
+    acc.push({
+      path,
+      kind: "image-data",
+      base64Length: obj.data.length,
+      mediaType: typeof obj.mediaType === "string" ? obj.mediaType : undefined,
+    });
+  }
+
+  if (
+    type === "file" &&
+    typeof obj.url === "string" &&
+    obj.url.startsWith("data:image/")
+  ) {
+    const base64 = obj.url.split(",")[1] || "";
+    acc.push({
+      path,
+      kind: "file-data-url",
+      base64Length: base64.length,
+      mediaType: typeof obj.mediaType === "string" ? obj.mediaType : undefined,
+    });
+  }
+
+  if (Array.isArray(obj.images)) {
+    obj.images.forEach((image, index) => {
+      if (image && typeof image === "object") {
+        const img = image as Record<string, unknown>;
+        acc.push({
+          path: `${path}.images[${index}]`,
+          kind: "tool-images",
+          base64Length: typeof img.data === "string" ? img.data.length : 0,
+          mediaType:
+            typeof img.mediaType === "string" ? img.mediaType : undefined,
+        });
+      }
+    });
+  }
+
+  if (
+    obj.kind === "image-ref" &&
+    typeof obj.assetId === "string" &&
+    typeof obj.mediaType === "string"
+  ) {
+    acc.push({
+      path,
+      kind: "tool-image-ref",
+      base64Length: 0,
+      mediaType: obj.mediaType,
+    });
+  }
+
+  for (const [key, child] of Object.entries(obj)) {
+    if (key === "images") continue;
+    collectImagePayloads(child, `${path}.${key}`, acc);
+  }
+}
+
+export function logContextDiagnostics(
+  logger: ReturnType<typeof getLogger>,
+  label: string,
+  value: unknown,
+): void {
+  if (!getLogger().isEnabled("ai-sdk", "debug")) return;
+
+  const strings: ContextStringDiagnostic[] = [];
+  const images: ContextImageDiagnostic[] = [];
+
+  collectLargestStrings(value, label, strings);
+  collectImagePayloads(value, label, images);
+
+  strings.sort((a, b) => b.length - a.length);
+  images.sort((a, b) => b.base64Length - a.base64Length);
+
+  logger.aiSdk.debug("[CTX_DIAGNOSTICS] Largest strings", {
+    label,
+    topStrings: strings.slice(0, 20),
+  });
+
+  logger.aiSdk.debug("[CTX_DIAGNOSTICS] Image payloads", {
+    label,
+    imagePayloads: images.slice(0, 20),
+  });
+}

--- a/src/main/services/ai/mcpToolsAdapter.ts
+++ b/src/main/services/ai/mcpToolsAdapter.ts
@@ -24,7 +24,10 @@ import {
   DEFAULT_MAX_MCP_OUTPUT_TOKENS,
   IMAGE_TOKEN_ESTIMATE,
 } from "../image/providerImageLimits.js";
-import { sanitizeToolOutput } from "../../../shared/toolOutputSanitizer.js";
+import {
+  canonicalizeRichToolOutput,
+  materializeToolResultForModel,
+} from "../toolResults/canonicalToolResultService";
 
 const logger = getLogger();
 
@@ -484,82 +487,11 @@ export function createAISDKTool(
     //   - "content" with parts (image-data + text) for multimodal results
     //   - "json" for structured content only
     //   - "text" for plain text results
-    toModelOutput: ({ output }) => {
-      if (
-        output &&
-        typeof output === "object" &&
-        "images" in output &&
-        Array.isArray((output as any).images)
-      ) {
-        const o = output as {
-          text?: string;
-          images: Array<{ data: string; mediaType: string }>;
-        };
-
-        if (!supportsVision) {
-          return {
-            type: "text",
-            value:
-              o.text ||
-              "[Tool returned an image, but the active model does not support vision.]",
-          };
-        }
-
-        const parts: Array<
-          | { type: "text"; text: string }
-          | { type: "image-data"; data: string; mediaType: string }
-        > = [];
-
-        if (o.text) {
-          parts.push({ type: "text", text: o.text });
-        }
-
-        for (const image of o.images) {
-          parts.push({
-            type: "image-data",
-            data: image.data,
-            mediaType: image.mediaType,
-          });
-        }
-
-        return {
-          type: "content",
-          value: parts,
-        };
-      }
-
-      if (typeof output === "string") {
-        return { type: "text", value: output };
-      }
-
-      if (output && typeof output === "object") {
-        const o = output as {
-          text?: string;
-          structuredContent?: Record<string, unknown>;
-          uiResources?: unknown[];
-        };
-
-        // IMPORTANT: uiResources is UI payload, it must NOT reach the model.
-        // If there are no images, only forward what's useful for the LLM.
-        if (o.structuredContent) {
-          return {
-            type: "json",
-            value: o.structuredContent as any,
-          };
-        }
-
-        if (o.text) {
-          return {
-            type: "text",
-            value: o.text,
-          };
-        }
-      }
-
-      return {
-        type: "json",
-        value: output as any,
-      };
+    toModelOutput: async ({ output }) => {
+      return materializeToolResultForModel({
+        output,
+        supportsVision,
+      });
     },
   });
 
@@ -1242,23 +1174,15 @@ export async function processToolResult(
       });
     }
 
-    // Return structured result when we have UI resources or images. Always pass
-    // through sanitizeToolOutput so `content[]` image blocks are turned into
-    // lightweight placeholders before the output is stored/rehydrated.
-    if (uiResources.length > 0 || imageParts.length > 0) {
-      return sanitizeToolOutput({
-        text,
-        content: result.content,
-        ...(result.structuredContent
-          ? { structuredContent: result.structuredContent }
-          : {}),
-        ...(uiResources.length > 0 ? { uiResources } : {}),
-        ...(imageParts.length > 0 ? { images: imageParts } : {}),
-      });
-    }
-
-    // No UI resources and no images - return text only
-    return text;
+    return canonicalizeRichToolOutput({
+      text,
+      content: result.content,
+      ...(result.structuredContent
+        ? { structuredContent: result.structuredContent }
+        : {}),
+      ...(uiResources.length > 0 ? { uiResources } : {}),
+      ...(imageParts.length > 0 ? { legacyImages: imageParts } : {}),
+    });
   }
 
   // For non-content results, return as-is

--- a/src/main/services/ai/toolMessageSanitizer.ts
+++ b/src/main/services/ai/toolMessageSanitizer.ts
@@ -148,26 +148,19 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
             cleanOutput.text = (output as any).text;
           }
 
-          if (Array.isArray((output as any).uiResources)) {
-            cleanOutput.uiResources = (output as any).uiResources;
-          }
-
           if (Array.isArray((output as any).content)) {
             cleanOutput.content = stripInlineImagesFromContent(
               (output as any).content as unknown[],
             );
           }
 
-          if (
-            Array.isArray((output as any).images) &&
-            (output as any).images.length > 0
-          ) {
-            cleanOutput.images = (output as any).images;
+          if (Object.keys(cleanOutput).length === 0) {
+            return { ...part, output: '[Widget rendered]' };
           }
 
           return {
             ...part,
-            output: Object.keys(cleanOutput).length > 0 ? cleanOutput : output,
+            output: cleanOutput,
           };
         }
       }

--- a/src/main/services/ai/toolMessageSanitizer.ts
+++ b/src/main/services/ai/toolMessageSanitizer.ts
@@ -1,4 +1,5 @@
 import { type UIMessage } from 'ai';
+import { isCanonicalToolResult } from '../../../shared/canonicalToolResult';
 import { stripInlineImagesFromContent } from '../../../shared/toolOutputSanitizer';
 
 /**
@@ -119,13 +120,12 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
         }
       }
 
+      // IMPORTANT:
+      // Tool output semantic conversion happens in materializeToolResultForModel()
+      // via tool.toModelOutput(). This sanitizer must not duplicate image handling.
+      //
       // Sanitize tool invocation outputs that contain uiResources (MCP-UI)
-      // According to MCP spec 2025-11-25:
-      // - structuredContent → SEND to LLM (structured JSON for processing)
-      // - content → SEND to LLM (text for backwards compatibility)
-      // - _meta → NEVER send (client metadata, may contain secrets like game words)
-      // - uiResources → NEVER send (only for widget rendering)
-      // Note: Tool parts can have type 'tool-invocation' or 'tool-{toolName}' depending on source
+      // or legacy image payloads without altering canonical semantics.
       const isToolWithOutput = (
         // AI SDK format: tool-invocation with output-available state
         (// Stored format: tool-{name} with output-available state
@@ -133,47 +133,29 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
       );
       if (isToolWithOutput && part.output) {
         const output = part.output;
-        if (
-          output &&
-          typeof output === 'object' &&
-          ('uiResources' in output || 'images' in output)
-        ) {
+        if (isCanonicalToolResult(output)) {
+          return part;
+        }
+
+        if (output && typeof output === 'object') {
           const cleanOutput: Record<string, unknown> = {};
 
           if ((output as any).structuredContent) {
             cleanOutput.structuredContent = (output as any).structuredContent;
           }
 
-          if (Array.isArray((output as any).content)) {
-            // Aligerar cualquier bloque image legacy reutilizando el helper
-            // unificado (evita duplicar la lógica de lápida aquí).
-            const neutralizedContent = stripInlineImagesFromContent(
-              (output as any).content as unknown[],
-            );
-
-            const contentTexts = neutralizedContent
-              .filter(
-                (item: any) => item?.type === 'text' && item?.text,
-              )
-              .map((item: any) => item.text as string);
-
-            const hadLegacyImages = ((output as any).content as any[]).some(
-              (item: any) => item?.type === 'image',
-            );
-
-            if (hadLegacyImages && !Array.isArray((output as any).images)) {
-              contentTexts.push(
-                '[Legacy MCP image omitted from historical tool output]',
-              );
-            }
-
-            if (contentTexts.length > 0) {
-              cleanOutput.text = contentTexts.join('\n');
-            }
+          if (typeof (output as any).text === 'string') {
+            cleanOutput.text = (output as any).text;
           }
 
-          if (!cleanOutput.text && (output as any).text) {
-            cleanOutput.text = (output as any).text;
+          if (Array.isArray((output as any).uiResources)) {
+            cleanOutput.uiResources = (output as any).uiResources;
+          }
+
+          if (Array.isArray((output as any).content)) {
+            cleanOutput.content = stripInlineImagesFromContent(
+              (output as any).content as unknown[],
+            );
           }
 
           if (
@@ -183,24 +165,9 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
             cleanOutput.images = (output as any).images;
           }
 
-          let outputForModel: unknown;
-
-          if (cleanOutput.images) {
-            outputForModel = {
-              text: cleanOutput.text ?? '',
-              images: cleanOutput.images,
-            };
-          } else if (cleanOutput.structuredContent) {
-            outputForModel = cleanOutput.structuredContent;
-          } else if (cleanOutput.text) {
-            outputForModel = cleanOutput.text;
-          } else {
-            outputForModel = '[Widget rendered]';
-          }
-
           return {
             ...part,
-            output: outputForModel,
+            output: Object.keys(cleanOutput).length > 0 ? cleanOutput : output,
           };
         }
       }

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -38,6 +38,7 @@ import type {
 } from "../../types/modelCategories";
 import type { InstalledSkill } from "../../types/skills";
 import { skillsService } from "./skillsService";
+import { buildHistoricalReplayTools } from "./toolResults/historicalToolReplayTools";
 
 export interface ChatRequest {
   messages: UIMessage[];
@@ -134,10 +135,145 @@ type PreExecutedTool = {
   errorText?: string;
 };
 
+type ContextStringDiagnostic = {
+  path: string;
+  length: number;
+  preview: string;
+};
+
+type ContextImageDiagnostic = {
+  path: string;
+  kind: "image-data" | "file-data-url" | "tool-images" | "tool-image-ref";
+  base64Length: number;
+  mediaType?: string;
+};
+
 function isToolLikePart(part: any): boolean {
   if (!part || typeof part !== "object") return false;
   if (part.type === "dynamic-tool") return true;
   return typeof part.type === "string" && part.type.startsWith("tool-");
+}
+
+function collectLargestStrings(
+  value: unknown,
+  path: string,
+  acc: ContextStringDiagnostic[]
+): void {
+  if (typeof value === "string") {
+    acc.push({
+      path,
+      length: value.length,
+      preview: value.slice(0, 120),
+    });
+    return;
+  }
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectLargestStrings(item, `${path}[${index}]`, acc)
+    );
+    return;
+  }
+
+  if (value && typeof value === "object") {
+    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+      collectLargestStrings(child, `${path}.${key}`, acc);
+    }
+  }
+}
+
+function collectImagePayloads(
+  value: unknown,
+  path: string,
+  acc: ContextImageDiagnostic[]
+): void {
+  if (!value || typeof value !== "object") return;
+
+  if (Array.isArray(value)) {
+    value.forEach((item, index) =>
+      collectImagePayloads(item, `${path}[${index}]`, acc)
+    );
+    return;
+  }
+
+  const obj = value as Record<string, unknown>;
+  const type = typeof obj.type === "string" ? obj.type : undefined;
+
+  if (type === "image-data" && typeof obj.data === "string") {
+    acc.push({
+      path,
+      kind: "image-data",
+      base64Length: obj.data.length,
+      mediaType: typeof obj.mediaType === "string" ? obj.mediaType : undefined,
+    });
+  }
+
+  if (type === "file" && typeof obj.url === "string" && obj.url.startsWith("data:image/")) {
+    const base64 = obj.url.split(",")[1] || "";
+    acc.push({
+      path,
+      kind: "file-data-url",
+      base64Length: base64.length,
+      mediaType: typeof obj.mediaType === "string" ? obj.mediaType : undefined,
+    });
+  }
+
+  if (Array.isArray(obj.images)) {
+    obj.images.forEach((image, index) => {
+      if (image && typeof image === "object") {
+        const img = image as Record<string, unknown>;
+        acc.push({
+          path: `${path}.images[${index}]`,
+          kind: "tool-images",
+          base64Length: typeof img.data === "string" ? img.data.length : 0,
+          mediaType: typeof img.mediaType === "string" ? img.mediaType : undefined,
+        });
+      }
+    });
+  }
+
+  if (
+    obj.kind === "image-ref" &&
+    typeof obj.assetId === "string" &&
+    typeof obj.mediaType === "string"
+  ) {
+    acc.push({
+      path,
+      kind: "tool-image-ref",
+      base64Length: 0,
+      mediaType: obj.mediaType,
+    });
+  }
+
+  for (const [key, child] of Object.entries(obj)) {
+    if (key === "images") continue;
+    collectImagePayloads(child, `${path}.${key}`, acc);
+  }
+}
+
+function logContextDiagnostics(
+  logger: ReturnType<typeof getLogger>,
+  label: string,
+  value: unknown
+): void {
+  const strings: ContextStringDiagnostic[] = [];
+  const images: ContextImageDiagnostic[] = [];
+
+  collectLargestStrings(value, label, strings);
+  collectImagePayloads(value, label, images);
+
+  strings.sort((a, b) => b.length - a.length);
+  images.sort((a, b) => b.base64Length - a.base64Length);
+
+  logger.aiSdk.info("[CTX_DIAGNOSTICS] Largest strings", {
+    label,
+    topStrings: strings.slice(0, 20),
+  });
+
+  logger.aiSdk.info("[CTX_DIAGNOSTICS] Image payloads", {
+    label,
+    imagePayloads: images.slice(0, 20),
+  });
 }
 
 function resolveToolNameFromPart(part: any): string | undefined {
@@ -1302,7 +1438,17 @@ export class AIService {
       // exact shape convertToModelMessages will consume.
       validateImagesForAPI(sanitizedMessages as unknown[]);
 
-      const modelMessages = await convertToModelMessages(sanitizedMessages);
+      const replayTools = await buildHistoricalReplayTools({
+        messages: sanitizedMessages,
+        liveTools: tools,
+        supportsVision: modelInfo?.capabilities?.supportsVision === true,
+      });
+
+      const modelMessages = await convertToModelMessages(sanitizedMessages, {
+        tools: replayTools,
+      });
+      logContextDiagnostics(this.logger, "sanitizedMessages", sanitizedMessages);
+      logContextDiagnostics(this.logger, "modelMessages", modelMessages);
 
       const todoToolsEnabled = 'todo_write' in tools;
 
@@ -2108,10 +2254,21 @@ export class AIService {
 
       const singleMsgSanitized = sanitizeMessagesForModel(messagesWithFileParts);
       validateImagesForAPI(singleMsgSanitized as unknown[]);
+      const singleMsgReplayTools = await buildHistoricalReplayTools({
+        messages: singleMsgSanitized,
+        liveTools: allSingleMsgTools,
+        supportsVision: modelInfo?.capabilities?.supportsVision === true,
+      });
+
+      const singleMsgModelMessages = await convertToModelMessages(singleMsgSanitized, {
+        tools: singleMsgReplayTools,
+      });
+      logContextDiagnostics(this.logger, "singleMsgSanitized", singleMsgSanitized);
+      logContextDiagnostics(this.logger, "singleMsgModelMessages", singleMsgModelMessages);
 
       const result = await generateText({
         model: modelProvider,
-        messages: await convertToModelMessages(singleMsgSanitized),
+        messages: singleMsgModelMessages,
         tools: allSingleMsgTools,
         system: await buildSystemPrompt(
           webSearch,

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -135,145 +135,17 @@ type PreExecutedTool = {
   errorText?: string;
 };
 
-type ContextStringDiagnostic = {
-  path: string;
-  length: number;
-  preview: string;
-};
-
-type ContextImageDiagnostic = {
-  path: string;
-  kind: "image-data" | "file-data-url" | "tool-images" | "tool-image-ref";
-  base64Length: number;
-  mediaType?: string;
-};
+export {
+  collectLargestStrings,
+  collectImagePayloads,
+  logContextDiagnostics,
+} from "./ai/contextDiagnostics";
+import { logContextDiagnostics } from "./ai/contextDiagnostics";
 
 function isToolLikePart(part: any): boolean {
   if (!part || typeof part !== "object") return false;
   if (part.type === "dynamic-tool") return true;
   return typeof part.type === "string" && part.type.startsWith("tool-");
-}
-
-function collectLargestStrings(
-  value: unknown,
-  path: string,
-  acc: ContextStringDiagnostic[]
-): void {
-  if (typeof value === "string") {
-    acc.push({
-      path,
-      length: value.length,
-      preview: value.slice(0, 120),
-    });
-    return;
-  }
-
-  if (Array.isArray(value)) {
-    value.forEach((item, index) =>
-      collectLargestStrings(item, `${path}[${index}]`, acc)
-    );
-    return;
-  }
-
-  if (value && typeof value === "object") {
-    for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
-      collectLargestStrings(child, `${path}.${key}`, acc);
-    }
-  }
-}
-
-function collectImagePayloads(
-  value: unknown,
-  path: string,
-  acc: ContextImageDiagnostic[]
-): void {
-  if (!value || typeof value !== "object") return;
-
-  if (Array.isArray(value)) {
-    value.forEach((item, index) =>
-      collectImagePayloads(item, `${path}[${index}]`, acc)
-    );
-    return;
-  }
-
-  const obj = value as Record<string, unknown>;
-  const type = typeof obj.type === "string" ? obj.type : undefined;
-
-  if (type === "image-data" && typeof obj.data === "string") {
-    acc.push({
-      path,
-      kind: "image-data",
-      base64Length: obj.data.length,
-      mediaType: typeof obj.mediaType === "string" ? obj.mediaType : undefined,
-    });
-  }
-
-  if (type === "file" && typeof obj.url === "string" && obj.url.startsWith("data:image/")) {
-    const base64 = obj.url.split(",")[1] || "";
-    acc.push({
-      path,
-      kind: "file-data-url",
-      base64Length: base64.length,
-      mediaType: typeof obj.mediaType === "string" ? obj.mediaType : undefined,
-    });
-  }
-
-  if (Array.isArray(obj.images)) {
-    obj.images.forEach((image, index) => {
-      if (image && typeof image === "object") {
-        const img = image as Record<string, unknown>;
-        acc.push({
-          path: `${path}.images[${index}]`,
-          kind: "tool-images",
-          base64Length: typeof img.data === "string" ? img.data.length : 0,
-          mediaType: typeof img.mediaType === "string" ? img.mediaType : undefined,
-        });
-      }
-    });
-  }
-
-  if (
-    obj.kind === "image-ref" &&
-    typeof obj.assetId === "string" &&
-    typeof obj.mediaType === "string"
-  ) {
-    acc.push({
-      path,
-      kind: "tool-image-ref",
-      base64Length: 0,
-      mediaType: obj.mediaType,
-    });
-  }
-
-  for (const [key, child] of Object.entries(obj)) {
-    if (key === "images") continue;
-    collectImagePayloads(child, `${path}.${key}`, acc);
-  }
-}
-
-function logContextDiagnostics(
-  logger: ReturnType<typeof getLogger>,
-  label: string,
-  value: unknown
-): void {
-  const strings: ContextStringDiagnostic[] = [];
-  const images: ContextImageDiagnostic[] = [];
-
-  collectLargestStrings(value, label, strings);
-  collectImagePayloads(value, label, images);
-
-  strings.sort((a, b) => b.length - a.length);
-  images.sort((a, b) => b.base64Length - a.base64Length);
-
-  logger.aiSdk.info("[CTX_DIAGNOSTICS] Largest strings", {
-    label,
-    topStrings: strings.slice(0, 20),
-  });
-
-  logger.aiSdk.info("[CTX_DIAGNOSTICS] Image payloads", {
-    label,
-    imagePayloads: images.slice(0, 20),
-  });
 }
 
 function resolveToolNameFromPart(part: any): string | undefined {

--- a/src/main/services/chatService.ts
+++ b/src/main/services/chatService.ts
@@ -123,21 +123,9 @@ export class ChatService {
     };
   }
 
-  private async rewriteNormalizedToolCalls(messageId: string, toolCalls: string): Promise<string> {
-    const normalized = await this.normalizeToolCallsJsonForStorage(toolCalls);
-    if (normalized.changed) {
-      await databaseService.execute(
-        'UPDATE messages SET tool_calls = ? WHERE id = ?',
-        [normalized.serialized as InValue, messageId as InValue],
-      );
-    }
-
-    return normalized.serialized ?? toolCalls;
-  }
-
   private async mapMessageRow(row: any[]): Promise<Message> {
     const toolCalls = typeof row[4] === 'string' && row[4].length > 0
-      ? await this.rewriteNormalizedToolCalls(row[0] as string, row[4] as string)
+      ? (await this.normalizeToolCallsJsonForStorage(row[4] as string)).serialized
       : ((row[4] as string) || null);
 
     return {

--- a/src/main/services/chatService.ts
+++ b/src/main/services/chatService.ts
@@ -3,6 +3,7 @@ import { databaseService } from './databaseService';
 import {
   ChatSession,
   Message,
+  PersistedToolCall,
   CreateChatSessionInput,
   CreateMessageInput,
   UpdateChatSessionInput,
@@ -14,9 +15,174 @@ import {
 } from '../../types/database';
 import { getLogger } from './logging';
 import { escapeLikePattern } from '../utils/sqlSanitizer';
+import {
+  collectToolResultAssetIds,
+  normalizeToolCallResultForStorage,
+} from './toolResults/canonicalToolResultService';
+import { deleteImageAssetsIfUnused } from './toolResults/toolResultAssetStore';
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === 'object' && !Array.isArray(value);
+}
+
+function coercePersistedToolCall(value: unknown): PersistedToolCall | null {
+  if (!isRecord(value)) {
+    return null;
+  }
+
+  return {
+    id: typeof value.id === 'string' ? value.id : '',
+    name: typeof value.name === 'string' ? value.name : '',
+    arguments: isRecord(value.arguments) ? value.arguments : {},
+    ...(value.result !== undefined ? { result: value.result } : {}),
+    status: typeof value.status === 'string' ? value.status : 'success',
+  };
+}
+
+function parsePersistedToolCalls(toolCalls: string | null | undefined): PersistedToolCall[] | null {
+  if (!toolCalls) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(toolCalls);
+    if (!Array.isArray(parsed)) {
+      return null;
+    }
+
+    return parsed
+      .map(coercePersistedToolCall)
+      .filter((toolCall): toolCall is PersistedToolCall => toolCall !== null);
+  } catch {
+    return null;
+  }
+}
+
+function collectAssetIdsFromToolCalls(toolCalls: PersistedToolCall[] | null | undefined): string[] {
+  if (!toolCalls) {
+    return [];
+  }
+
+  return [...new Set(toolCalls.flatMap((toolCall) => collectToolResultAssetIds(toolCall.result)))];
+}
+
+async function normalizeToolCallsForStorage(toolCalls: PersistedToolCall[]): Promise<{
+  value: PersistedToolCall[];
+  changed: boolean;
+  assetIds: string[];
+}> {
+  const value: PersistedToolCall[] = [];
+  const assetIds: string[] = [];
+  let changed = false;
+
+  for (const toolCall of toolCalls) {
+    const normalizedResult = await normalizeToolCallResultForStorage(toolCall.result);
+    value.push({
+      ...toolCall,
+      ...(normalizedResult.normalized !== undefined
+        ? { result: normalizedResult.normalized }
+        : {}),
+    });
+    assetIds.push(...normalizedResult.assetIds);
+    if (normalizedResult.changed) {
+      changed = true;
+    }
+  }
+
+  return {
+    value,
+    changed,
+    assetIds: [...new Set(assetIds)],
+  };
+}
 
 export class ChatService {
   private logger = getLogger();
+
+  private async normalizeToolCallsJsonForStorage(toolCalls: string | null | undefined): Promise<{
+    serialized: string | null;
+    changed: boolean;
+    assetIds: string[];
+  }> {
+    const parsed = parsePersistedToolCalls(toolCalls);
+    if (!parsed) {
+      return {
+        serialized: toolCalls ?? null,
+        changed: false,
+        assetIds: [],
+      };
+    }
+
+    const normalized = await normalizeToolCallsForStorage(parsed);
+    const serialized = JSON.stringify(normalized.value);
+
+    return {
+      serialized,
+      changed: normalized.changed || serialized !== toolCalls,
+      assetIds: normalized.assetIds,
+    };
+  }
+
+  private async rewriteNormalizedToolCalls(messageId: string, toolCalls: string): Promise<string> {
+    const normalized = await this.normalizeToolCallsJsonForStorage(toolCalls);
+    if (normalized.changed) {
+      await databaseService.execute(
+        'UPDATE messages SET tool_calls = ? WHERE id = ?',
+        [normalized.serialized as InValue, messageId as InValue],
+      );
+    }
+
+    return normalized.serialized ?? toolCalls;
+  }
+
+  private async mapMessageRow(row: any[]): Promise<Message> {
+    const toolCalls = typeof row[4] === 'string' && row[4].length > 0
+      ? await this.rewriteNormalizedToolCalls(row[0] as string, row[4] as string)
+      : ((row[4] as string) || null);
+
+    return {
+      id: row[0] as string,
+      session_id: row[1] as string,
+      role: row[2] as 'user' | 'assistant' | 'system',
+      content: row[3] as string,
+      tool_calls: toolCalls,
+      created_at: row[5] as number,
+      attachments: (row[6] as string) || null,
+      reasoningText: (row[7] as string) || null,
+      input_tokens: (row[8] as number) ?? null,
+      output_tokens: (row[9] as number) ?? null,
+      total_tokens: (row[10] as number) ?? null,
+    };
+  }
+
+  private async getAssetIdsForSessionMessages(sessionId: string): Promise<string[]> {
+    const result = await databaseService.execute(
+      'SELECT tool_calls FROM messages WHERE session_id = ?',
+      [sessionId as InValue],
+    );
+
+    return [...new Set(
+      result.rows.flatMap((row) =>
+        collectAssetIdsFromToolCalls(parsePersistedToolCalls((row[0] as string) || null)),
+      ),
+    )];
+  }
+
+  private async getAssetIdsForMessagesAfter(
+    sessionId: string,
+    afterTimestamp: number,
+  ): Promise<string[]> {
+    const result = await databaseService.execute(
+      'SELECT tool_calls FROM messages WHERE session_id = ? AND created_at > ?',
+      [sessionId as InValue, afterTimestamp as InValue],
+    );
+
+    return [...new Set(
+      result.rows.flatMap((row) =>
+        collectAssetIdsFromToolCalls(parsePersistedToolCalls((row[0] as string) || null)),
+      ),
+    )];
+  }
 
   // Chat Sessions
   async createSession(input: CreateChatSessionInput): Promise<DatabaseResult<ChatSession>> {
@@ -221,10 +387,14 @@ export class ChatService {
 
   async deleteSession(id: string): Promise<DatabaseResult<boolean>> {
     try {
+      const assetIds = await this.getAssetIdsForSessionMessages(id);
+
       await databaseService.execute(
         'DELETE FROM chat_sessions WHERE id = ?',
         [id as InValue]
       );
+
+      await deleteImageAssetsIfUnused(assetIds);
 
       return { data: true, success: true };
     } catch (error) {
@@ -255,6 +425,9 @@ export class ChatService {
       // Use frontend-provided ID when present, otherwise generate a new one
       const id = input.id || this.generateId();
       const now = Date.now();
+      const normalizedToolCalls = input.tool_calls
+        ? await normalizeToolCallsForStorage(input.tool_calls)
+        : null;
 
       const attachmentsString = input.attachments ? JSON.stringify(input.attachments) : null;
       const reasoningString = input.reasoningText ? JSON.stringify(input.reasoningText) : null;
@@ -271,7 +444,7 @@ export class ChatService {
         session_id: input.session_id,
         role: input.role,
         content: input.content,
-        tool_calls: input.tool_calls ? JSON.stringify(input.tool_calls) : null,
+        tool_calls: normalizedToolCalls ? JSON.stringify(normalizedToolCalls.value) : null,
         attachments: attachmentsString,
         reasoningText: reasoningString,
         input_tokens: input.input_tokens ?? null,
@@ -386,19 +559,9 @@ export class ChatService {
         [session_id as InValue, limit as InValue, offset as InValue]
       );
 
-      const messages: Message[] = result.rows.map(row => ({
-        id: row[0] as string,
-        session_id: row[1] as string,
-        role: row[2] as 'user' | 'assistant' | 'system',
-        content: row[3] as string,
-        tool_calls: row[4] as string,
-        created_at: row[5] as number,
-        attachments: (row[6] as string) || null,
-        reasoningText: (row[7] as string) || null,
-        input_tokens: (row[8] as number) ?? null,
-        output_tokens: (row[9] as number) ?? null,
-        total_tokens: (row[10] as number) ?? null,
-      }));
+      const messages = await Promise.all(
+        result.rows.map((row) => this.mapMessageRow(row as unknown as any[])),
+      );
 
       const paginatedResult: PaginatedResult<Message> = {
         items: messages,
@@ -443,19 +606,9 @@ export class ChatService {
       // Column order from PRAGMA table_info(messages):
       // 0: id, 1: session_id, 2: role, 3: content, 4: tool_calls,
       // 5: created_at, 6: attachments, 7: reasoning, 8: input_tokens, 9: output_tokens, 10: total_tokens
-      const messages: Message[] = result.rows.map(row => ({
-        id: row[0] as string,
-        session_id: row[1] as string,
-        role: row[2] as 'user' | 'assistant' | 'system',
-        content: row[3] as string,
-        tool_calls: row[4] as string,
-        created_at: row[5] as number,
-        attachments: (row[6] as string) || null,
-        reasoningText: (row[7] as string) || null,
-        input_tokens: (row[8] as number) ?? null,
-        output_tokens: (row[9] as number) ?? null,
-        total_tokens: (row[10] as number) ?? null,
-      }));
+      const messages = await Promise.all(
+        result.rows.map((row) => this.mapMessageRow(row as unknown as any[])),
+      );
 
       this.logger.database.debug('Search completed', { found: messages.length, query: searchQuery });
       return { data: messages, success: true };
@@ -486,8 +639,14 @@ export class ChatService {
     });
 
     try {
+      const existingMessage = await this.getMessage(input.id);
+      const previousToolCalls = existingMessage.success && existingMessage.data?.tool_calls
+        ? parsePersistedToolCalls(existingMessage.data.tool_calls)
+        : null;
+      const previousAssetIds = collectAssetIdsFromToolCalls(previousToolCalls);
       const updateFields: string[] = [];
       const params: InValue[] = [];
+      let nextAssetIds = previousAssetIds;
 
       if (input.content !== undefined) {
         updateFields.push('content = ?');
@@ -495,8 +654,10 @@ export class ChatService {
       }
 
       if (input.tool_calls !== undefined) {
+        const normalizedToolCalls = await normalizeToolCallsForStorage(input.tool_calls);
         updateFields.push('tool_calls = ?');
-        params.push(JSON.stringify(input.tool_calls) as InValue);
+        params.push(JSON.stringify(normalizedToolCalls.value) as InValue);
+        nextAssetIds = normalizedToolCalls.assetIds;
       }
 
       if (updateFields.length === 0) {
@@ -510,6 +671,13 @@ export class ChatService {
         `UPDATE messages SET ${updateFields.join(', ')} WHERE id = ?`,
         params
       );
+
+      const orphanedAssetIds = previousAssetIds.filter(
+        (assetId) => !nextAssetIds.includes(assetId),
+      );
+      if (orphanedAssetIds.length > 0) {
+        await deleteImageAssetsIfUnused(orphanedAssetIds);
+      }
 
       this.logger.database.info('Message updated successfully', { messageId: input.id });
       return this.getMessage(input.id);
@@ -537,12 +705,17 @@ export class ChatService {
     });
 
     try {
+      const assetIds = await this.getAssetIdsForMessagesAfter(sessionId, afterTimestamp);
       const result = await databaseService.execute(
         'DELETE FROM messages WHERE session_id = ? AND created_at > ?',
         [sessionId as InValue, afterTimestamp as InValue]
       );
 
       const deletedCount = result.rowsAffected || 0;
+
+      if (deletedCount > 0) {
+        await deleteImageAssetsIfUnused(assetIds);
+      }
 
       this.logger.database.info('Messages deleted successfully', {
         sessionId,
@@ -581,20 +754,7 @@ export class ChatService {
         return { data: null, success: true };
       }
 
-      const row = result.rows[0];
-      const message: Message = {
-        id: row[0] as string,
-        session_id: row[1] as string,
-        role: row[2] as 'user' | 'assistant' | 'system',
-        content: row[3] as string,
-        tool_calls: row[4] as string,
-        created_at: row[5] as number,
-        attachments: (row[6] as string) || null,
-        reasoningText: (row[7] as string) || null,
-        input_tokens: (row[8] as number) ?? null,
-        output_tokens: (row[9] as number) ?? null,
-        total_tokens: (row[10] as number) ?? null,
-      };
+      const message = await this.mapMessageRow(result.rows[0] as unknown as any[]);
 
       return { data: message, success: true };
     } catch (error) {

--- a/src/main/services/compactionService.ts
+++ b/src/main/services/compactionService.ts
@@ -3,6 +3,10 @@ import type { Message } from '../../types/database';
 import { chatService } from './chatService';
 import { getLogger } from './logging';
 import { classifyStreamingError } from './ai/streamingErrorClassifier';
+import {
+  isCanonicalImageRef,
+  isCanonicalToolResult,
+} from '../../shared/canonicalToolResult';
 
 const COMPACTION_MARKER = '[COMPACTION_SUMMARY]';
 const CHARS_PER_TOKEN = 4;
@@ -36,6 +40,51 @@ export const COMPACTION_STAGES: CompactionStage[] = [
   { stage: 4, toolCallTokenLimit: null, contentMaxChars: 300,   reasoningMaxChars: null, messagePercentage: 0.5  },
   { stage: 5, toolCallTokenLimit: null, contentMaxChars: 200,   reasoningMaxChars: null, messagePercentage: 0.25 },
 ];
+
+export function summarizeToolCallsForCompaction(toolCallsJson: string): string {
+  try {
+    const parsed = JSON.parse(toolCallsJson);
+    if (!Array.isArray(parsed)) {
+      return toolCallsJson;
+    }
+
+    let changed = false;
+    const summarized = parsed.map((toolCall) => {
+      if (!toolCall || typeof toolCall !== 'object') {
+        return toolCall;
+      }
+
+      const result = (toolCall as { result?: unknown }).result;
+      if (!isCanonicalToolResult(result)) {
+        return toolCall;
+      }
+
+      const imageCount =
+        result.modelOutput.type === 'content'
+          ? result.modelOutput.value.filter(isCanonicalImageRef).length
+          : 0;
+
+      if (imageCount === 0) {
+        return toolCall;
+      }
+
+      changed = true;
+
+      return {
+        name: (toolCall as { name?: unknown }).name,
+        status: (toolCall as { status?: unknown }).status,
+        result: {
+          text: result.text,
+          imageCount,
+        },
+      };
+    });
+
+    return changed ? JSON.stringify(summarized) : toolCallsJson;
+  } catch {
+    return toolCallsJson;
+  }
+}
 
 export class CompactionService {
   private logger = getLogger();
@@ -150,7 +199,9 @@ export class CompactionService {
       ? `PREVIOUS_SUMMARY:\n${message.content.replace(COMPACTION_MARKER, '').trim()}`
       : message.content;
 
-    const toolPart = message.tool_calls ? `\n\n[TOOL_CALLS]\n${message.tool_calls}` : '';
+    const toolPart = message.tool_calls
+      ? `\n\n[TOOL_CALLS]\n${summarizeToolCallsForCompaction(message.tool_calls)}`
+      : '';
     const reasoningPart = message.reasoningText ? `\n\n[REASONING]\n${message.reasoningText}` : '';
 
     return `[${message.role.toUpperCase()}] ${baseContent}${toolPart}${reasoningPart}`;

--- a/src/main/services/image/__tests__/imageResizer.test.ts
+++ b/src/main/services/image/__tests__/imageResizer.test.ts
@@ -10,7 +10,7 @@ vi.mock("../../logging", () => {
 });
 
 import sharp from "sharp";
-import { resizeMCPImage, ImageResizeError } from "../imageResizer";
+import { resizeMCPImage, getImageDimensions, ImageResizeError } from "../imageResizer";
 import { API_IMAGE_MAX_BASE64_SIZE } from "../providerImageLimits";
 
 async function makePng(width: number, height: number): Promise<Buffer> {
@@ -35,6 +35,20 @@ async function makeNoisyPng(width: number, height: number): Promise<Buffer> {
   }
   return sharp(raw, { raw: { width, height, channels } }).png().toBuffer();
 }
+
+describe("getImageDimensions", () => {
+  it("returns width and height for a valid PNG buffer", async () => {
+    const buffer = await makePng(32, 16);
+    const dims = await getImageDimensions(buffer);
+    expect(dims.width).toBe(32);
+    expect(dims.height).toBe(16);
+  });
+
+  it("returns {} for an invalid buffer", async () => {
+    const dims = await getImageDimensions(Buffer.from("not-an-image"));
+    expect(dims).toEqual({});
+  });
+});
 
 describe("resizeMCPImage", () => {
   it("passes small images through unchanged", async () => {

--- a/src/main/services/image/imageResizer.ts
+++ b/src/main/services/image/imageResizer.ts
@@ -64,6 +64,22 @@ async function encode(
   }
 }
 
+export async function getImageDimensions(
+  buffer: Buffer,
+): Promise<{ width?: number; height?: number }> {
+  try {
+    const metadata = await sharp(buffer).metadata();
+    return {
+      ...(typeof metadata.width === "number" ? { width: metadata.width } : {}),
+      ...(typeof metadata.height === "number"
+        ? { height: metadata.height }
+        : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
 /**
  * Resize an image buffer to fit within API limits using a cascade strategy.
  *

--- a/src/main/services/toolResults/__tests__/canonicalToolResultService.test.ts
+++ b/src/main/services/toolResults/__tests__/canonicalToolResultService.test.ts
@@ -25,6 +25,7 @@ import {
   canonicalizeRichToolOutput,
   materializeToolResultForModel,
   normalizeToolCallResultForStorage,
+  MAX_TOOL_TEXT_CHARS,
 } from "../canonicalToolResultService";
 
 describe("canonicalToolResultService", () => {
@@ -135,6 +136,74 @@ describe("canonicalToolResultService", () => {
         { type: "image-data", data: "BBBB", mediaType: "image/png" },
       ],
     });
+  });
+
+  it("truncates long text in canonical text-type output at model injection", async () => {
+    const longText = "x".repeat(MAX_TOOL_TEXT_CHARS + 5000);
+    const result = await materializeToolResultForModel({
+      supportsVision: false,
+      output: {
+        __levanteToolResult: 1,
+        text: longText,
+        modelOutput: { type: "text", value: longText },
+      },
+    });
+
+    expect(result.type).toBe("text");
+    expect((result as any).value.length).toBeLessThan(longText.length);
+    expect((result as any).value).toContain("[truncated 5000 chars]");
+  });
+
+  it("truncates long text parts inside canonical content-type output", async () => {
+    const longText = "y".repeat(MAX_TOOL_TEXT_CHARS + 1000);
+    const result = await materializeToolResultForModel({
+      supportsVision: true,
+      output: {
+        __levanteToolResult: 1,
+        text: longText,
+        modelOutput: {
+          type: "content",
+          value: [
+            { type: "text", text: longText },
+            {
+              kind: "image-ref",
+              assetId: "asset-1",
+              mediaType: "image/png",
+              byteSize: 4,
+              base64Length: 4,
+              sha256: "asset-1",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result.type).toBe("content");
+    const textPart = (result as any).value.find((p: any) => p.type === "text");
+    expect(textPart.text).toContain("[truncated 1000 chars]");
+  });
+
+  it("truncates long text in legacy text-only output", async () => {
+    const longText = "z".repeat(MAX_TOOL_TEXT_CHARS + 2000);
+    const result = await materializeToolResultForModel({
+      supportsVision: false,
+      output: { text: longText },
+    });
+
+    expect(result.type).toBe("text");
+    expect((result as any).value).toContain("[truncated 2000 chars]");
+    expect((result as any).value.length).toBeLessThan(longText.length);
+  });
+
+  it("does not truncate text stored in the DB (canonicalize is storage-only)", async () => {
+    // canonicalizeRichToolOutput writes to storage — must NOT truncate.
+    const longText = "w".repeat(MAX_TOOL_TEXT_CHARS + 1000);
+    const result = await canonicalizeRichToolOutput({ text: longText });
+
+    expect(result.text).toHaveLength(longText.length);
+    if (result.modelOutput.type === "text") {
+      expect(result.modelOutput.value).toHaveLength(longText.length);
+    }
   });
 
   it("keeps canonical outputs unchanged when normalizing for storage", async () => {

--- a/src/main/services/toolResults/__tests__/canonicalToolResultService.test.ts
+++ b/src/main/services/toolResults/__tests__/canonicalToolResultService.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { persistImageAsset, readImageAsset } = vi.hoisted(() => ({
+  persistImageAsset: vi.fn(async (params: { mediaType: string; dataBase64: string }) => ({
+    assetId: "asset-1",
+    sha256: "asset-1",
+    mediaType: params.mediaType,
+    byteSize: 4,
+    base64Length: params.dataBase64.length,
+    width: 10,
+    height: 10,
+  })),
+  readImageAsset: vi.fn(async () => ({
+    dataBase64: "AAAA",
+    mediaType: "image/png",
+  })),
+}));
+
+vi.mock("../toolResultAssetStore", () => ({
+  persistImageAsset,
+  readImageAsset,
+}));
+
+import {
+  canonicalizeRichToolOutput,
+  materializeToolResultForModel,
+  normalizeToolCallResultForStorage,
+} from "../canonicalToolResultService";
+
+describe("canonicalToolResultService", () => {
+  beforeEach(() => {
+    persistImageAsset.mockClear();
+    readImageAsset.mockClear();
+  });
+
+  it("canonicalizes legacy rich outputs with images[]", async () => {
+    const result = await canonicalizeRichToolOutput({
+      text: "Screenshot captured",
+      content: [
+        { type: "text", text: "Screenshot captured" },
+        { type: "image", data: "BBBB", mimeType: "image/png" },
+      ],
+      legacyImages: [{ data: "BBBB", mediaType: "image/png" }],
+    });
+
+    expect(result.__levanteToolResult).toBe(1);
+    expect(result.modelOutput.type).toBe("content");
+    expect(result.modelOutput.value).toEqual([
+      { type: "text", text: "Screenshot captured" },
+      expect.objectContaining({
+        kind: "image-ref",
+        assetId: "asset-1",
+        mediaType: "image/png",
+      }),
+    ]);
+    expect(result.content).toEqual([
+      { type: "text", text: "Screenshot captured" },
+      { type: "image", mimeType: "image/png", omitted: true },
+    ]);
+  });
+
+  it("materializes canonical content with image-data when vision is enabled", async () => {
+    const result = await materializeToolResultForModel({
+      supportsVision: true,
+      output: {
+        __levanteToolResult: 1,
+        text: "Screenshot captured",
+        modelOutput: {
+          type: "content",
+          value: [
+            { type: "text", text: "Screenshot captured" },
+            {
+              kind: "image-ref",
+              assetId: "asset-1",
+              mediaType: "image/png",
+              byteSize: 4,
+              base64Length: 4,
+              sha256: "asset-1",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      type: "content",
+      value: [
+        { type: "text", text: "Screenshot captured" },
+        { type: "image-data", data: "AAAA", mediaType: "image/png" },
+      ],
+    });
+  });
+
+  it("degrades canonical image output to text when vision is disabled", async () => {
+    const result = await materializeToolResultForModel({
+      supportsVision: false,
+      output: {
+        __levanteToolResult: 1,
+        text: "Fallback text",
+        modelOutput: {
+          type: "content",
+          value: [
+            {
+              kind: "image-ref",
+              assetId: "asset-1",
+              mediaType: "image/png",
+              byteSize: 4,
+              base64Length: 4,
+              sha256: "asset-1",
+            },
+          ],
+        },
+      },
+    });
+
+    expect(result).toEqual({
+      type: "text",
+      value: "Fallback text",
+    });
+  });
+
+  it("supports legacy inputs with images[] during materialization", async () => {
+    const result = await materializeToolResultForModel({
+      supportsVision: true,
+      output: {
+        text: "Legacy screenshot",
+        images: [{ data: "BBBB", mediaType: "image/png" }],
+      },
+    });
+
+    expect(result).toEqual({
+      type: "content",
+      value: [
+        { type: "text", text: "Legacy screenshot" },
+        { type: "image-data", data: "BBBB", mediaType: "image/png" },
+      ],
+    });
+  });
+
+  it("keeps canonical outputs unchanged when normalizing for storage", async () => {
+    const canonical = {
+      __levanteToolResult: 1,
+      text: "Saved",
+      modelOutput: {
+        type: "content" as const,
+        value: [
+          {
+            kind: "image-ref" as const,
+            assetId: "asset-1",
+            mediaType: "image/png",
+            byteSize: 4,
+            base64Length: 4,
+            sha256: "asset-1",
+          },
+        ],
+      },
+    };
+
+    const result = await normalizeToolCallResultForStorage(canonical);
+
+    expect(result.changed).toBe(false);
+    expect(result.normalized).toBe(canonical);
+    expect(result.assetIds).toEqual(["asset-1"]);
+  });
+});

--- a/src/main/services/toolResults/__tests__/toolResultAssetStore.test.ts
+++ b/src/main/services/toolResults/__tests__/toolResultAssetStore.test.ts
@@ -1,0 +1,116 @@
+import { mkdtemp, readdir } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const { getPathMock, executeMock } = vi.hoisted(() => ({
+  getPathMock: vi.fn(),
+  executeMock: vi.fn(),
+}));
+
+vi.mock("electron", () => ({
+  app: {
+    getPath: getPathMock,
+  },
+}));
+
+vi.mock("../../databaseService", () => ({
+  databaseService: {
+    execute: executeMock,
+  },
+}));
+
+import {
+  deleteImageAssetsIfUnused,
+  persistImageAsset,
+  readImageAsset,
+} from "../toolResultAssetStore";
+
+describe("toolResultAssetStore", () => {
+  let userDataDir: string;
+  let referencedAssetIds: Set<string>;
+  let imageBase64: string;
+
+  beforeEach(async () => {
+    userDataDir = await mkdtemp(path.join(os.tmpdir(), "levante-tool-assets-"));
+    referencedAssetIds = new Set<string>();
+    imageBase64 = Buffer.from("fake-image-bytes").toString("base64");
+
+    getPathMock.mockReturnValue(userDataDir);
+    executeMock.mockImplementation(async (_sql: string, params: unknown[]) => {
+      const needle = String(params[0] ?? "").replace(/%/g, "");
+      return {
+        rows: referencedAssetIds.has(needle) ? [[1]] : [],
+      };
+    });
+  });
+
+  it("persists a new asset and returns metadata", async () => {
+    const asset = await persistImageAsset({
+      dataBase64: imageBase64,
+      mediaType: "image/png",
+    });
+
+    expect(asset.assetId).toBe(asset.sha256);
+    expect(asset.byteSize).toBe(Buffer.from(imageBase64, "base64").length);
+    expect(asset.base64Length).toBe(imageBase64.length);
+  });
+
+  it("reuses the same assetId for identical content", async () => {
+    const first = await persistImageAsset({
+      dataBase64: imageBase64,
+      mediaType: "image/png",
+    });
+    const second = await persistImageAsset({
+      dataBase64: imageBase64,
+      mediaType: "image/png",
+    });
+
+    expect(first.assetId).toBe(second.assetId);
+
+    const files = await readdir(path.join(userDataDir, "tool-result-assets", "images"));
+    expect(files).toHaveLength(1);
+  });
+
+  it("rehydrates the same base64 payload", async () => {
+    const asset = await persistImageAsset({
+      dataBase64: imageBase64,
+      mediaType: "image/png",
+    });
+
+    const restored = await readImageAsset({
+      assetId: asset.assetId,
+      mediaType: "image/png",
+    });
+
+    expect(restored).toEqual({
+      dataBase64: imageBase64,
+      mediaType: "image/png",
+    });
+  });
+
+  it("does not delete an asset that is still referenced", async () => {
+    const asset = await persistImageAsset({
+      dataBase64: imageBase64,
+      mediaType: "image/png",
+    });
+    referencedAssetIds.add(asset.assetId);
+
+    await deleteImageAssetsIfUnused([asset.assetId]);
+
+    const files = await readdir(path.join(userDataDir, "tool-result-assets", "images"));
+    expect(files).toHaveLength(1);
+  });
+
+  it("deletes an asset when no reference remains", async () => {
+    const asset = await persistImageAsset({
+      dataBase64: imageBase64,
+      mediaType: "image/png",
+    });
+
+    await deleteImageAssetsIfUnused([asset.assetId]);
+
+    const files = await readdir(path.join(userDataDir, "tool-result-assets", "images"));
+    expect(files).toHaveLength(0);
+  });
+});

--- a/src/main/services/toolResults/canonicalToolResultService.ts
+++ b/src/main/services/toolResults/canonicalToolResultService.ts
@@ -1,0 +1,347 @@
+import type { ToolResultOutput } from "@ai-sdk/provider-utils";
+import {
+  extractLegacyImages,
+  isCanonicalImageRef,
+  isCanonicalToolResult,
+  looksLikeLegacyRichToolOutput,
+  type CanonicalToolResultV1,
+} from "../../../shared/canonicalToolResult";
+import { stripInlineImagesFromContent } from "../../../shared/toolOutputSanitizer";
+import {
+  persistImageAsset,
+  readImageAsset,
+} from "./toolResultAssetStore";
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function getStructuredContent(
+  value: unknown,
+): Record<string, unknown> | undefined {
+  if (!isRecord(value)) return undefined;
+  return isRecord(value.structuredContent)
+    ? (value.structuredContent as Record<string, unknown>)
+    : undefined;
+}
+
+function getContent(value: unknown): unknown[] | undefined {
+  if (!isRecord(value) || !Array.isArray(value.content)) {
+    return undefined;
+  }
+
+  return value.content;
+}
+
+function getUiResources(value: unknown): unknown[] | undefined {
+  if (!isRecord(value) || !Array.isArray(value.uiResources)) {
+    return undefined;
+  }
+
+  return value.uiResources;
+}
+
+function extractTextFromContent(content: unknown[]): string | undefined {
+  const texts = content
+    .flatMap((item) => {
+      if (
+        item &&
+        typeof item === "object" &&
+        (item as { type?: string }).type === "text" &&
+        typeof (item as { text?: string }).text === "string"
+      ) {
+        return [(item as { text: string }).text];
+      }
+
+      return [];
+    })
+    .filter((text) => text.length > 0);
+
+  if (texts.length === 0) {
+    return undefined;
+  }
+
+  return texts.join("\n");
+}
+
+function getLegacyText(value: unknown): string | undefined {
+  if (!isRecord(value)) return undefined;
+
+  if (typeof value.text === "string" && value.text.length > 0) {
+    return value.text;
+  }
+
+  if (Array.isArray(value.content)) {
+    return extractTextFromContent(value.content);
+  }
+
+  return undefined;
+}
+
+function collectCanonicalImageRefs(output: CanonicalToolResultV1) {
+  if (output.modelOutput.type !== "content") {
+    return [];
+  }
+
+  return output.modelOutput.value.filter(isCanonicalImageRef);
+}
+
+export function collectToolResultAssetIds(value: unknown): string[] {
+  if (!isCanonicalToolResult(value)) {
+    return [];
+  }
+
+  return collectCanonicalImageRefs(value).map((part) => part.assetId);
+}
+
+export async function canonicalizeRichToolOutput(params: {
+  text?: string;
+  structuredContent?: Record<string, unknown>;
+  uiResources?: unknown[];
+  content?: unknown[];
+  legacyImages?: Array<{ data: string; mediaType: string }>;
+}): Promise<CanonicalToolResultV1> {
+  const sanitizedContent = Array.isArray(params.content)
+    ? stripInlineImagesFromContent(params.content)
+    : undefined;
+
+  const text =
+    params.text && params.text.length > 0
+      ? params.text
+      : sanitizedContent
+        ? extractTextFromContent(sanitizedContent)
+        : undefined;
+
+  const imageAssets = await Promise.all(
+    (params.legacyImages ?? []).map((image) =>
+      persistImageAsset({
+        dataBase64: image.data,
+        mediaType: image.mediaType,
+      }),
+    ),
+  );
+
+  const modelOutput =
+    imageAssets.length > 0
+      ? {
+          type: "content" as const,
+          value: [
+            ...(text ? [{ type: "text" as const, text }] : []),
+            ...imageAssets.map((asset) => ({
+              kind: "image-ref" as const,
+              assetId: asset.assetId,
+              mediaType: asset.mediaType,
+              byteSize: asset.byteSize,
+              base64Length: asset.base64Length,
+              sha256: asset.sha256,
+              ...(asset.width !== undefined ? { width: asset.width } : {}),
+              ...(asset.height !== undefined ? { height: asset.height } : {}),
+            })),
+          ],
+        }
+      : params.structuredContent
+        ? {
+            type: "json" as const,
+            value: params.structuredContent,
+          }
+        : {
+            type: "text" as const,
+            value: text ?? "",
+          };
+
+  return {
+    __levanteToolResult: 1,
+    ...(text ? { text } : {}),
+    ...(params.structuredContent ? { structuredContent: params.structuredContent } : {}),
+    ...(params.uiResources && params.uiResources.length > 0
+      ? { uiResources: params.uiResources }
+      : {}),
+    ...(sanitizedContent ? { content: sanitizedContent } : {}),
+    modelOutput,
+  };
+}
+
+export async function normalizeToolCallResultForStorage(
+  value: unknown,
+): Promise<{ normalized: unknown; changed: boolean; assetIds: string[] }> {
+  if (isCanonicalToolResult(value)) {
+    return {
+      normalized: value,
+      changed: false,
+      assetIds: collectToolResultAssetIds(value),
+    };
+  }
+
+  if (!looksLikeLegacyRichToolOutput(value)) {
+    return {
+      normalized: value,
+      changed: false,
+      assetIds: [],
+    };
+  }
+
+  const normalized = await canonicalizeRichToolOutput({
+    text: getLegacyText(value),
+    structuredContent: getStructuredContent(value),
+    uiResources: getUiResources(value),
+    content: getContent(value),
+    legacyImages: extractLegacyImages(value),
+  });
+
+  return {
+    normalized,
+    changed: true,
+    assetIds: collectToolResultAssetIds(normalized),
+  };
+}
+
+async function materializeCanonicalToolResult(params: {
+  output: CanonicalToolResultV1;
+  supportsVision: boolean;
+}): Promise<ToolResultOutput> {
+  const { output, supportsVision } = params;
+
+  if (output.modelOutput.type === "text") {
+    return {
+      type: "text",
+      value: output.modelOutput.value,
+    };
+  }
+
+  if (output.modelOutput.type === "json") {
+    return {
+      type: "json",
+      value: output.modelOutput.value as any,
+    };
+  }
+
+  if (!supportsVision) {
+    return {
+      type: "text",
+      value:
+        output.text ||
+        "[Tool returned images, but the active model does not support vision.]",
+    };
+  }
+
+  const value: Array<
+    | { type: "text"; text: string }
+    | { type: "image-data"; data: string; mediaType: string }
+  > = [];
+
+  for (const part of output.modelOutput.value) {
+    if ("type" in part && part.type === "text") {
+      value.push({ type: "text", text: part.text });
+      continue;
+    }
+
+    if (!isCanonicalImageRef(part)) {
+      continue;
+    }
+
+    const image = await readImageAsset({
+      assetId: part.assetId,
+      mediaType: part.mediaType,
+    });
+
+    value.push({
+      type: "image-data",
+      data: image.dataBase64,
+      mediaType: image.mediaType,
+    });
+  }
+
+  return {
+    type: "content",
+    value,
+  };
+}
+
+async function materializeLegacyToolResult(params: {
+  output: Record<string, unknown>;
+  supportsVision: boolean;
+}): Promise<ToolResultOutput> {
+  const text = getLegacyText(params.output);
+  const images = extractLegacyImages(params.output);
+
+  if (images.length > 0) {
+    if (!params.supportsVision) {
+      return {
+        type: "text",
+        value:
+          text ||
+          "[Tool returned images, but the active model does not support vision.]",
+      };
+    }
+
+    return {
+      type: "content",
+      value: [
+        ...(text ? [{ type: "text" as const, text }] : []),
+        ...images.map((image) => ({
+          type: "image-data" as const,
+          data: image.data,
+          mediaType: image.mediaType,
+        })),
+      ],
+    };
+  }
+
+  const structuredContent = getStructuredContent(params.output);
+  if (structuredContent) {
+    return {
+      type: "json",
+      value: structuredContent as any,
+    };
+  }
+
+  return {
+    type: "text",
+    value: text ?? "",
+  };
+}
+
+export async function materializeToolResultForModel(params: {
+  output: unknown;
+  supportsVision: boolean;
+}): Promise<ToolResultOutput> {
+  if (isCanonicalToolResult(params.output)) {
+    return materializeCanonicalToolResult({
+      output: params.output,
+      supportsVision: params.supportsVision,
+    });
+  }
+
+  if (typeof params.output === "string") {
+    return {
+      type: "text",
+      value: params.output,
+    };
+  }
+
+  if (looksLikeLegacyRichToolOutput(params.output)) {
+    return materializeLegacyToolResult({
+      output: params.output as Record<string, unknown>,
+      supportsVision: params.supportsVision,
+    });
+  }
+
+  if (isRecord(params.output) && isRecord(params.output.structuredContent)) {
+    return {
+      type: "json",
+      value: params.output.structuredContent as any,
+    };
+  }
+
+  if (isRecord(params.output) && typeof params.output.text === "string") {
+    return {
+      type: "text",
+      value: params.output.text,
+    };
+  }
+
+  return {
+    type: "json",
+    value: (params.output ?? null) as any,
+  };
+}

--- a/src/main/services/toolResults/canonicalToolResultService.ts
+++ b/src/main/services/toolResults/canonicalToolResultService.ts
@@ -12,6 +12,17 @@ import {
   readImageAsset,
 } from "./toolResultAssetStore";
 
+/** Maximum characters injected as text into the model per tool result. */
+export const MAX_TOOL_TEXT_CHARS = 30_000;
+
+function truncateText(text: string): string {
+  if (text.length <= MAX_TOOL_TEXT_CHARS) return text;
+  return (
+    text.slice(0, MAX_TOOL_TEXT_CHARS) +
+    `\n...[truncated ${text.length - MAX_TOOL_TEXT_CHARS} chars]`
+  );
+}
+
 function isRecord(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
 }
@@ -204,7 +215,7 @@ async function materializeCanonicalToolResult(params: {
   if (output.modelOutput.type === "text") {
     return {
       type: "text",
-      value: output.modelOutput.value,
+      value: truncateText(output.modelOutput.value),
     };
   }
 
@@ -218,9 +229,10 @@ async function materializeCanonicalToolResult(params: {
   if (!supportsVision) {
     return {
       type: "text",
-      value:
+      value: truncateText(
         output.text ||
         "[Tool returned images, but the active model does not support vision.]",
+      ),
     };
   }
 
@@ -231,7 +243,7 @@ async function materializeCanonicalToolResult(params: {
 
   for (const part of output.modelOutput.value) {
     if ("type" in part && part.type === "text") {
-      value.push({ type: "text", text: part.text });
+      value.push({ type: "text", text: truncateText(part.text) });
       continue;
     }
 
@@ -268,16 +280,17 @@ async function materializeLegacyToolResult(params: {
     if (!params.supportsVision) {
       return {
         type: "text",
-        value:
+        value: truncateText(
           text ||
           "[Tool returned images, but the active model does not support vision.]",
+        ),
       };
     }
 
     return {
       type: "content",
       value: [
-        ...(text ? [{ type: "text" as const, text }] : []),
+        ...(text ? [{ type: "text" as const, text: truncateText(text) }] : []),
         ...images.map((image) => ({
           type: "image-data" as const,
           data: image.data,
@@ -297,7 +310,7 @@ async function materializeLegacyToolResult(params: {
 
   return {
     type: "text",
-    value: text ?? "",
+    value: truncateText(text ?? ""),
   };
 }
 

--- a/src/main/services/toolResults/historicalToolReplayTools.ts
+++ b/src/main/services/toolResults/historicalToolReplayTools.ts
@@ -1,9 +1,14 @@
 import { jsonSchema } from "ai";
 import {
+  extractLegacyImages,
+  isCanonicalImageRef,
   isCanonicalToolResult,
   looksLikeLegacyRichToolOutput,
 } from "../../../shared/canonicalToolResult";
 import { materializeToolResultForModel } from "./canonicalToolResultService";
+
+/** Maximum number of historical image payloads re-injected per turn. */
+const HISTORICAL_IMAGE_BUDGET = 2;
 
 function resolveToolName(part: Record<string, unknown>): string | undefined {
   if (typeof part.toolName === "string" && part.toolName.length > 0) {
@@ -21,12 +26,46 @@ function resolveToolName(part: Record<string, unknown>): string | undefined {
   return undefined;
 }
 
+function outputHasImages(output: unknown): boolean {
+  if (isCanonicalToolResult(output)) {
+    return (
+      output.modelOutput.type === "content" &&
+      output.modelOutput.value.some(isCanonicalImageRef)
+    );
+  }
+  if (looksLikeLegacyRichToolOutput(output)) {
+    return extractLegacyImages(output as Record<string, unknown>).length > 0;
+  }
+  return false;
+}
+
+function countHistoricalImages(
+  messages: Array<{ role: string; parts?: unknown[] }>,
+): number {
+  let count = 0;
+  for (const message of messages) {
+    if (!Array.isArray(message.parts)) continue;
+    for (const rawPart of message.parts) {
+      if (!rawPart || typeof rawPart !== "object") continue;
+      const part = rawPart as Record<string, unknown>;
+      if (part.state !== "output-available") continue;
+      if (outputHasImages(part.output)) count++;
+    }
+  }
+  return count;
+}
+
 export async function buildHistoricalReplayTools(params: {
   messages: Array<{ role: string; parts?: unknown[] }>;
   liveTools: Record<string, any>;
   supportsVision: boolean;
 }): Promise<Record<string, any>> {
   const tools = { ...params.liveTools };
+
+  // Track how many image-bearing historical results to degrade (oldest first).
+  // This prevents O(turns²) image re-injection when a tool is called repeatedly.
+  const totalImages = countHistoricalImages(params.messages);
+  let imagesToSkip = Math.max(0, totalImages - HISTORICAL_IMAGE_BUDGET);
 
   for (const message of params.messages) {
     if (!Array.isArray(message.parts)) {
@@ -61,6 +100,14 @@ export async function buildHistoricalReplayTools(params: {
         description: "Historical tool replay adapter",
         inputSchema: jsonSchema({ type: "object", additionalProperties: true }),
         async toModelOutput({ output }: { output: unknown }) {
+          // Degrade oldest image results to text to stay within the budget.
+          // imagesToSkip is captured by reference and shared across all tool
+          // stubs — the SDK calls toModelOutput in message order (oldest first),
+          // so decrementing here keeps the NEWEST images intact.
+          if (outputHasImages(output) && imagesToSkip > 0) {
+            imagesToSkip--;
+            return materializeToolResultForModel({ output, supportsVision: false });
+          }
           return materializeToolResultForModel({
             output,
             supportsVision: params.supportsVision,

--- a/src/main/services/toolResults/historicalToolReplayTools.ts
+++ b/src/main/services/toolResults/historicalToolReplayTools.ts
@@ -1,0 +1,74 @@
+import { jsonSchema } from "ai";
+import {
+  isCanonicalToolResult,
+  looksLikeLegacyRichToolOutput,
+} from "../../../shared/canonicalToolResult";
+import { materializeToolResultForModel } from "./canonicalToolResultService";
+
+function resolveToolName(part: Record<string, unknown>): string | undefined {
+  if (typeof part.toolName === "string" && part.toolName.length > 0) {
+    return part.toolName;
+  }
+
+  if (
+    typeof part.type === "string" &&
+    part.type.startsWith("tool-") &&
+    part.type !== "tool-invocation"
+  ) {
+    return part.type.slice("tool-".length);
+  }
+
+  return undefined;
+}
+
+export async function buildHistoricalReplayTools(params: {
+  messages: Array<{ role: string; parts?: unknown[] }>;
+  liveTools: Record<string, any>;
+  supportsVision: boolean;
+}): Promise<Record<string, any>> {
+  const tools = { ...params.liveTools };
+
+  for (const message of params.messages) {
+    if (!Array.isArray(message.parts)) {
+      continue;
+    }
+
+    for (const rawPart of message.parts) {
+      if (!rawPart || typeof rawPart !== "object") {
+        continue;
+      }
+
+      const part = rawPart as Record<string, unknown>;
+      if (part.state !== "output-available") {
+        continue;
+      }
+
+      const toolName = resolveToolName(part);
+      if (!toolName || toolName in tools) {
+        continue;
+      }
+
+      const output = part.output;
+      if (
+        !isCanonicalToolResult(output) &&
+        !looksLikeLegacyRichToolOutput(output)
+      ) {
+        continue;
+      }
+
+      tools[toolName] = {
+        type: "dynamic",
+        description: "Historical tool replay adapter",
+        inputSchema: jsonSchema({ type: "object", additionalProperties: true }),
+        async toModelOutput({ output }: { output: unknown }) {
+          return materializeToolResultForModel({
+            output,
+            supportsVision: params.supportsVision,
+          });
+        },
+      };
+    }
+  }
+
+  return tools;
+}

--- a/src/main/services/toolResults/toolResultAssetStore.ts
+++ b/src/main/services/toolResults/toolResultAssetStore.ts
@@ -1,0 +1,164 @@
+import { createHash } from "node:crypto";
+import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { app } from "electron";
+import sharp from "sharp";
+import { databaseService } from "../databaseService";
+
+export interface PersistedImageAsset {
+  assetId: string;
+  sha256: string;
+  mediaType: string;
+  byteSize: number;
+  base64Length: number;
+  width?: number;
+  height?: number;
+}
+
+function getImageAssetsDirectory(): string {
+  return path.join(app.getPath("userData"), "tool-result-assets", "images");
+}
+
+function extensionFromMediaType(mediaType: string): string {
+  switch (mediaType) {
+    case "image/jpeg":
+      return ".jpg";
+    case "image/gif":
+      return ".gif";
+    case "image/webp":
+      return ".webp";
+    case "image/png":
+    default:
+      return ".png";
+  }
+}
+
+function buildAssetPath(assetId: string, mediaType: string): string {
+  return path.join(
+    getImageAssetsDirectory(),
+    `${assetId}${extensionFromMediaType(mediaType)}`,
+  );
+}
+
+async function getImageDimensions(
+  buffer: Buffer,
+): Promise<{ width?: number; height?: number }> {
+  try {
+    const metadata = await sharp(buffer).metadata();
+    return {
+      ...(typeof metadata.width === "number" ? { width: metadata.width } : {}),
+      ...(typeof metadata.height === "number"
+        ? { height: metadata.height }
+        : {}),
+    };
+  } catch {
+    return {};
+  }
+}
+
+async function findAssetPaths(assetId: string): Promise<string[]> {
+  try {
+    const entries = await readdir(getImageAssetsDirectory());
+    return entries
+      .filter((entry) => entry === assetId || entry.startsWith(`${assetId}.`))
+      .map((entry) => path.join(getImageAssetsDirectory(), entry));
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code === "ENOENT") {
+      return [];
+    }
+    throw error;
+  }
+}
+
+async function isAssetReferenced(assetId: string): Promise<boolean> {
+  const result = await databaseService.execute(
+    "SELECT 1 FROM messages WHERE tool_calls LIKE ? LIMIT 1",
+    [`%${assetId}%`],
+  );
+
+  return result.rows.length > 0;
+}
+
+export async function persistImageAsset(params: {
+  dataBase64: string;
+  mediaType: string;
+}): Promise<PersistedImageAsset> {
+  const bytes = Buffer.from(params.dataBase64, "base64");
+  const sha256 = createHash("sha256").update(bytes).digest("hex");
+  const assetId = sha256;
+  const assetPath = buildAssetPath(assetId, params.mediaType);
+
+  await mkdir(getImageAssetsDirectory(), { recursive: true });
+
+  try {
+    await writeFile(assetPath, bytes, { flag: "wx" });
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== "EEXIST") {
+      throw error;
+    }
+  }
+
+  const dimensions = await getImageDimensions(bytes);
+
+  return {
+    assetId,
+    sha256,
+    mediaType: params.mediaType,
+    byteSize: bytes.length,
+    base64Length: params.dataBase64.length,
+    ...dimensions,
+  };
+}
+
+export async function readImageAsset(params: {
+  assetId: string;
+  mediaType: string;
+}): Promise<{ dataBase64: string; mediaType: string }> {
+  const preferredPath = buildAssetPath(params.assetId, params.mediaType);
+  let bytes: Buffer;
+
+  try {
+    bytes = await readFile(preferredPath);
+  } catch (error) {
+    const err = error as NodeJS.ErrnoException;
+    if (err.code !== "ENOENT") {
+      throw error;
+    }
+
+    const fallbackPaths = await findAssetPaths(params.assetId);
+    if (fallbackPaths.length === 0) {
+      throw error;
+    }
+
+    bytes = await readFile(fallbackPaths[0]);
+  }
+
+  return {
+    dataBase64: bytes.toString("base64"),
+    mediaType: params.mediaType,
+  };
+}
+
+export async function deleteImageAssetsIfUnused(assetIds: string[]): Promise<void> {
+  const uniqueAssetIds = [...new Set(assetIds.filter(Boolean))];
+
+  for (const assetId of uniqueAssetIds) {
+    if (await isAssetReferenced(assetId)) {
+      continue;
+    }
+
+    const assetPaths = await findAssetPaths(assetId);
+    for (const assetPath of assetPaths) {
+      try {
+        await unlink(assetPath);
+      } catch (error) {
+        const err = error as NodeJS.ErrnoException;
+        if (err.code !== "ENOENT") {
+          throw error;
+        }
+      }
+    }
+  }
+}

--- a/src/main/services/toolResults/toolResultAssetStore.ts
+++ b/src/main/services/toolResults/toolResultAssetStore.ts
@@ -2,8 +2,8 @@ import { createHash } from "node:crypto";
 import { mkdir, readdir, readFile, unlink, writeFile } from "node:fs/promises";
 import path from "node:path";
 import { app } from "electron";
-import sharp from "sharp";
 import { databaseService } from "../databaseService";
+import { getImageDimensions } from "../image/imageResizer";
 
 export interface PersistedImageAsset {
   assetId: string;
@@ -40,22 +40,6 @@ function buildAssetPath(assetId: string, mediaType: string): string {
   );
 }
 
-async function getImageDimensions(
-  buffer: Buffer,
-): Promise<{ width?: number; height?: number }> {
-  try {
-    const metadata = await sharp(buffer).metadata();
-    return {
-      ...(typeof metadata.width === "number" ? { width: metadata.width } : {}),
-      ...(typeof metadata.height === "number"
-        ? { height: metadata.height }
-        : {}),
-    };
-  } catch {
-    return {};
-  }
-}
-
 async function findAssetPaths(assetId: string): Promise<string[]> {
   try {
     const entries = await readdir(getImageAssetsDirectory());
@@ -71,6 +55,14 @@ async function findAssetPaths(assetId: string): Promise<string[]> {
   }
 }
 
+/**
+ * Reference check using full-table LIKE scan. assetIds are SHA-256 hex
+ * (64 chars, [0-9a-f]) so they contain no SQL LIKE metacharacters.
+ *
+ * Acceptable for current message volumes; consider a dedicated join
+ * table (message_tool_assets: message_id, asset_id) if this becomes
+ * a hotspot.
+ */
 async function isAssetReferenced(assetId: string): Promise<boolean> {
   const result = await databaseService.execute(
     "SELECT 1 FROM messages WHERE tool_calls LIKE ? LIMIT 1",

--- a/src/main/windows/__tests__/miniChatWindow.test.ts
+++ b/src/main/windows/__tests__/miniChatWindow.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from "vitest";
+
+// Stub Electron APIs — miniChatWindow imports BrowserWindow, ipcMain, etc.
+vi.mock("electron", () => ({
+  BrowserWindow: class {
+    isDestroyed() { return false; }
+    static getAllWindows() { return []; }
+  },
+  screen: { getPrimaryDisplay: vi.fn(), getCursorScreenPoint: vi.fn(), getDisplayNearestPoint: vi.fn() },
+  shell: { openExternal: vi.fn() },
+  ipcMain: { handle: vi.fn() },
+  app: {},
+}));
+
+vi.mock("../../services/logging", () => ({
+  getLogger: () => ({
+    core: { debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+  }),
+}));
+
+vi.mock("../../services/chatService", () => ({
+  chatService: {},
+}));
+
+import { mapPartsToPersistedToolCalls } from "../miniChatWindow";
+
+describe("mapPartsToPersistedToolCalls", () => {
+  it("returns null when there are no tool parts", () => {
+    const parts = [
+      { type: "text", text: "hello" },
+      { type: "reasoning", reasoning: "..." },
+    ];
+    expect(mapPartsToPersistedToolCalls(parts)).toBeNull();
+  });
+
+  it("returns null for an empty array", () => {
+    expect(mapPartsToPersistedToolCalls([])).toBeNull();
+  });
+
+  it("pairs tool-call and tool-result parts by toolCallId", () => {
+    const parts = [
+      { type: "tool-call", toolCallId: "id-1", toolName: "bash", input: { cmd: "ls" } },
+      { type: "tool-result", toolCallId: "id-1", toolName: "bash", output: "file.txt" },
+    ];
+    const result = mapPartsToPersistedToolCalls(parts);
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      id: "id-1",
+      name: "bash",
+      arguments: { cmd: "ls" },
+      result: "file.txt",
+      status: "success",
+    });
+  });
+
+  it("preserves input and output payloads verbatim", () => {
+    const input = { nested: { key: "value" }, arr: [1, 2, 3] };
+    const output = { images: [{ data: "AAAA", mediaType: "image/png" }] };
+    const parts = [
+      { type: "tool-call", toolCallId: "id-2", toolName: "screenshot", input },
+      { type: "tool-result", toolCallId: "id-2", output },
+    ];
+    const result = mapPartsToPersistedToolCalls(parts);
+    expect(result![0].arguments).toEqual(input);
+    expect(result![0].result).toEqual(output);
+  });
+
+  it("handles orphan tool-result without matching tool-call", () => {
+    const parts = [
+      { type: "tool-result", toolCallId: "orphan-1", toolName: "myTool", output: "data" },
+    ];
+    const result = mapPartsToPersistedToolCalls(parts);
+    expect(result).toHaveLength(1);
+    expect(result![0]).toEqual({
+      id: "orphan-1",
+      name: "myTool",
+      arguments: {},
+      result: "data",
+      status: "success",
+    });
+  });
+
+  it("handles multiple tool calls in a single message", () => {
+    const parts = [
+      { type: "tool-call", toolCallId: "a", toolName: "toolA", input: { x: 1 } },
+      { type: "tool-call", toolCallId: "b", toolName: "toolB", input: { y: 2 } },
+      { type: "tool-result", toolCallId: "a", output: "resultA" },
+      { type: "tool-result", toolCallId: "b", output: "resultB" },
+    ];
+    const result = mapPartsToPersistedToolCalls(parts);
+    expect(result).toHaveLength(2);
+    const a = result!.find((r) => r.id === "a")!;
+    const b = result!.find((r) => r.id === "b")!;
+    expect(a.result).toBe("resultA");
+    expect(b.result).toBe("resultB");
+  });
+});

--- a/src/main/windows/miniChatWindow.ts
+++ b/src/main/windows/miniChatWindow.ts
@@ -295,7 +295,7 @@ export function registerMiniChatIPC(): void {
 
         // Persist all messages (legacy mode)
         for (const msg of messages) {
-          let toolCalls: object[] | null = null;
+          let toolCalls: any[] | null = null;
           if (msg.parts && Array.isArray(msg.parts)) {
             const toolParts = msg.parts.filter(
               (p: any) => p.type === 'tool-call' || p.type === 'tool-result'

--- a/src/main/windows/miniChatWindow.ts
+++ b/src/main/windows/miniChatWindow.ts
@@ -9,6 +9,7 @@ import { BrowserWindow, screen, shell, ipcMain } from 'electron';
 import { join } from 'path';
 import { getLogger } from '../services/logging';
 import { chatService } from '../services/chatService';
+import type { PersistedToolCall } from '../../types/database';
 
 const logger = getLogger();
 
@@ -295,15 +296,9 @@ export function registerMiniChatIPC(): void {
 
         // Persist all messages (legacy mode)
         for (const msg of messages) {
-          let toolCalls: any[] | null = null;
-          if (msg.parts && Array.isArray(msg.parts)) {
-            const toolParts = msg.parts.filter(
-              (p: any) => p.type === 'tool-call' || p.type === 'tool-result'
-            );
-            if (toolParts.length > 0) {
-              toolCalls = toolParts;
-            }
-          }
+          const toolCalls = msg.parts && Array.isArray(msg.parts)
+            ? mapPartsToPersistedToolCalls(msg.parts)
+            : null;
 
           await chatService.createMessage({
             id: msg.id,
@@ -347,6 +342,41 @@ export function registerMiniChatIPC(): void {
   });
 
   logger.core.debug('Mini chat IPC handlers registered');
+}
+
+/**
+ * Maps AI SDK message parts to PersistedToolCall shape, pairing tool-call and
+ * tool-result parts by toolCallId. Returns null when no tool parts are present.
+ */
+export function mapPartsToPersistedToolCalls(parts: unknown[]): PersistedToolCall[] | null {
+  const byId = new Map<string, PersistedToolCall>();
+
+  for (const p of parts as any[]) {
+    if (p?.type === 'tool-call' && typeof p.toolCallId === 'string') {
+      byId.set(p.toolCallId, {
+        id: p.toolCallId,
+        name: p.toolName ?? '',
+        arguments: (p.input ?? {}) as Record<string, unknown>,
+        status: 'pending',
+      });
+    } else if (p?.type === 'tool-result' && typeof p.toolCallId === 'string') {
+      const existing = byId.get(p.toolCallId);
+      if (existing) {
+        existing.result = p.output;
+        existing.status = 'success';
+      } else {
+        byId.set(p.toolCallId, {
+          id: p.toolCallId,
+          name: p.toolName ?? '',
+          arguments: {},
+          result: p.output,
+          status: 'success',
+        });
+      }
+    }
+  }
+
+  return byId.size > 0 ? Array.from(byId.values()) : null;
 }
 
 /**

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -18,6 +18,7 @@ import type { ChatSession, Message, CreateMessageInput, SessionType } from '../.
 import type { UIMessage } from 'ai';
 import type { TokenUsage } from '../../preload/types';
 import { getRendererLogger } from '@/services/logger';
+import { isCanonicalToolResult } from '../../shared/canonicalToolResult';
 import { sanitizeToolOutput } from '../../shared/toolOutputSanitizer';
 
 const logger = getRendererLogger();
@@ -502,10 +503,12 @@ export const useChatStore = create<ChatStore>()(
               id: part.toolCallId || `tool-${Date.now()}`,
               name: part.type.replace('tool-', ''),
               arguments: part.input || {},
-              // Sanear: nunca persistir base64 raw de imágenes en content[] cuando
-              // ya existe una versión comprimida en `images`. Ver Paso 5/11 del plan.
+              // New rich tool results are canonicalized in main before hitting the DB.
+              // Renderer must not re-shape canonical outputs or reintroduce inline base64.
               result:
-                part.output && typeof part.output === 'object'
+                isCanonicalToolResult(part.output)
+                  ? part.output
+                  : part.output && typeof part.output === 'object'
                   ? sanitizeToolOutput(part.output)
                   : part.output,
               status: part.state === 'output-available' ? 'success' : part.state,

--- a/src/shared/canonicalToolResult.ts
+++ b/src/shared/canonicalToolResult.ts
@@ -1,0 +1,160 @@
+export const CANONICAL_TOOL_RESULT_VERSION = 1 as const;
+
+export interface CanonicalImageAssetRef {
+  kind: "image-ref";
+  assetId: string;
+  mediaType: string;
+  byteSize: number;
+  base64Length: number;
+  sha256: string;
+  width?: number;
+  height?: number;
+}
+
+export type CanonicalToolModelPart =
+  | {
+      type: "text";
+      text: string;
+    }
+  | CanonicalImageAssetRef;
+
+export type CanonicalToolModelOutput =
+  | {
+      type: "text";
+      value: string;
+    }
+  | {
+      type: "json";
+      value: unknown;
+    }
+  | {
+      type: "content";
+      value: CanonicalToolModelPart[];
+    };
+
+export interface CanonicalToolResultV1 {
+  __levanteToolResult: 1;
+  text?: string;
+  structuredContent?: Record<string, unknown>;
+  uiResources?: unknown[];
+  content?: unknown[];
+  modelOutput: CanonicalToolModelOutput;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+export function isCanonicalImageRef(value: unknown): value is CanonicalImageAssetRef {
+  if (!isRecord(value)) return false;
+
+  return (
+    value.kind === "image-ref" &&
+    typeof value.assetId === "string" &&
+    typeof value.mediaType === "string" &&
+    typeof value.byteSize === "number" &&
+    typeof value.base64Length === "number" &&
+    typeof value.sha256 === "string" &&
+    (value.width === undefined || typeof value.width === "number") &&
+    (value.height === undefined || typeof value.height === "number")
+  );
+}
+
+function isCanonicalToolModelPart(value: unknown): value is CanonicalToolModelPart {
+  if (!isRecord(value)) return false;
+
+  if (value.type === "text") {
+    return typeof value.text === "string";
+  }
+
+  return isCanonicalImageRef(value);
+}
+
+function isCanonicalToolModelOutput(value: unknown): value is CanonicalToolModelOutput {
+  if (!isRecord(value) || typeof value.type !== "string") return false;
+
+  if (value.type === "text") {
+    return typeof value.value === "string";
+  }
+
+  if (value.type === "json") {
+    return "value" in value;
+  }
+
+  if (value.type === "content") {
+    return Array.isArray(value.value) && value.value.every(isCanonicalToolModelPart);
+  }
+
+  return false;
+}
+
+export function isCanonicalToolResult(value: unknown): value is CanonicalToolResultV1 {
+  if (!isRecord(value)) return false;
+
+  return (
+    value.__levanteToolResult === CANONICAL_TOOL_RESULT_VERSION &&
+    isCanonicalToolModelOutput(value.modelOutput) &&
+    (value.text === undefined || typeof value.text === "string") &&
+    (value.structuredContent === undefined || isRecord(value.structuredContent)) &&
+    (value.uiResources === undefined || Array.isArray(value.uiResources)) &&
+    (value.content === undefined || Array.isArray(value.content))
+  );
+}
+
+export function looksLikeLegacyRichToolOutput(value: unknown): boolean {
+  if (!isRecord(value)) return false;
+
+  return (
+    typeof value.text === "string" ||
+    Array.isArray(value.content) ||
+    Array.isArray(value.uiResources) ||
+    Array.isArray(value.images) ||
+    isRecord(value.structuredContent)
+  );
+}
+
+export function extractLegacyImages(
+  value: unknown,
+): Array<{ data: string; mediaType: string }> {
+  if (!isRecord(value)) return [];
+
+  if (Array.isArray(value.images)) {
+    return value.images.flatMap((image) => {
+      if (!isRecord(image) || typeof image.data !== "string") {
+        return [];
+      }
+
+      const mediaType =
+        typeof image.mediaType === "string"
+          ? image.mediaType
+          : typeof image.mimeType === "string"
+            ? image.mimeType
+            : "image/png";
+
+      return [{ data: image.data, mediaType }];
+    });
+  }
+
+  if (!Array.isArray(value.content)) {
+    return [];
+  }
+
+  return value.content.flatMap((item) => {
+    if (
+      !isRecord(item) ||
+      item.type !== "image" ||
+      typeof item.data !== "string"
+    ) {
+      return [];
+    }
+
+    const mediaType =
+      typeof item.mediaType === "string"
+        ? item.mediaType
+        : typeof item.mimeType === "string"
+          ? item.mimeType
+          : "image/png";
+
+    return [{ data: item.data, mediaType }];
+  });
+}

--- a/src/shared/toolOutputSanitizer.ts
+++ b/src/shared/toolOutputSanitizer.ts
@@ -16,6 +16,10 @@ export interface ToolOutputShape {
 }
 
 /**
+ * Legacy helper:
+ * kept only to neutralize old raw MCP content[] image blocks.
+ * New rich tool outputs must use CanonicalToolResultV1 instead.
+ *
  * Deja una "lápida" (`omitted: true`) en vez del base64 para cada bloque `image`
  * dentro de `content[]`. No muta el input. Única fuente de verdad sobre cómo
  * se aligera el output de tool antes de persistir o rehidratar.
@@ -38,9 +42,9 @@ export function stripInlineImagesFromContent(content: unknown[]): unknown[] {
 }
 
 /**
- * Sanea un output de tool completo: preserva text/uiResources/structuredContent/images
- * y aligera `content[]` via `stripInlineImagesFromContent`. Usar este helper tanto
- * cuando el adapter devuelve el resultado como cuando el renderer va a persistirlo.
+ * Legacy/transitional helper:
+ * preserva text/uiResources/structuredContent/images y aligera `content[]`.
+ * No debe usarse como formato persistido nuevo.
  */
 export function sanitizeToolOutput(output: ToolOutputShape): ToolOutputShape {
   const sanitized: ToolOutputShape = { ...output };

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -68,6 +68,14 @@ export interface Message {
   created_at: number;
 }
 
+export interface PersistedToolCall {
+  id: string;
+  name: string;
+  arguments: Record<string, unknown>;
+  result?: unknown;
+  status: string;
+}
+
 export interface Provider {
   id: string;
   name: string;
@@ -129,7 +137,7 @@ export interface CreateMessageInput {
   session_id: string;
   role: "user" | "assistant" | "system";
   content: string;
-  tool_calls?: object[] | null; // Will be JSON stringified or null
+  tool_calls?: PersistedToolCall[] | null; // Will be JSON stringified or null
   attachments?: MessageAttachment[] | null; // File attachments (images, audio)
   reasoningText?: { text: string; duration?: number } | null; // Reasoning content from AI models
   input_tokens?: number | null;
@@ -184,7 +192,7 @@ export interface UpdateChatSessionInput {
 export interface UpdateMessageInput {
   id: string;
   content?: string;
-  tool_calls?: object[];
+  tool_calls?: PersistedToolCall[];
 }
 
 // Query types


### PR DESCRIPTION
## Summary
- Introduce `CanonicalToolResultV1` as the single storage format for MCP tool outputs (`src/shared/canonicalToolResult.ts`)
- Persist tool-result images on disk under `userData/tool-result-assets/images` keyed by SHA-256; DB stores only lightweight `image-ref` entries (`src/main/services/toolResults/toolResultAssetStore.ts`)
- Rebuild model payload for historical tool calls via `tool.toModelOutput`, keeping base64 out of the sanitizer pipeline and compaction summaries (`historicalToolReplayTools.ts`, `canonicalToolResultService.ts`)
- Reference-count assets and clean them up on session delete, message update, and `deleteMessagesAfter` (`chatService.ts`)
- Summarize image-bearing tool calls as `{ text, imageCount }` during compaction to avoid bloating the compaction prompt (`compactionService.ts`)
- Add context-size diagnostics before sending messages to the model (`aiService.ts`)
- Simplify `toolMessageSanitizer` and `mcpToolsAdapter` now that image semantics live in the canonical layer

## Test plan
- [ ] `pnpm test` — unit suites for `canonicalToolResultService`, `toolResultAssetStore`, `historicalToolReplay`, `chatService.toolResults`, `compactionService`, `toolMessageSanitizer`, `mcpToolsAdapter.image`
- [ ] Manually trigger an MCP tool that returns images; verify a file lands in `~/Library/Application Support/levante/tool-result-assets/images/` and the `messages.tool_calls` row contains an `image-ref`
- [ ] Reload the session, send another turn: confirm the model still receives the image via historical replay
- [ ] Delete the session: verify the file is removed (unless deduplicated into another session)
- [ ] Edit an earlier message so subsequent turns are deleted: verify orphaned assets are cleaned up
- [ ] Trigger compaction on a session with image tool results and confirm the summary payload does not include base64

## Follow-ups (not in this PR)
- Startup GC to sweep orphaned files left by crashes between `persistImageAsset` and the DB commit
- Consider a dedicated `tool_call_assets` table to replace the `LIKE '%assetId%'` reference check

🤖 Generated with [Claude Code](https://claude.com/claude-code)