### PR TITLE
feat(local): optional API key for private local/OpenAI-compatible endpoints

### DIFF
--- a/docs/developer/local-provider-apikey-implementation-plan.md
+++ b/docs/developer/local-provider-apikey-implementation-plan.md
@@ -1,0 +1,545 @@
+# Plan de implementación: API Key opcional para Local Provider
+
+> Objetivo: permitir que el usuario configure una **API key opcional** en el Local Provider para poder conectarse a endpoints privados detrás de VPN u otros servidores OpenAI-compatible que requieran autenticación, sin romper el flujo actual (Ollama sin key).
+>
+> **Fecha:** 2026-04-17
+> **Estado:** Propuesta — pendiente de implementación.
+
+---
+
+## Resumen
+
+Hoy el Local Provider ignora `ProviderConfig.apiKey`. Hay que propagar la key en **tres rutas**:
+
+1. **Inferencia** (streaming vía Vercel AI SDK).
+2. **Descubrimiento de modelos** (`/api/tags` + `/v1/models`).
+3. **Validación manual** de endpoint.
+
+Y exponer el campo en la **UI** (`LocalConfig`).
+
+La encriptación en disco ya la aplica `PreferencesService` automáticamente a `providers[].apiKey` — **no hay que tocar almacenamiento ni añadir migraciones**.
+
+---
+
+## Archivos afectados (resumen)
+
+| # | Archivo | Cambio |
+|---|---------|--------|
+| 1 | `src/renderer/pages/ModelPage/ProviderConfigs.tsx` | Añadir input `apiKey` opcional en `LocalConfig` |
+| 2 | `src/main/services/ai/providerResolver.ts` | Pasar `Authorization` header en `configureLocalProvider` |
+| 3 | `src/main/services/modelFetchService.ts` | Aceptar `apiKey?` en `fetchLocalModels` y enviar header |
+| 4 | `src/main/ipc/modelHandlers.ts` | Reenviar `apiKey` desde IPC |
+| 5 | `src/preload/api/models.ts` | Ampliar firma `fetchLocal(endpoint, apiKey?)` |
+| 6 | `src/renderer/services/model/providers/localProvider.ts` | `discoverLocalModels(endpoint, apiKey?)` |
+| 7 | `src/renderer/services/modelService.ts` | Pasar `provider.apiKey` al discover |
+| 8 | `src/main/services/apiValidation/providers/local.ts` | Aceptar `apiKey?` y enviar header |
+| 9 | `src/renderer/locales/en/models.json` | Strings i18n |
+| 10 | `src/renderer/locales/es/models.json` | Strings i18n |
+| 11 | `src/types/models.ts` *(opcional)* | Actualizar comentario sobre `apiKey` |
+| 12 | `docs/developer/local-provider-architecture.md` *(opcional)* | Refrescar doc |
+
+---
+
+## Paso a paso
+
+### Paso 1 — Preload: ampliar firma del bridge IPC
+
+**Archivo:** `src/preload/api/models.ts`
+
+**Cambio (línea 8-9):**
+
+```ts
+// Antes
+fetchLocal: (endpoint: string) =>
+  ipcRenderer.invoke('levante/models/local', endpoint),
+```
+
+```ts
+// Después
+fetchLocal: (endpoint: string, apiKey?: string) =>
+  ipcRenderer.invoke('levante/models/local', endpoint, apiKey),
+```
+
+> Sin esto, el renderer no podría mandar la key al main process.
+
+---
+
+### Paso 2 — IPC handler: reenviar `apiKey`
+
+**Archivo:** `src/main/ipc/modelHandlers.ts` (líneas 44-60)
+
+**Cambio:**
+
+```ts
+// Antes
+ipcMain.handle('levante/models/local', async (_, endpoint: string) => {
+  try {
+    const models = await ModelFetchService.fetchLocalModels(endpoint);
+    return { success: true, data: models };
+  } catch (error) {
+    logger.ipc.error('Failed to fetch local models', { endpoint, error: error instanceof Error ? error.message : error });
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+});
+```
+
+```ts
+// Después
+ipcMain.handle('levante/models/local', async (_, endpoint: string, apiKey?: string) => {
+  try {
+    const models = await ModelFetchService.fetchLocalModels(endpoint, apiKey);
+    return { success: true, data: models };
+  } catch (error) {
+    logger.ipc.error('Failed to fetch local models', { endpoint, error: error instanceof Error ? error.message : error });
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+});
+```
+
+> No loguear la `apiKey` nunca — mantener solo `endpoint` en el log.
+
+---
+
+### Paso 3 — Descubrimiento: enviar `Authorization` en Ollama y OpenAI-compatible
+
+**Archivo:** `src/main/services/modelFetchService.ts` (líneas 105-203)
+
+**Cambios:**
+
+1. Firma del método (línea 106):
+
+```ts
+// Antes
+static async fetchLocalModels(endpoint: string): Promise<any[]> {
+```
+
+```ts
+// Después
+static async fetchLocalModels(endpoint: string, apiKey?: string): Promise<any[]> {
+```
+
+2. Construir headers helper (justo después de validar el endpoint, alrededor de la línea 121):
+
+```ts
+const authHeaders: Record<string, string> = {
+  "Content-Type": "application/json",
+};
+if (apiKey) {
+  authHeaders.Authorization = `Bearer ${apiKey}`;
+}
+```
+
+3. Usar `authHeaders` en ambos `safeFetch`:
+
+```ts
+// Línea ~127-133 (Ollama)
+const response = await safeFetch(
+  ollamaUrl,
+  { headers: authHeaders },
+  2000
+);
+```
+
+```ts
+// Línea ~167-171 (OpenAI-compatible fallback)
+const response = await safeFetch(url, {
+  headers: authHeaders,
+});
+```
+
+> Ollama ignora el header `Authorization`, así que no rompe el flujo existente.
+
+---
+
+### Paso 4 — Renderer provider service: propagar `apiKey`
+
+**Archivo:** `src/renderer/services/model/providers/localProvider.ts`
+
+**Reemplazo completo de `discoverLocalModels`:**
+
+```ts
+export async function discoverLocalModels(
+  endpoint: string,
+  apiKey?: string
+): Promise<Model[]> {
+  try {
+    const result = await window.levante.models.fetchLocal(endpoint, apiKey);
+
+    if (!result.success) {
+      logger.models.warn('Failed to discover local models', {
+        endpoint,
+        error: result.error
+      });
+      return [];
+    }
+
+    const data = result.data || [];
+
+    return data.map((model: any): Model => ({
+      id: model.name,
+      name: model.name,
+      provider: 'local',
+      contextLength: model.details?.context_length || 0,
+      capabilities: ['text'],
+      isAvailable: true,
+      userDefined: false
+    }));
+  } catch (error) {
+    logger.models.error('Failed to discover local models', {
+      endpoint,
+      error: error instanceof Error ? error.message : error
+    });
+    return [];
+  }
+}
+```
+
+---
+
+### Paso 5 — `ModelService._doSyncProviderModels`: pasar la key
+
+**Archivo:** `src/renderer/services/modelService.ts` (líneas 591-595)
+
+**Cambio:**
+
+```ts
+// Antes
+case 'local':
+  if (provider.baseUrl) {
+    models = await discoverLocalModels(provider.baseUrl);
+  }
+  break;
+```
+
+```ts
+// Después
+case 'local':
+  if (provider.baseUrl) {
+    models = await discoverLocalModels(provider.baseUrl, provider.apiKey);
+  }
+  break;
+```
+
+---
+
+### Paso 6 — Inferencia: inyectar `Authorization` en el AI SDK
+
+**Archivo:** `src/main/services/ai/providerResolver.ts` (líneas 147-172)
+
+**Reemplazo completo de `configureLocalProvider`:**
+
+```ts
+function configureLocalProvider(provider: ProviderConfig, modelId: string) {
+  if (!provider.baseUrl) {
+    throw new Error(
+      `Local provider endpoint missing for provider ${provider.name}`
+    );
+  }
+
+  // Ensure the baseURL has the /v1 suffix for OpenAI compatibility
+  let localBaseUrl = provider.baseUrl;
+  if (!localBaseUrl.endsWith('/v1')) {
+    localBaseUrl = localBaseUrl.replace(/\/$/, '') + '/v1';
+  }
+
+  logger.aiSdk.debug("Creating Local provider", {
+    modelId,
+    baseURL: localBaseUrl,
+    hasApiKey: Boolean(provider.apiKey),
+  });
+
+  const localProvider = createOpenAICompatible({
+    name: "local",
+    baseURL: localBaseUrl,
+    headers: provider.apiKey
+      ? { Authorization: `Bearer ${provider.apiKey}` }
+      : undefined,
+  });
+
+  return localProvider(modelId);
+}
+```
+
+> **Nunca** loguear `provider.apiKey`. Solo `hasApiKey: boolean`.
+
+---
+
+### Paso 7 — Validación manual: enviar header si hay key
+
+**Archivo:** `src/main/services/apiValidation/providers/local.ts`
+
+**Reemplazo completo:**
+
+```ts
+import { getLogger } from '../../logging';
+import type { ValidationResult, ModelsResponse } from '../types';
+
+const logger = getLogger();
+
+/**
+ * Validate local endpoint (Ollama, LM Studio, private OpenAI-compatible).
+ */
+export async function validateLocal(
+  endpoint: string,
+  apiKey?: string
+): Promise<ValidationResult> {
+  try {
+    if (!endpoint) {
+      return {
+        isValid: false,
+        error: 'Endpoint is required for local models',
+      };
+    }
+
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+
+    // Try Ollama endpoint first
+    const response = await fetch(`${endpoint}/api/tags`, {
+      headers,
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!response.ok) {
+      // Try OpenAI-compatible endpoint as fallback
+      const fallbackResponse = await fetch(`${endpoint}/v1/models`, {
+        headers,
+        signal: AbortSignal.timeout(5000),
+      });
+
+      if (!fallbackResponse.ok) {
+        return {
+          isValid: false,
+          error: `Cannot connect to local server. Make sure it's running at ${endpoint}`,
+        };
+      }
+
+      const fallbackData = await fallbackResponse.json() as ModelsResponse;
+      const modelsCount = fallbackData.data?.length || 0;
+
+      logger.core.info('Local validation successful (OpenAI-compatible)', {
+        endpoint,
+        modelsCount,
+        hasApiKey: Boolean(apiKey),
+      });
+
+      return { isValid: true, modelsCount };
+    }
+
+    const data = await response.json() as ModelsResponse;
+    const modelsCount = data.models?.length || 0;
+
+    logger.core.info('Local validation successful (Ollama)', {
+      endpoint,
+      modelsCount,
+      hasApiKey: Boolean(apiKey),
+    });
+
+    return { isValid: true, modelsCount };
+  } catch (error) {
+    logger.core.error('Local validation error', {
+      error: error instanceof Error ? error.message : error,
+      endpoint,
+    });
+
+    if (error instanceof Error && error.name === 'AbortError') {
+      return {
+        isValid: false,
+        error: `Connection timeout. Is your local server running at ${endpoint}?`,
+      };
+    }
+
+    return {
+      isValid: false,
+      error: `Cannot connect to local server. Make sure it's running at ${endpoint}`,
+    };
+  }
+}
+```
+
+> Buscar callers de `validateLocal` con `Grep` y añadirles `provider.apiKey` como segundo argumento (todos deberían estar en el flujo de "Validar endpoint" del UI).
+
+---
+
+### Paso 8 — UI: añadir input opcional de API key
+
+**Archivo:** `src/renderer/pages/ModelPage/ProviderConfigs.tsx` (líneas 177-224)
+
+**Reemplazo completo de `LocalConfig`:**
+
+```tsx
+export const LocalConfig = ({ provider }: { provider: ProviderConfig }) => {
+  const { t } = useTranslation('models');
+  const { updateProvider, syncProviderModels, syncing } = useModelStore();
+  const [baseUrl, setBaseUrl] = React.useState(provider.baseUrl || 'http://localhost:11434');
+  const [apiKey, setApiKey] = React.useState(provider.apiKey || '');
+
+  // Sync local state when provider changes
+  React.useEffect(() => {
+    setBaseUrl(provider.baseUrl || 'http://localhost:11434');
+    setApiKey(provider.apiKey || '');
+  }, [provider.baseUrl, provider.apiKey]);
+
+  const handleSave = async () => {
+    await updateProvider(provider.id, {
+      baseUrl,
+      apiKey: apiKey.trim() || undefined,
+    });
+    if (baseUrl) {
+      syncProviderModels(provider.id);
+    }
+  };
+
+  const handleSync = () => {
+    syncProviderModels(provider.id);
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2">
+        <Label htmlFor="local-url">{t('base_url.label')}</Label>
+        <Input
+          id="local-url"
+          type="url"
+          placeholder="http://localhost:11434"
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
+        />
+        <p className="text-xs text-muted-foreground">{t('base_url.help_local')}</p>
+      </div>
+
+      <div className="space-y-2">
+        <Label htmlFor="local-api-key">{t('api_key.label_local')}</Label>
+        <Input
+          id="local-api-key"
+          type="password"
+          placeholder={t('api_key.placeholder_local')}
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          autoComplete="off"
+        />
+        <p className="text-xs text-muted-foreground">{t('api_key.help_local')}</p>
+      </div>
+
+      <div className="flex gap-2">
+        <Button onClick={handleSave}>{t('stats.save')}</Button>
+        {provider.baseUrl && (
+          <Button onClick={handleSync} disabled={syncing} variant="outline">
+            <RefreshCw className={`w-4 h-4 mr-2 ${syncing ? 'animate-spin' : ''}`} />
+            {t('models.discover')}
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+};
+```
+
+> El `apiKey.trim() || undefined` permite **borrar** la key dejando el campo vacío y guardando.
+
+---
+
+### Paso 9 — i18n: strings en inglés y español
+
+**Archivo:** `src/renderer/locales/en/models.json`
+
+Añadir bajo la clave `api_key` (crearla si no existe):
+
+```json
+{
+  "api_key": {
+    "label_local": "API Key (optional)",
+    "placeholder_local": "Leave empty if your server does not require authentication",
+    "help_local": "Only needed for private endpoints behind VPN or gateways that require a Bearer token. Not required for local Ollama/LM Studio."
+  }
+}
+```
+
+**Archivo:** `src/renderer/locales/es/models.json`
+
+```json
+{
+  "api_key": {
+    "label_local": "API Key (opcional)",
+    "placeholder_local": "Déjalo vacío si tu servidor no requiere autenticación",
+    "help_local": "Solo es necesaria para endpoints privados detrás de VPN o gateways que requieran un Bearer token. No hace falta para Ollama/LM Studio local."
+  }
+}
+```
+
+> Si ya existen otras subclaves dentro de `api_key` en los JSON, hacer **merge** en lugar de sobrescribir.
+
+---
+
+### Paso 10 *(opcional)* — Limpiar comentario desactualizado en types
+
+**Archivo:** `src/types/models.ts` (líneas 34-51)
+
+Si el comentario dice "No utilizado en local" sobre `apiKey`, actualizarlo:
+
+```ts
+apiKey?: string;  // Cloud providers + optional for private local endpoints behind VPN
+```
+
+---
+
+### Paso 11 *(opcional)* — Refrescar la doc existente
+
+**Archivo:** `docs/developer/local-provider-architecture.md`
+
+Secciones a actualizar:
+
+- **§1 "Interfaz `ProviderConfig`"**: cambiar la nota de `apiKey` a "opcional; usado si el endpoint privado requiere Bearer token".
+- **§2.1**: reflejar el nuevo input en `LocalConfig`.
+- **§3.2** y **§3.4**: añadir que ahora se envía `Authorization: Bearer {apiKey}` si existe.
+- **§4.2**: reflejar que `createOpenAICompatible` recibe `headers`.
+- **§8**: añadir un nuevo edge case "Autenticación opcional para endpoints privados".
+
+---
+
+## Pruebas manuales
+
+Después de implementar, validar:
+
+1. **Ollama local sin key**: funciona igual que antes (no se envía `Authorization`). Discover muestra modelos. Chat stream OK.
+2. **Endpoint privado con key correcta**:
+   - Guardar URL + API key.
+   - Click "Discover" → aparecen modelos.
+   - Enviar mensaje → respuesta en streaming.
+3. **Endpoint privado con key incorrecta**: Discover falla con 401; mensaje de error visible en UI.
+4. **Borrar la key**: vaciar el input + Save → `provider.apiKey === undefined`, siguiente request no envía header.
+5. **Persistencia**: reiniciar la app → la key sigue ahí, encriptada (`ENCRYPTED:` prefix en `~/levante/ui-preferences.json`).
+
+## Tests unitarios recomendados (opcional, PR aparte)
+
+- `fetchLocalModels(endpoint, apiKey)` con mock de `safeFetch` comprobando que el header `Authorization` se envía solo cuando hay key.
+- `configureLocalProvider` con y sin `provider.apiKey`: verificar el argumento `headers` pasado a `createOpenAICompatible`.
+- `validateLocal` con 401 → `isValid: false`.
+
+---
+
+## Consideraciones de seguridad
+
+- **Nunca loguear la key**: usar `hasApiKey: Boolean(...)` en los `logger.*.debug/info`.
+- **TLS con CA corporativa**: si el endpoint HTTPS usa un cert de CA privada de la VPN, puede fallar por TLS. **No** añadir `rejectUnauthorized: false` como primera opción — primero verificar que Electron pueda confiar en la CA del sistema. Si aparece el problema, abrir issue aparte.
+- **SSRF**: `validateLocalEndpoint` ya es permisivo (documentado en §8.6 de `local-provider-architecture.md`), así que IPs privadas de la VPN siguen permitidas.
+- **Backwards compatibility**: al ser `apiKey` opcional y la rama OLLAMA ignorar el header, no se rompe ninguna instalación existente.
+
+---
+
+## Orden sugerido de commits
+
+1. **feat(local): thread optional apiKey through ipc + discover** — Pasos 1-5.
+2. **feat(local): send Bearer token in inference and validation** — Pasos 6-7.
+3. **feat(local): add optional api key input to LocalConfig UI** — Pasos 8-9.
+4. **docs(local): document optional api key for private endpoints** — Pasos 10-11.
+
+Cada commit debe ser verde en `pnpm typecheck` y `pnpm lint` de forma independiente.

--- a/docs/developer/local-provider-architecture.md
+++ b/docs/developer/local-provider-architecture.md
@@ -1,0 +1,827 @@
+# Local Provider - Arquitectura y Funcionamiento
+
+> Documento técnico exhaustivo sobre cómo funciona el proveedor **Local** en Levante (Ollama, LM Studio, LocalAI y cualquier endpoint OpenAI-compatible).
+>
+> **Última actualización:** 2026-04-17
+
+---
+
+## Resumen Ejecutivo
+
+El **Local Provider** en Levante permite a los usuarios configurar endpoints locales (Ollama, LM Studio, LocalAI) para ejecutar modelos de IA **sin dependencias cloud**.
+
+**Características clave:**
+
+- Configuración sencilla: solo requiere URL del endpoint.
+- **Dual fallback**: soporta tanto la API nativa de Ollama (`/api/tags`) como endpoints OpenAI-compatible (`/v1/models`).
+- Descubrimiento automático de modelos disponibles en el servidor.
+- Persistencia de configuración y selecciones en `~/levante/ui-preferences.json`.
+- Integración nativa con Vercel AI SDK (`createOpenAICompatible`) para streaming.
+- Clasificación automática de modelos para determinar capabilities.
+- Permite agregar modelos manualmente (user-defined) si el descubrimiento automático falla.
+
+---
+
+## Tabla de Contenidos
+
+1. [Definición y tipos](#1-definición-y-tipos-del-proveedor-local)
+2. [Flujo de configuración](#2-flujo-de-configuración)
+3. [Descubrimiento y fetching de modelos](#3-descubrimiento-y-fetching-de-modelos-locales)
+4. [Inferencia y streaming](#4-inferencia-y-streaming)
+5. [UI y UX](#5-ui-y-ux)
+6. [ModelStore (Zustand)](#6-modelstore-zustand)
+7. [Tests existentes](#7-tests-existentes)
+8. [Edge cases y particularidades](#8-edge-cases-y-particularidades)
+9. [Flujo completo end-to-end](#9-flujo-completo-end-to-end)
+10. [Manifiesto de archivos involucrados](#10-manifiesto-de-archivos-involucrados)
+
+---
+
+## 1. Definición y Tipos del Proveedor Local
+
+### Definición del tipo
+
+**Archivo:** `src/types/models.ts:31-32`
+
+```typescript
+export type CloudProviderType = 'openai' | 'anthropic' | 'google' | 'groq' | 'xai' | 'huggingface';
+export type ProviderType = 'openrouter' | 'vercel-gateway' | 'local' | 'levante-platform' | CloudProviderType;
+```
+
+El valor `'local'` es miembro del tipo unión `ProviderType`.
+
+### Interfaz `ProviderConfig`
+
+**Archivo:** `src/types/models.ts:34-51`
+
+```typescript
+export interface ProviderConfig {
+  id: string;
+  name: string;
+  type: ProviderType;       // 'local' para proveedores locales
+  apiKey?: string;          // Opcional; usado si el endpoint privado requiere Bearer token
+  baseUrl?: string;         // CRÍTICO: URL del endpoint (ej: http://localhost:11434)
+  models: Model[];
+  selectedModelIds?: string[];
+  isActive: boolean;
+  settings: Record<string, any>;
+  modelSource: 'dynamic' | 'user-defined';
+  lastModelSync?: number;
+}
+```
+
+Para proveedores locales:
+
+- `type`: siempre `'local'`.
+- `baseUrl`: URL del endpoint (ej: `http://localhost:11434`).
+- `modelSource`: típicamente `'user-defined'`.
+- `apiKey`: opcional; solo se envía como `Authorization: Bearer {apiKey}` si el endpoint privado (VPN/gateway) lo requiere. Ignorado por Ollama/LM Studio.
+
+### Inicialización por defecto
+
+**Archivo:** `src/renderer/services/modelService.ts:140-147`
+
+```typescript
+{
+  id: 'local',
+  name: 'Local Provider',
+  type: 'local',
+  models: [],
+  isActive: false,
+  settings: {},
+  modelSource: 'user-defined'
+}
+```
+
+---
+
+## 2. Flujo de Configuración
+
+### 2.1 Configuración desde la UI
+
+**Componente:** `src/renderer/pages/ModelPage/ProviderConfigs.tsx:177-224`
+
+```typescript
+export const LocalConfig = ({ provider }: { provider: ProviderConfig }) => {
+  const { updateProvider, syncProviderModels, syncing } = useModelStore();
+  const [baseUrl, setBaseUrl] = React.useState(provider.baseUrl || 'http://localhost:11434');
+  const [apiKey, setApiKey] = React.useState(provider.apiKey || '');
+
+  const handleSave = async () => {
+    await updateProvider(provider.id, {
+      baseUrl,
+      apiKey: apiKey.trim() || undefined,
+    });
+    if (baseUrl) {
+      syncProviderModels(provider.id);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <Label htmlFor="local-url">{t('base_url.label')}</Label>
+      <Input id="local-url" type="url" placeholder="http://localhost:11434" value={baseUrl} onChange={(e) => setBaseUrl(e.target.value)} />
+      <Label htmlFor="local-api-key">{t('api_key.label_local')}</Label>
+      <Input id="local-api-key" type="password" placeholder={t('api_key.placeholder_local')} value={apiKey} onChange={(e) => setApiKey(e.target.value)} autoComplete="off" />
+      <Button onClick={handleSave}>{t('stats.save')}</Button>
+      {provider.baseUrl && (
+        <Button onClick={handleSync} disabled={syncing}>
+          <RefreshCw className={`w-4 h-4 mr-2 ${syncing ? 'animate-spin' : ''}`} />
+          {t('models.discover')}
+        </Button>
+      )}
+    </div>
+  );
+};
+```
+
+**Flujo:**
+1. Usuario ingresa la URL del endpoint (ej: `http://localhost:11434`).
+2. Opcionalmente ingresa una API key (solo para endpoints privados detrás de VPN que requieran `Authorization: Bearer`).
+3. Al guardar, se llama a `updateProvider(provider.id, { baseUrl, apiKey })`. Un string vacío se guarda como `undefined` para poder borrar la key.
+4. Automáticamente dispara `syncProviderModels(provider.id)`.
+
+### 2.2 Persistencia en `ui-preferences.json`
+
+**Archivo:** `src/main/services/preferencesService.ts:26-30`
+
+```typescript
+this.store = new Store({
+  name: 'ui-preferences',
+  cwd: directoryService.getBaseDir(), // ~/levante/
+  defaults: DEFAULT_PREFERENCES,
+});
+```
+
+La configuración se persiste en `~/levante/ui-preferences.json` dentro del array `providers`.
+
+**Ejemplo de estructura persistida:**
+
+```json
+{
+  "providers": [
+    {
+      "id": "local",
+      "name": "Local Provider",
+      "type": "local",
+      "baseUrl": "http://localhost:11434",
+      "models": [...],
+      "selectedModelIds": ["model-id-1", "model-id-2"],
+      "isActive": true,
+      "modelSource": "user-defined",
+      "lastModelSync": 1713358092000
+    }
+  ],
+  "activeProvider": "local"
+}
+```
+
+### 2.3 `PreferencesService`
+
+**Archivo:** `src/main/services/preferencesService.ts`
+
+Métodos clave:
+
+- `get(key)` → `Promise<unknown>`: obtiene preferencias (incluye el array `providers`).
+- `set(key, value)` → `Promise<{success: boolean}>`: persiste cambios.
+- **Encriptación**: los API keys se encriptan mediante `encryptProvidersApiKeys()` (no aplica al Local provider, pero el pipeline atraviesa igual).
+
+---
+
+## 3. Descubrimiento y Fetching de Modelos Locales
+
+### 3.1 IPC Handler: `levante/models/local`
+
+**Archivo:** `src/main/ipc/modelHandlers.ts:44-60`
+
+```typescript
+ipcMain.handle('levante/models/local', async (_, endpoint: string, apiKey?: string) => {
+  try {
+    const models = await ModelFetchService.fetchLocalModels(endpoint, apiKey);
+    return { success: true, data: models };
+  } catch (error) {
+    logger.ipc.error('Failed to fetch local models', { endpoint, error });
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : 'Unknown error'
+    };
+  }
+});
+```
+
+**Invocación desde el renderer** (`src/preload/api/models.ts:8-9`):
+
+```typescript
+fetchLocal: (endpoint: string, apiKey?: string) =>
+  ipcRenderer.invoke('levante/models/local', endpoint, apiKey),
+```
+
+Si `apiKey` está presente, `fetchLocalModels()` añade `Authorization: Bearer {apiKey}` al header de las peticiones tanto a `/api/tags` (Ollama) como a `/v1/models` (OpenAI-compatible). Ollama ignora el header, así que no rompe el flujo sin key.
+
+### 3.2 `ModelFetchService.fetchLocalModels()`
+
+**Archivo:** `src/main/services/modelFetchService.ts:105-203`
+
+Algoritmo de descubrimiento con **dual fallback**:
+
+```
+1. Normalizar endpoint (agregar http:// si falta).
+2. Validar endpoint URL (SSRF prevention).
+3. Intentar Ollama (/api/tags):
+   - GET http://localhost:11434/api/tags
+   - Timeout: 2000 ms
+   - Estructura esperada: { models: [...] }
+4. Si falla o retorna 0 modelos:
+   - Fallback a OpenAI-compatible (/v1/models)
+   - GET http://localhost:11434/v1/models
+   - Estructura esperada: { data: [...] }
+5. Normalizar respuesta OpenAI a formato Ollama:
+   - Asegura campo 'name' (usa 'id' como fallback).
+   - Asegura campo 'details'.
+```
+
+**Endpoints soportados:**
+
+| Servidor  | `/api/tags` | `/v1/models` | Puerto por defecto |
+|-----------|-------------|--------------|--------------------|
+| Ollama    | ✓ (preferido) | ✗          | 11434              |
+| LM Studio | ✗           | ✓            | 1234               |
+| LocalAI   | ✗           | ✓            | 8080               |
+
+**Snippets relevantes:**
+
+```typescript
+// Intento Ollama (líneas 122-149)
+const ollamaUrl = `${normalizedEndpoint}/api/tags`;
+const response = await safeFetch(ollamaUrl, { headers: {...} }, 2000);
+if (response.ok && data.models?.length > 0) {
+  return data.models;
+}
+
+// Fallback OpenAI-compatible (líneas 162-195)
+const url = `${normalizedEndpoint}/v1/models`;
+const response = await safeFetch(url, { headers: {...} });
+const models = data.data || [];
+const normalized = models.map((m: any) => ({
+  ...m,
+  name: m.name || m.id,
+  details: m.details || { family: "unknown" },
+}));
+```
+
+### 3.3 Renderer Provider Service
+
+**Archivo:** `src/renderer/services/model/providers/localProvider.ts`
+
+```typescript
+export async function discoverLocalModels(endpoint: string): Promise<Model[]> {
+  const result = await window.levante.models.fetchLocal(endpoint);
+
+  if (!result.success) {
+    logger.models.warn('Failed to discover local models', { endpoint, error: result.error });
+    return [];
+  }
+
+  return (result.data || []).map((model: any): Model => ({
+    id: model.name,
+    name: model.name,
+    provider: 'local',
+    contextLength: model.details?.context_length || 0,
+    capabilities: ['text'],
+    isAvailable: true,
+    userDefined: false
+  }));
+}
+```
+
+**Mapeo de campos:**
+
+- `model.name` → `Model.id`.
+- `model.details.context_length` → `Model.contextLength` (0 si no reportado).
+- `capabilities` por defecto: `['text']` (se reclasifica luego en `_doSyncProviderModels`).
+
+### 3.4 Validación del Endpoint
+
+**Archivo:** `src/main/services/apiValidation/providers/local.ts:10-82`
+
+```typescript
+export async function validateLocal(
+  endpoint: string,
+  apiKey?: string
+): Promise<ValidationResult> {
+  const headers: Record<string, string> = {};
+  if (apiKey) {
+    headers.Authorization = `Bearer ${apiKey}`;
+  }
+
+  const response = await fetch(`${endpoint}/api/tags`, {
+    headers,
+    signal: AbortSignal.timeout(5000),
+  });
+
+  if (!response.ok) {
+    // Fallback OpenAI-compatible
+    const fallbackResponse = await fetch(`${endpoint}/v1/models`, {
+      headers,
+      signal: AbortSignal.timeout(5000),
+    });
+
+    if (!fallbackResponse.ok) {
+      return {
+        isValid: false,
+        error: `Cannot connect to local server. Make sure it's running at ${endpoint}`,
+      };
+    }
+    const fallbackData = await fallbackResponse.json();
+    return { isValid: true, modelsCount: fallbackData.data?.length || 0 };
+  }
+
+  const data = await response.json();
+  return { isValid: true, modelsCount: data.models?.length || 0 };
+}
+```
+
+**Errores contemplados:**
+
+- Timeout (5 s): `"Connection timeout. Is your local server running at {endpoint}?"`.
+- Connection refused: `"Cannot connect to local server..."`.
+- HTTP error: intenta fallback automático.
+
+### 3.5 Sincronización en `ModelService`
+
+**Archivo:** `src/renderer/services/modelService.ts:575-783`
+
+Método: `_doSyncProviderModels(providerId)`
+
+Para `provider.type === 'local'` (líneas 591-595):
+
+```typescript
+case 'local':
+  if (provider.baseUrl) {
+    models = await discoverLocalModels(provider.baseUrl);
+  }
+  break;
+```
+
+Luego:
+
+1. **Clasificación de modelos** (líneas 639-682): invoca `classifyModel(model)` para asignar `category` y `computedCapabilities`, con caché.
+2. **Restauración de selecciones** (líneas 684-716): si existen `selectedModelIds` persistidos, se usan; en la primera sincronización se auto-seleccionan modelos "top".
+3. **Preservación de modelos user-defined** (líneas 718-747): se concatenan al resultado descubierto.
+4. **Persistencia** (líneas 771-772):
+   ```typescript
+   provider.lastModelSync = Date.now();
+   await this.saveProviders();
+   ```
+
+---
+
+## 4. Inferencia y Streaming
+
+### 4.1 Provider Resolver
+
+**Archivo:** `src/main/services/ai/providerResolver.ts:24-54`
+
+```
+1. Resolver target del modelo (plataforma vs provider standalone).
+2. Si source === 'provider':
+   - Obtener ProviderConfig.
+   - Switch por provider.type.
+3. Si type === 'local':
+   - Llamar a configureLocalProvider(provider, modelId).
+```
+
+### 4.2 `configureLocalProvider`
+
+**Archivo:** `src/main/services/ai/providerResolver.ts:147-172`
+
+```typescript
+function configureLocalProvider(provider: ProviderConfig, modelId: string) {
+  if (!provider.baseUrl) {
+    throw new Error(`Local provider endpoint missing for provider ${provider.name}`);
+  }
+
+  // Ensure the baseURL has the /v1 suffix for OpenAI compatibility
+  let localBaseUrl = provider.baseUrl;
+  if (!localBaseUrl.endsWith('/v1')) {
+    localBaseUrl = localBaseUrl.replace(/\/$/, '') + '/v1';
+  }
+
+  logger.aiSdk.debug("Creating Local provider", {
+    modelId,
+    baseURL: localBaseUrl,
+    hasApiKey: Boolean(provider.apiKey),
+  });
+
+  const localProvider = createOpenAICompatible({
+    name: "local",
+    baseURL: localBaseUrl,
+    headers: provider.apiKey
+      ? { Authorization: `Bearer ${provider.apiKey}` }
+      : undefined,
+  });
+
+  return localProvider(modelId);
+}
+```
+
+**Detalles críticos:**
+
+- Usa `createOpenAICompatible()` del Vercel AI SDK.
+- Fuerza el sufijo `/v1` (ej: `http://localhost:11434` → `http://localhost:11434/v1`).
+- Si `provider.apiKey` está presente, pasa `headers: { Authorization: 'Bearer ...' }` a `createOpenAICompatible`, que los reenvía en cada request de inferencia. Nunca se loguea la key (solo `hasApiKey: boolean`).
+
+### 4.3 Streaming vía Vercel AI SDK
+
+**Archivo:** `src/main/services/aiService.ts:~1309`
+
+```typescript
+const result = streamText({
+  model: languageModel, // retornado por getModelProvider()
+  system: systemPrompt,
+  messages: convertedMessages,
+  tools: toolsToUse,
+  // ...
+});
+```
+
+El modelo local realiza:
+
+1. `POST http://localhost:11434/v1/chat/completions`.
+2. Con payload OpenAI estándar.
+3. Streaming de eventos SSE (`data: {...}`).
+
+### 4.4 Validación de Capacidades
+
+**Archivo:** `src/main/services/aiService.ts:1011-1075`
+
+```typescript
+const isLocalProvider = providerType === "local";
+
+// Validate capabilities BEFORE execution (skip for local providers)
+if (!isLocalProvider) {
+  const validation = validateToolsForModel(modelCapabilities, toolsToUse);
+  // ...
+}
+
+if (isLocalProvider && toolsToUse.length > 0) {
+  this.logger.aiSdk.debug(
+    "Attempting tool use with local model (skipping proactive validation)"
+  );
+}
+```
+
+**Comportamiento especial para `local`:**
+
+- No se valida la capacidad proactivamente (los modelos locales suelen tener metadata incompleta).
+- Se permite intentar tool-use sin bloquear.
+- Se confía en el servidor local para rechazar requests inválidos.
+
+---
+
+## 5. UI y UX
+
+### 5.1 `ProviderConfigPanel`
+
+**Archivo:** `src/renderer/components/providers/ProviderConfigPanel.tsx:95-114`
+
+```typescript
+const renderProviderConfig = (provider: ProviderConfig) => {
+  switch (provider.type) {
+    case 'local':
+      return <LocalConfig provider={provider} />;
+    // ...
+  }
+};
+```
+
+### 5.2 `ModelList`
+
+```tsx
+<ModelList
+  models={activeProvider.models.filter((m) => m.isAvailable)}
+  showSelection={
+    activeProvider.modelSource === 'dynamic' || activeProvider.type === 'local'
+  }
+  onModelToggle={handleModelToggle}
+  searchQuery={searchQuery}
+  providerType={activeProvider.type}
+/>
+```
+
+**Features para `local`:**
+
+- Checkboxes para seleccionar/deseleccionar modelos.
+- Botones "Select All" / "Deselect All".
+- Botón **Discover** (en lugar de "Sync") para refrescar modelos.
+- Búsqueda por nombre de modelo.
+
+### 5.3 Localizaciones
+
+**`src/renderer/locales/en/models.json`:**
+
+```json
+{
+  "provider_types": {
+    "local": "Local AI models (Ollama, LM Studio, etc.)"
+  },
+  "base_url": {
+    "label": "Base URL",
+    "help_local": "Default ports: Ollama (11434), LM Studio (1234), LocalAI (8080)"
+  }
+}
+```
+
+**`src/renderer/locales/es/models.json`:**
+
+```json
+{
+  "provider_types": {
+    "local": "Modelos de IA locales (Ollama, LM Studio, etc.)"
+  },
+  "base_url": {
+    "help_local": "Puertos predeterminados: Ollama (11434), LM Studio (1234), LocalAI (8080)"
+  }
+}
+```
+
+---
+
+## 6. ModelStore (Zustand)
+
+**Archivo:** `src/renderer/stores/modelStore.ts`
+
+### Estado
+
+```typescript
+interface ModelState {
+  providers: ProviderConfig[];
+  activeProvider: ProviderConfig | null;
+  loading: boolean;
+  syncing: boolean;
+  error: string | null;
+  success: string | null;
+}
+```
+
+### Actions clave para Local
+
+1. **`initialize()`** (líneas 38-51): carga providers desde `PreferencesService` y obtiene el `activeProvider`.
+2. **`updateProvider(providerId, updates)`** (líneas 71-89): actualiza `baseUrl` y persiste via `modelService.updateProvider()`.
+3. **`syncProviderModels(providerId)`** (líneas 92-112): llama a `modelService.syncProviderModels()`; para `local` dispara `discoverLocalModels(provider.baseUrl)`.
+4. **`toggleModelSelection(providerId, modelId, selected)`** (líneas 115-126): marca modelos como seleccionados y persiste en `selectedModelIds`.
+
+---
+
+## 7. Tests Existentes
+
+### 7.1 `modelService.firstSyncSelection.test.ts`
+
+**Archivo:** `src/renderer/services/modelService.firstSyncSelection.test.ts`
+
+Mock del local provider (línea 60):
+
+```typescript
+vi.mock('./model/providers/localProvider', () => ({ discoverLocalModels: vi.fn() }));
+```
+
+Casos cubiertos:
+
+- Auto-selección en la primera sincronización.
+- Preservación de estado ya persistido.
+- Preservación de selecciones en memoria.
+
+### 7.2 Huecos de cobertura
+
+No existen tests específicos para:
+
+- `ModelFetchService.fetchLocalModels()`.
+- `localProvider.discoverLocalModels()`.
+- `apiValidation/providers/local.validateLocal()`.
+- `providerResolver.configureLocalProvider()`.
+- Edge cases: servidor offline, timeouts, formatos inesperados.
+
+---
+
+## 8. Edge Cases y Particularidades
+
+### 8.1 Estrategia de dual fallback
+
+El código intenta primero la API nativa de Ollama (`/api/tags`) y, si falla o retorna 0 modelos, cae automáticamente al estándar OpenAI-compatible (`/v1/models`). Máxima compatibilidad con el ecosistema local.
+
+### 8.2 `contextLength` por defecto
+
+**`src/renderer/services/model/providers/localProvider.ts:27`**
+
+```typescript
+contextLength: model.details?.context_length || 0,
+```
+
+Si el servidor local no reporta `context_length`, se asigna **0**. Esto puede provocar edge cases aguas arriba (p. ej. estimación de tokens).
+
+### 8.3 Capabilities por defecto
+
+**`src/renderer/services/model/providers/localProvider.ts:28`**
+
+```typescript
+capabilities: ['text'],
+```
+
+Todos los modelos locales arrancan como `'text'`. Posteriormente `_doSyncProviderModels()` los reclasifica mediante `classifyModel()` en base al ID del modelo (p. ej. detecta familias `llava`, `mistral`, `qwen`, etc.).
+
+### 8.4 Sin tool approval para Local
+
+**`src/types/preferences.ts:78`**
+
+```typescript
+providersWithoutToolApproval?: ProviderType[];
+```
+
+Los usuarios pueden añadir `'local'` para desactivar la confirmación de tool execution (confiando en que el servidor local validará).
+
+### 8.5 URL normalization
+
+**`src/main/utils/urlValidator.ts:183-191`**
+
+```typescript
+export function normalizeEndpoint(endpoint: string): string {
+  if (endpoint.match(/^https?:\/\//i)) return endpoint;
+  return `http://${endpoint}`;
+}
+```
+
+- Usuario ingresa `localhost:11434` → se normaliza a `http://localhost:11434`.
+- En inferencia, se agrega `/v1` → `http://localhost:11434/v1`.
+
+### 8.6 SSRF Protection (permisiva)
+
+**`src/main/utils/urlValidator.ts:194-230`**
+
+`validateLocalEndpoint()` es deliberadamente **permisivo**:
+
+- Valida únicamente el protocol (`http`/`https`).
+- Permite `localhost`, IPs privadas y endpoints de metadata.
+- **Sin restricción de puertos.**
+
+Rationale (líneas 199-203): "Es una aplicación desktop open-source donde los usuarios tienen control completo. Los endpoints se configuran manualmente, no desde fuentes externas."
+
+### 8.7 Timeouts diferenciados
+
+- **Descubrimiento en sync:** 2 segundos (`modelFetchService.ts:127-132`).
+- **Validación manual:** 5 segundos (`apiValidation/providers/local.ts:21`).
+
+Permite que endpoints lentos se descubran durante validación manual, pero fallen rápido en fetches automáticos.
+
+### 8.8 Autenticación opcional para endpoints privados
+
+El campo `provider.apiKey` es **opcional** para el Local provider:
+
+- Si está vacío, no se envía ningún header `Authorization` → compatible con Ollama/LM Studio locales sin autenticación.
+- Si está presente, se añade `Authorization: Bearer {apiKey}` en:
+  - `fetchLocalModels()` — requests a `/api/tags` y `/v1/models`.
+  - `configureLocalProvider()` — header persistente del Vercel AI SDK para todas las llamadas de inferencia.
+  - `validateLocal()` — la validación manual del endpoint.
+- El valor se persiste encriptado por `PreferencesService` (prefijo `ENCRYPTED:` en `~/levante/ui-preferences.json`) gracias a `encryptProvidersApiKeys()`.
+- Caso de uso: conectarse a servidores OpenAI-compatible privados detrás de una VPN o gateway corporativo que requiera un Bearer token. Ollama ignora el header si se envía, por lo que no rompe el flujo sin key.
+- Nunca se loguea la key en texto plano — solo `hasApiKey: Boolean(...)`.
+
+### 8.9 Modelos user-defined
+
+**`src/renderer/services/modelService.ts:718-750`**
+
+```typescript
+const userDefinedModels = provider.models.filter(m => m.userDefined);
+// ...
+provider.models = [...models, ...userDefinedModels];
+```
+
+Permite agregar modelos manualmente aunque no se descubran automáticamente (útil para modelos no estándar o servidores personalizados).
+
+---
+
+## 9. Flujo Completo End-to-End
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│ 1. USER ACTION: Ingresa "http://localhost:11434" en UI       │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 2. ProviderConfigPanel (React) → LocalConfig.handleSave()   │
+│    updateProvider(id, { baseUrl })                          │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 3. ModelStore (Zustand) → modelService.updateProvider()     │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 4. PreferencesService (Main) → ~/levante/ui-preferences.json│
+│    providers[local].baseUrl = "http://localhost:11434"      │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 5. USER ACTION: Click "Discover"                            │
+│    syncProviderModels('local')                              │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 6. ModelService (Renderer) → discoverLocalModels(baseUrl)   │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 7. IPC: window.levante.models.fetchLocal(endpoint)          │
+│    → 'levante/models/local'                                 │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 8. ModelFetchService.fetchLocalModels() (Main)              │
+│    GET /api/tags (Ollama) → fallback GET /v1/models         │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 9. Clasificación (Renderer): classifyModel() por modelo     │
+│    Asigna category + computedCapabilities (cacheado)        │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 10. Persistencia: selectedModelIds, lastModelSync           │
+│     Guardado en ui-preferences.json                         │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 11. USER ACTION: Selecciona modelo y envía mensaje          │
+│     modelRef: "local:llama2"                                │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 12. Chat Request (Main → aiService)                         │
+│     resolveModelTarget("local:llama2")                      │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 13. providerResolver.configureLocalProvider()               │
+│     createOpenAICompatible({ baseURL: ".../v1" })           │
+└─────────────────────────────────────────────────────────────┘
+                              ↓
+┌─────────────────────────────────────────────────────────────┐
+│ 14. Vercel AI SDK streamText()                              │
+│     POST http://localhost:11434/v1/chat/completions         │
+│     Streaming SSE de vuelta                                 │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 10. Manifiesto de Archivos Involucrados
+
+### Tipos y definiciones
+
+- `src/types/models.ts` — `ProviderType`, `ProviderConfig`, `Model`.
+- `src/types/preferences.ts` — `DEFAULT_PREFERENCES`, `UIPreferences`, `providersWithoutToolApproval`.
+
+### Main process (backend)
+
+- `src/main/ipc/modelHandlers.ts` — IPC handler `levante/models/local` (líneas 44-60).
+- `src/main/services/modelFetchService.ts` — `fetchLocalModels()` (líneas 105-203).
+- `src/main/services/preferencesService.ts` — persistencia de providers.
+- `src/main/services/ai/providerResolver.ts` — `configureLocalProvider()` (líneas 147-172).
+- `src/main/services/ai/modelTargetResolver.ts` — resolución modelo → provider.
+- `src/main/services/apiValidation/providers/local.ts` — `validateLocal()`.
+- `src/main/utils/urlValidator.ts` — validación + normalización de URL.
+- `src/main/services/aiService.ts` — streaming con el provider local.
+
+### Preload / IPC bridge
+
+- `src/preload/api/models.ts` — bridge IPC para `fetchLocal()`.
+
+### Renderer (frontend)
+
+- `src/renderer/services/modelService.ts` — `ModelService`, `syncProviderModels()` (líneas 559-783).
+- `src/renderer/services/model/providers/localProvider.ts` — `discoverLocalModels()`.
+- `src/renderer/stores/modelStore.ts` — Zustand store.
+- `src/renderer/components/providers/ProviderConfigPanel.tsx` — renderiza `LocalConfig`.
+- `src/renderer/pages/ModelPage/ProviderConfigs.tsx` — componente `LocalConfig` (líneas 177-224).
+- `src/renderer/pages/ModelPage/ModelList.tsx` — listado de modelos con toggles.
+
+### Localización
+
+- `src/renderer/locales/en/models.json`.
+- `src/renderer/locales/es/models.json`.
+
+### Tests
+
+- `src/renderer/services/modelService.firstSyncSelection.test.ts`.
+
+---
+
+## Apéndice: Recomendaciones Futuras
+
+1. **Añadir tests unitarios** dedicados a:
+   - `ModelFetchService.fetchLocalModels()` (ambos caminos: Ollama y fallback OpenAI).
+   - `validateLocal()` con diferentes estados de conexión.
+   - `configureLocalProvider()` con URLs con/sin `/v1`.
+2. **Mejorar detección de capabilities** más allá de `['text']` base — p. ej. detectar `llava` automáticamente como vision.
+3. **Telemetría opcional** del tipo de servidor local detectado (Ollama vs OpenAI-compatible) para monitorear uso.
+4. **Exponer `contextLength` configurable** en la UI para modelos locales que no reportan este dato.
+5. **Soporte para múltiples Local providers** (actualmente hay uno con `id: 'local'` fijo; usuarios pueden querer varios endpoints).

--- a/src/main/ipc/modelHandlers.ts
+++ b/src/main/ipc/modelHandlers.ts
@@ -43,9 +43,9 @@ export function setupModelHandlers() {
 
   // Fetch local models
   ipcMain.removeHandler('levante/models/local');
-  ipcMain.handle('levante/models/local', async (_, endpoint: string) => {
+  ipcMain.handle('levante/models/local', async (_, endpoint: string, apiKey?: string) => {
     try {
-      const models = await ModelFetchService.fetchLocalModels(endpoint);
+      const models = await ModelFetchService.fetchLocalModels(endpoint, apiKey);
       return {
         success: true,
         data: models

--- a/src/main/services/ai/providerResolver.ts
+++ b/src/main/services/ai/providerResolver.ts
@@ -160,12 +160,16 @@ function configureLocalProvider(provider: ProviderConfig, modelId: string) {
 
   logger.aiSdk.debug("Creating Local provider", {
     modelId,
-    baseURL: localBaseUrl
+    baseURL: localBaseUrl,
+    hasApiKey: Boolean(provider.apiKey),
   });
 
   const localProvider = createOpenAICompatible({
     name: "local",
     baseURL: localBaseUrl,
+    headers: provider.apiKey
+      ? { Authorization: `Bearer ${provider.apiKey}` }
+      : undefined,
   });
 
   return localProvider(modelId);

--- a/src/main/services/apiValidation/index.ts
+++ b/src/main/services/apiValidation/index.ts
@@ -26,7 +26,7 @@ export class ApiValidationService {
         case 'gateway':
           return await validateGateway(config.apiKey!, config.endpoint);
         case 'local':
-          return await validateLocal(config.endpoint!);
+          return await validateLocal(config.endpoint!, config.apiKey);
         case 'openai':
           return await validateOpenAI(config.apiKey!);
         case 'anthropic':

--- a/src/main/services/apiValidation/providers/local.ts
+++ b/src/main/services/apiValidation/providers/local.ts
@@ -1,13 +1,15 @@
 import { getLogger } from '../../logging';
-import type { ValidationResult } from '../types';
-import type { ModelsResponse } from '../types';
+import type { ValidationResult, ModelsResponse } from '../types';
 
 const logger = getLogger();
 
 /**
- * Validate local endpoint (Ollama, LM Studio)
+ * Validate local endpoint (Ollama, LM Studio, private OpenAI-compatible).
  */
-export async function validateLocal(endpoint: string): Promise<ValidationResult> {
+export async function validateLocal(
+  endpoint: string,
+  apiKey?: string
+): Promise<ValidationResult> {
   try {
     if (!endpoint) {
       return {
@@ -16,14 +18,25 @@ export async function validateLocal(endpoint: string): Promise<ValidationResult>
       };
     }
 
+    const headers: Record<string, string> = {};
+    if (apiKey) {
+      headers.Authorization = `Bearer ${apiKey}`;
+    }
+
+    // Strip trailing /v1 so discovery paths don't double it when the user
+    // saved the OpenAI-style base URL (http://host/v1).
+    const rootEndpoint = endpoint.replace(/\/+$/, '').replace(/\/v1$/, '');
+
     // Try Ollama endpoint first
-    const response = await fetch(`${endpoint}/api/tags`, {
-      signal: AbortSignal.timeout(5000), // 5s timeout for local
+    const response = await fetch(`${rootEndpoint}/api/tags`, {
+      headers,
+      signal: AbortSignal.timeout(5000),
     });
 
     if (!response.ok) {
       // Try OpenAI-compatible endpoint as fallback
-      const fallbackResponse = await fetch(`${endpoint}/v1/models`, {
+      const fallbackResponse = await fetch(`${rootEndpoint}/v1/models`, {
+        headers,
         signal: AbortSignal.timeout(5000),
       });
 
@@ -40,12 +53,10 @@ export async function validateLocal(endpoint: string): Promise<ValidationResult>
       logger.core.info('Local validation successful (OpenAI-compatible)', {
         endpoint,
         modelsCount,
+        hasApiKey: Boolean(apiKey),
       });
 
-      return {
-        isValid: true,
-        modelsCount,
-      };
+      return { isValid: true, modelsCount };
     }
 
     const data = await response.json() as ModelsResponse;
@@ -54,12 +65,10 @@ export async function validateLocal(endpoint: string): Promise<ValidationResult>
     logger.core.info('Local validation successful (Ollama)', {
       endpoint,
       modelsCount,
+      hasApiKey: Boolean(apiKey),
     });
 
-    return {
-      isValid: true,
-      modelsCount,
-    };
+    return { isValid: true, modelsCount };
   } catch (error) {
     logger.core.error('Local validation error', {
       error: error instanceof Error ? error.message : error,

--- a/src/main/services/modelFetchService.ts
+++ b/src/main/services/modelFetchService.ts
@@ -103,7 +103,7 @@ export class ModelFetchService {
   }
 
   // Fetch local models (Ollama or OpenAI-compatible)
-  static async fetchLocalModels(endpoint: string): Promise<any[]> {
+  static async fetchLocalModels(endpoint: string, apiKey?: string): Promise<any[]> {
     try {
       // Normalize endpoint (add http:// if missing)
       const normalizedEndpoint = normalizeEndpoint(endpoint);
@@ -119,16 +119,27 @@ export class ModelFetchService {
         throw new Error(validation.error || "Invalid endpoint URL");
       }
 
+      // Strip trailing /v1 (and any trailing slash) so discovery paths don't double it.
+      // Users may save the OpenAI-style base URL (e.g. http://host/v1) used for inference.
+      const rootEndpoint = normalizedEndpoint
+        .replace(/\/+$/, '')
+        .replace(/\/v1$/, '');
+
+      const authHeaders: Record<string, string> = {
+        "Content-Type": "application/json",
+      };
+      if (apiKey) {
+        authHeaders.Authorization = `Bearer ${apiKey}`;
+      }
+
       // 1. Try Ollama endpoint (/api/tags)
       try {
-        const ollamaUrl = `${normalizedEndpoint}/api/tags`;
+        const ollamaUrl = `${rootEndpoint}/api/tags`;
         logger.models.debug(`Trying Ollama endpoint: ${ollamaUrl}`);
         // Use shorter timeout for first attempt
         const response = await safeFetch(
           ollamaUrl,
-          {
-            headers: { "Content-Type": "application/json" },
-          },
+          { headers: authHeaders },
           2000
         );
 
@@ -161,13 +172,11 @@ export class ModelFetchService {
 
       // 2. Try OpenAI-compatible endpoint (/v1/models)
       // This is used by LM Studio, LocalAI, etc.
-      const url = `${normalizedEndpoint}/v1/models`;
+      const url = `${rootEndpoint}/v1/models`;
       logger.models.debug(`Trying OpenAI endpoint: ${url}`);
 
       const response = await safeFetch(url, {
-        headers: {
-          "Content-Type": "application/json",
-        },
+        headers: authHeaders,
       });
 
       logger.models.debug(

--- a/src/preload/api/models.ts
+++ b/src/preload/api/models.ts
@@ -5,8 +5,8 @@ export const modelsApi = {
     ipcRenderer.invoke('levante/models/openrouter', apiKey),
   fetchGateway: (apiKey: string, baseUrl?: string) =>
     ipcRenderer.invoke('levante/models/gateway', apiKey, baseUrl),
-  fetchLocal: (endpoint: string) =>
-    ipcRenderer.invoke('levante/models/local', endpoint),
+  fetchLocal: (endpoint: string, apiKey?: string) =>
+    ipcRenderer.invoke('levante/models/local', endpoint, apiKey),
   fetchOpenAI: (
     params:
       | string

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -250,7 +250,8 @@ export interface LevanteAPI {
       baseUrl?: string
     ) => Promise<{ success: boolean; data?: any[]; error?: string }>;
     fetchLocal: (
-      endpoint: string
+      endpoint: string,
+      apiKey?: string
     ) => Promise<{ success: boolean; data?: any[]; error?: string }>;
     fetchOpenAI: (
       params:

--- a/src/renderer/components/chat/BackgroundTasksDropdown.tsx
+++ b/src/renderer/components/chat/BackgroundTasksDropdown.tsx
@@ -265,10 +265,13 @@ export function BackgroundTasksDropdown({ className }: BackgroundTasksDropdownPr
                       : 'hover:bg-accent/50'
                   )}
                 >
-                  <div className="flex items-start justify-between gap-2 mb-1">
-                    <div className="flex items-center gap-2 min-w-0 flex-1">
+                  <div className="grid grid-cols-[minmax(0,1fr)_auto] items-start gap-2 mb-1">
+                    <div className="flex min-w-0 items-center gap-2 overflow-hidden">
                       {getStatusIcon(task.status)}
-                      <code className="text-xs font-mono truncate flex-1">
+                      <code
+                        className="block w-full min-w-0 overflow-hidden text-ellipsis whitespace-nowrap text-xs font-mono"
+                        title={task.command}
+                      >
                         {getCommandPreview(task.command)}
                       </code>
                     </div>

--- a/src/renderer/components/chat/TodoPanel.tsx
+++ b/src/renderer/components/chat/TodoPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useMemo } from 'react';
 import { CheckCircle2, Circle } from 'lucide-react';
 import { useTodoStore } from '@/stores/todoStore';
 import { cn } from '@/lib/utils';
@@ -11,24 +11,9 @@ import logoBlanco from '@/assets/icons/logo_blanco.svg';
 export function InlineTodoList() {
   const theme = useThemeDetector();
   const logoSvg = theme === 'dark' ? logoBlanco : logoNegro;
-  const [fadingIds, setFadingIds] = useState<Set<string>>(new Set());
   const todos = useTodoStore((s) => s.todos);
-  const previousTodos = useTodoStore((s) => s.previousTodos);
 
-  useEffect(() => {
-    const currentIds = new Set(todos.map((t) => t.id));
-    const removed = previousTodos.filter(
-      (t) => t.status === 'completed' && !currentIds.has(t.id)
-    );
-    if (removed.length === 0) return;
-
-    setFadingIds(new Set(removed.map((t) => t.id)));
-    const timer = setTimeout(() => setFadingIds(new Set()), 500);
-    return () => clearTimeout(timer);
-  }, [todos, previousTodos]);
-
-  const fadingTodos = previousTodos.filter((t) => fadingIds.has(t.id));
-  const visibleTodos = [...todos, ...fadingTodos];
+  const visibleTodos = useMemo(() => todos, [todos]);
 
   if (visibleTodos.length === 0) return null;
 
@@ -39,8 +24,7 @@ export function InlineTodoList() {
           key={todo.id}
           className={cn(
             'flex items-center gap-2 text-sm transition-all duration-300',
-            todo.status === 'completed' && 'text-muted-foreground line-through',
-            fadingIds.has(todo.id) && 'opacity-0 -translate-y-1 duration-500'
+            todo.status === 'completed' && 'text-muted-foreground line-through'
           )}
         >
           {todo.status === 'completed' && (

--- a/src/renderer/locales/en/models.json
+++ b/src/renderer/locales/en/models.json
@@ -20,7 +20,10 @@
   "api_key": {
     "label": "API Key",
     "optional": "API key is optional for model listing but required for inference",
-    "get_key": "Get your key"
+    "get_key": "Get your key",
+    "label_local": "API Key (optional)",
+    "placeholder_local": "Leave empty if your server does not require authentication",
+    "help_local": "Only needed for private endpoints behind VPN or gateways that require a Bearer token. Not required for local Ollama/LM Studio."
   },
   "oauth": {
     "sign_in": "Sign in with OpenRouter",

--- a/src/renderer/locales/es/models.json
+++ b/src/renderer/locales/es/models.json
@@ -20,7 +20,10 @@
   "api_key": {
     "label": "Clave de API",
     "optional": "La clave de API es opcional para listar modelos pero necesaria para inferencia",
-    "get_key": "Obtener tu clave"
+    "get_key": "Obtener tu clave",
+    "label_local": "API Key (opcional)",
+    "placeholder_local": "Déjalo vacío si tu servidor no requiere autenticación",
+    "help_local": "Solo es necesaria para endpoints privados detrás de VPN o gateways que requieran un Bearer token. No hace falta para Ollama/LM Studio local."
   },
   "oauth": {
     "sign_in": "Inicia sesión con OpenRouter",

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -205,6 +205,7 @@ const ChatPage = () => {
   const updateLearnedOverhead = useChatStore((state) => state.updateLearnedOverhead);
   const recalculateContextBudget = useChatStore((state) => state.recalculateContextBudget);
   const currentSession = useChatStore((state) => state.currentSession);
+  const todosInProgress = useTodoStore((s) => s.todos.some((t) => t.status === 'in_progress'));
   const persistMessage = useChatStore((state) => state.persistMessage);
   const editMessage = useChatStore((state) => state.editMessage); // ← NEW
   const createSession = useChatStore((state) => state.createSession);
@@ -1470,8 +1471,8 @@ const ChatPage = () => {
                   {/* Inline todo list */}
                   <InlineTodoList />
 
-                  {/* Streaming indicator */}
-                  {(status === 'streaming' || status === 'submitted') && (
+                  {/* Streaming indicator (hidden when todos are in progress) */}
+                  {(status === 'streaming' || status === 'submitted') && !todosInProgress && (
                     <Message from="assistant">
                       <MessageContent>
                         <BreathingLogo />

--- a/src/renderer/pages/ChatPage.tsx
+++ b/src/renderer/pages/ChatPage.tsx
@@ -205,7 +205,6 @@ const ChatPage = () => {
   const updateLearnedOverhead = useChatStore((state) => state.updateLearnedOverhead);
   const recalculateContextBudget = useChatStore((state) => state.recalculateContextBudget);
   const currentSession = useChatStore((state) => state.currentSession);
-  const todosInProgress = useTodoStore((s) => s.todos.some((t) => t.status === 'in_progress'));
   const persistMessage = useChatStore((state) => state.persistMessage);
   const editMessage = useChatStore((state) => state.editMessage); // ← NEW
   const createSession = useChatStore((state) => state.createSession);
@@ -1341,19 +1340,32 @@ const ChatPage = () => {
           {/* Show error if any */}
           {chatError && (() => {
             const category = transport.lastErrorCategory;
+            const isPlatform = currentModelInfo?.provider === 'levante-platform';
             const friendlyKeys: Record<string, string> = {
               insufficient_balance: 'api.insufficient_balance',
               rate_limit: 'api.rate_limit',
               quota_exceeded: 'api.quota_exceeded',
-              unauthorized: 'api.unauthorized',
+              unauthorized: isPlatform ? 'api.unauthorized' : 'api.invalid_key',
               model_not_available: 'api.model_not_available',
             };
             const i18nKey = category && friendlyKeys[category];
             const friendlyMessage = i18nKey ? tErrors(i18nKey) : chatError.message;
+            // For non-platform providers, surface the original server message too so
+            // users can see what the endpoint actually returned (e.g. "Invalid API key: sk-***").
+            const showServerDetail =
+              !isPlatform &&
+              category === 'unauthorized' &&
+              chatError.message &&
+              chatError.message !== friendlyMessage;
 
             return (
               <div className="p-4 bg-destructive/10 border border-destructive/30 text-destructive text-sm flex items-start justify-between gap-3">
-                <span>{friendlyMessage}</span>
+                <span className="flex flex-col gap-1">
+                  <span>{friendlyMessage}</span>
+                  {showServerDetail && (
+                    <span className="text-xs opacity-80">{chatError.message}</span>
+                  )}
+                </span>
                 {category === 'insufficient_balance' && (
                   <button
                     type="button"
@@ -1370,7 +1382,7 @@ const ChatPage = () => {
                     {t('manage_balance')}
                   </button>
                 )}
-                {category === 'unauthorized' && (
+                {category === 'unauthorized' && isPlatform && (
                   <button
                     type="button"
                     className="shrink-0 underline underline-offset-2 hover:opacity-80 transition-opacity whitespace-nowrap"
@@ -1458,8 +1470,8 @@ const ChatPage = () => {
                   {/* Inline todo list */}
                   <InlineTodoList />
 
-                  {/* Streaming indicator (hidden when todos are in progress) */}
-                  {(status === 'streaming' || status === 'submitted') && !todosInProgress && (
+                  {/* Streaming indicator */}
+                  {(status === 'streaming' || status === 'submitted') && (
                     <Message from="assistant">
                       <MessageContent>
                         <BreathingLogo />

--- a/src/renderer/pages/ModelPage/ProviderConfigs.tsx
+++ b/src/renderer/pages/ModelPage/ProviderConfigs.tsx
@@ -178,15 +178,19 @@ export const LocalConfig = ({ provider }: { provider: ProviderConfig }) => {
   const { t } = useTranslation('models');
   const { updateProvider, syncProviderModels, syncing } = useModelStore();
   const [baseUrl, setBaseUrl] = React.useState(provider.baseUrl || 'http://localhost:11434');
+  const [apiKey, setApiKey] = React.useState(provider.apiKey || '');
 
   // Sync local state when provider changes
   React.useEffect(() => {
     setBaseUrl(provider.baseUrl || 'http://localhost:11434');
-  }, [provider.baseUrl]);
+    setApiKey(provider.apiKey || '');
+  }, [provider.baseUrl, provider.apiKey]);
 
   const handleSave = async () => {
-    await updateProvider(provider.id, { baseUrl });
-    // Trigger sync after saving
+    await updateProvider(provider.id, {
+      baseUrl,
+      apiKey: apiKey.trim() || undefined,
+    });
     if (baseUrl) {
       syncProviderModels(provider.id);
     }
@@ -200,25 +204,38 @@ export const LocalConfig = ({ provider }: { provider: ProviderConfig }) => {
     <div className="space-y-4">
       <div className="space-y-2">
         <Label htmlFor="local-url">{t('base_url.label')}</Label>
-        <div className="flex gap-2">
-          <Input
-            id="local-url"
-            type="url"
-            placeholder="http://localhost:11434"
-            value={baseUrl}
-            onChange={(e) => setBaseUrl(e.target.value)}
-          />
-          <Button onClick={handleSave}>{t('stats.save')}</Button>
-        </div>
+        <Input
+          id="local-url"
+          type="url"
+          placeholder="http://localhost:11434"
+          value={baseUrl}
+          onChange={(e) => setBaseUrl(e.target.value)}
+        />
         <p className="text-xs text-muted-foreground">{t('base_url.help_local')}</p>
       </div>
 
-      {provider.baseUrl && (
-        <Button onClick={handleSync} disabled={syncing} variant="outline">
-          <RefreshCw className={`w-4 h-4 mr-2 ${syncing ? 'animate-spin' : ''}`} />
-          {t('models.discover')}
-        </Button>
-      )}
+      <div className="space-y-2">
+        <Label htmlFor="local-api-key">{t('api_key.label_local')}</Label>
+        <Input
+          id="local-api-key"
+          type="password"
+          placeholder={t('api_key.placeholder_local')}
+          value={apiKey}
+          onChange={(e) => setApiKey(e.target.value)}
+          autoComplete="off"
+        />
+        <p className="text-xs text-muted-foreground">{t('api_key.help_local')}</p>
+      </div>
+
+      <div className="flex gap-2">
+        <Button onClick={handleSave}>{t('stats.save')}</Button>
+        {provider.baseUrl && (
+          <Button onClick={handleSync} disabled={syncing} variant="outline">
+            <RefreshCw className={`w-4 h-4 mr-2 ${syncing ? 'animate-spin' : ''}`} />
+            {t('models.discover')}
+          </Button>
+        )}
+      </div>
     </div>
   );
 };

--- a/src/renderer/selectors/__tests__/deriveTodos.test.ts
+++ b/src/renderer/selectors/__tests__/deriveTodos.test.ts
@@ -13,6 +13,7 @@ const mkAssistant = (parts: any[]): UIMessage => ({
 const mkToolPart = (todos: unknown[]) => ({
   type: 'tool-todo_write',
   toolName: 'todo_write',
+  state: 'output-available',
   output: { todos },
 });
 
@@ -67,6 +68,47 @@ describe('deriveTodosFromMessages', () => {
     ];
     const state = deriveTodosFromMessages(msgs);
     expect(state.todos).toEqual([]);
+  });
+
+  it('ignores an incomplete latest todo_write and falls back to the previous completed one', () => {
+    const msgs = [
+      mkAssistant([mkToolPart([{ id: 'x', subject: 'done', status: 'completed' }])]),
+      mkAssistant([
+        {
+          type: 'tool-todo_write',
+          toolName: 'todo_write',
+          state: 'input-available',
+          input: {
+            todos: [{ id: 'y', subject: 'stuck', status: 'in_progress' }],
+          },
+        },
+      ]),
+    ];
+
+    const state = deriveTodosFromMessages(msgs);
+    expect(state.todos).toHaveLength(1);
+    expect(state.todos[0].id).toBe('x');
+  });
+
+  it('supports tool-invocation parts with completed results', () => {
+    const msgs = [
+      mkAssistant([
+        {
+          type: 'tool-invocation',
+          toolName: 'todo_write',
+          toolInvocation: {
+            state: 'result',
+            result: {
+              todos: [{ id: 'z', subject: 'legacy', status: 'pending' }],
+            },
+          },
+        },
+      ]),
+    ];
+
+    const state = deriveTodosFromMessages(msgs);
+    expect(state.todos).toHaveLength(1);
+    expect(state.todos[0].id).toBe('z');
   });
 
   it('falls back to previous todo_write when latest message removed', () => {

--- a/src/renderer/selectors/deriveTodos.ts
+++ b/src/renderer/selectors/deriveTodos.ts
@@ -20,6 +20,55 @@ const EMPTY: DerivedTodoState = {
   hasTodoWrite: false,
 };
 
+interface TodoPayloadLike {
+  id: string;
+  subject: string;
+  activeForm?: string;
+  status: DerivedTodo['status'];
+}
+
+function isTodoPayloadLike(value: unknown): value is TodoPayloadLike {
+  if (typeof value !== 'object' || value === null) return false;
+
+  const todo = value as Record<string, unknown>;
+  return (
+    typeof todo.id === 'string' &&
+    typeof todo.subject === 'string' &&
+    (todo.activeForm === undefined || typeof todo.activeForm === 'string') &&
+    (todo.status === 'pending' ||
+      todo.status === 'in_progress' ||
+      todo.status === 'completed')
+  );
+}
+
+function extractCompletedTodoOutput(part: any): TodoPayloadLike[] | null {
+  const normalize = (candidate: unknown): TodoPayloadLike[] | null =>
+    Array.isArray(candidate) && candidate.every(isTodoPayloadLike) ? candidate : null;
+
+  if (Array.isArray(part.output?.todos)) {
+    return part.state === undefined || part.state === 'output-available'
+      ? normalize(part.output.todos)
+      : null;
+  }
+
+  if (Array.isArray(part.result?.todos)) {
+    return part.state === undefined || part.state === 'output-available'
+      ? normalize(part.result.todos)
+      : null;
+  }
+
+  if (Array.isArray(part.toolInvocation?.result?.todos)) {
+    const invocationState = part.toolInvocation?.state;
+    return invocationState === undefined ||
+      invocationState === 'result' ||
+      invocationState === 'output-available'
+      ? normalize(part.toolInvocation.result.todos)
+      : null;
+  }
+
+  return null;
+}
+
 /**
  * Walks messages in reverse and returns the todo list from the most recent
  * `todo_write` tool call. Returns empty state if none found.
@@ -49,12 +98,7 @@ export function deriveTodosFromMessages(messages: UIMessage[]): DerivedTodoState
 
       if (toolName !== 'todo_write') continue;
 
-      const output =
-        part.output?.todos ??
-        part.result?.todos ??
-        part.toolInvocation?.result?.todos ??
-        part.input?.todos ??
-        part.args?.todos;
+      const output = extractCompletedTodoOutput(part);
 
       if (!Array.isArray(output)) continue;
 

--- a/src/renderer/services/model/providers/localProvider.ts
+++ b/src/renderer/services/model/providers/localProvider.ts
@@ -6,9 +6,12 @@ const logger = getRendererLogger();
 /**
  * Discover models from local endpoint (Ollama, LM Studio, etc.)
  */
-export async function discoverLocalModels(endpoint: string): Promise<Model[]> {
+export async function discoverLocalModels(
+  endpoint: string,
+  apiKey?: string
+): Promise<Model[]> {
   try {
-    const result = await window.levante.models.fetchLocal(endpoint);
+    const result = await window.levante.models.fetchLocal(endpoint, apiKey);
 
     if (!result.success) {
       logger.models.warn('Failed to discover local models', {

--- a/src/renderer/services/modelService.ts
+++ b/src/renderer/services/modelService.ts
@@ -590,7 +590,7 @@ class ModelServiceImpl {
           break;
         case 'local':
           if (provider.baseUrl) {
-            models = await discoverLocalModels(provider.baseUrl);
+            models = await discoverLocalModels(provider.baseUrl, provider.apiKey);
           }
           break;
         case 'openai':

--- a/src/shared/__tests__/toolOutputSanitizer.test.ts
+++ b/src/shared/__tests__/toolOutputSanitizer.test.ts
@@ -70,6 +70,18 @@ describe("sanitizeToolOutput", () => {
     expect(Object.keys(result)).toEqual([]);
   });
 
+  it("preserves arbitrary tool output fields like files and todos", () => {
+    const output = {
+      success: true,
+      files: [{ path: "/tmp/test.excalidraw", exists: true }],
+      todos: [{ id: "a", subject: "finish", status: "completed" }],
+    };
+
+    const result = sanitizeToolOutput(output);
+
+    expect(result).toEqual(output);
+  });
+
   it("replaces image blocks inside content[] with tombstones", () => {
     const result = sanitizeToolOutput({
       content: [

--- a/src/shared/toolOutputSanitizer.ts
+++ b/src/shared/toolOutputSanitizer.ts
@@ -12,6 +12,7 @@ export interface ToolOutputShape {
   uiResources?: unknown[];
   structuredContent?: Record<string, unknown>;
   images?: Array<{ data: string; mediaType: string }>;
+  [key: string]: unknown;
 }
 
 /**
@@ -42,15 +43,11 @@ export function stripInlineImagesFromContent(content: unknown[]): unknown[] {
  * cuando el adapter devuelve el resultado como cuando el renderer va a persistirlo.
  */
 export function sanitizeToolOutput(output: ToolOutputShape): ToolOutputShape {
-  const cleanContent = Array.isArray(output.content)
-    ? stripInlineImagesFromContent(output.content)
-    : undefined;
+  const sanitized: ToolOutputShape = { ...output };
 
-  return {
-    ...(output.text ? { text: output.text } : {}),
-    ...(cleanContent ? { content: cleanContent } : {}),
-    ...(output.uiResources ? { uiResources: output.uiResources } : {}),
-    ...(output.structuredContent ? { structuredContent: output.structuredContent } : {}),
-    ...(output.images ? { images: output.images } : {}),
-  };
+  if (Array.isArray(output.content)) {
+    sanitized.content = stripInlineImagesFromContent(output.content);
+  }
+
+  return sanitized;
 }

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -35,7 +35,7 @@ export interface ProviderConfig {
   id: string;
   name: string;
   type: ProviderType;
-  apiKey?: string;
+  apiKey?: string;  // Cloud providers + optional for private local endpoints behind VPN
   baseUrl?: string;
   models: Model[]; // In-memory: full list. In storage: only selected models for 'dynamic' providers
   selectedModelIds?: string[]; // IDs of selected models (for dynamic providers, saved to disk)


### PR DESCRIPTION
## Summary
- Adds an **optional API Key** field to the Local provider so private endpoints behind VPN / OpenAI-compatible gateways (that require a Bearer token) can be used. Ollama / LM Studio sin auth siguen funcionando igual.
- La API key se propaga end-to-end: UI → preferences → `ModelFetchService` (descubrimiento) → `providerResolver` (inferencia) → `apiValidation`, siempre como header `Authorization: Bearer <key>`.
- Normaliza el endpoint: elimina `/v1` final antes de construir rutas de discovery (`/api/tags`, `/v1/models`) para evitar `…/v1/v1/models`.
- Mejora errores en chat para proveedores no-plataforma: los `unauthorized` muestran "Invalid API key" en vez del CTA de la plataforma, y además incluye el mensaje original del servidor.
- Arregla el panel de todos: ignora `todo_write` con state `input-available` (todavía en curso) y cae al último resultado completado; añade tests.
- Fix de `toolOutputSanitizer`: preserva campos arbitrarios (`files`, `todos`, etc.) en lugar de descartarlos — antes se perdían al persistir.
- Pequeño fix de UI: el dropdown de Background Tasks ahora trunca correctamente comandos largos con ellipsis.
- Docs: añade `docs/developer/local-provider-architecture.md` (827 líneas) y `docs/PRD/local-provider-apikey-implementation-plan.md` (545 líneas).

## Cambios por área
**Main process**
- `modelHandlers.ts`, `modelFetchService.ts`: handler `levante/models/local` acepta `apiKey`; strip de `/v1` en endpoint.
- `providerResolver.ts`: `createOpenAICompatible` inyecta `Authorization` header si hay apiKey.
- `apiValidation/providers/local.ts`: validación con Bearer opcional sobre `/api/tags` y `/v1/models`.

**Preload / Renderer**
- `preload/api/models.ts`, `preload.ts`: firma `fetchLocal(endpoint, apiKey?)`.
- `ProviderConfigs.tsx` (LocalConfig): nuevo input password para API Key, reorganización del layout de botones.
- `localProvider.ts`, `modelService.ts`: pasan `provider.apiKey` al discovery.
- `ChatPage.tsx`: diferenciación de errores unauthorized para platform vs. otros providers.
- `deriveTodos.ts` + tests: sólo acepta outputs con state completo (`output-available` / `result`).
- `TodoPanel.tsx`: elimina la animación de fade-out (dependía de `previousTodos`).
- `BackgroundTasksDropdown.tsx`: grid con truncado correcto.
- Locales `en/es`: claves `api_key.label_local`, `placeholder_local`, `help_local`.

**Shared**
- `toolOutputSanitizer.ts` + test: mantiene todas las keys del output, solo sanitiza `content[]`.
- `types/models.ts`: comentario aclarando que `apiKey` también aplica a local privado.

## Test plan
- [ ] Configurar Local provider contra Ollama local sin API key → discovery + chat OK
- [ ] Configurar Local provider contra un endpoint OpenAI-compatible privado con Bearer → discovery y chat OK; sin key muestra 401 del servidor
- [ ] Probar endpoint guardado como `http://host/v1` → no duplica `/v1/v1/models`
- [ ] `pnpm test` (incluye los nuevos tests de `deriveTodos` y `toolOutputSanitizer`)
- [ ] `pnpm typecheck` y `pnpm lint`
- [ ] Verificar que el panel de todos no parpadea cuando llegan chunks parciales del tool
- [ ] Verificar truncado en el dropdown de Background Tasks con comandos largos

🤖 Generated with [Claude Code](https://claude.com/claude-code)