### PR TITLE
fix/refactor: sidebar scope, file browser, model catalog cache

### DIFF
--- a/src/main/ipc/projectHandlers.ts
+++ b/src/main/ipc/projectHandlers.ts
@@ -57,5 +57,13 @@ export function setupProjectHandlers(): void {
     return await projectService.addFilesToProject(projectId, result.filePaths);
   });
 
+  ipcMain.removeHandler('levante/projects/addFilesWithPaths');
+  ipcMain.handle('levante/projects/addFilesWithPaths', async (_, projectId: string, filePaths: string[]) => {
+    if (!Array.isArray(filePaths) || filePaths.length === 0) {
+      return { data: [], success: true };
+    }
+    return await projectService.addFilesToProject(projectId, filePaths);
+  });
+
   logger.ipc.info('Project IPC handlers registered');
 }

--- a/src/main/services/aiService.ts
+++ b/src/main/services/aiService.ts
@@ -885,28 +885,12 @@ export class AIService {
     try {
       const target = await resolveModelTarget(modelId);
       return target.providerType;
-    } catch {
-      // Fallback: try raw lookup in providers for backwards compat
-      try {
-        const rawId = getRawModelId(modelId);
-        const { preferencesService } = await import("./preferencesService");
-        const providers = (preferencesService.get("providers") as any[]) || [];
-
-        const providerWithModel = providers.find((provider) => {
-          if (provider.modelSource === "dynamic") {
-            return provider.selectedModelIds?.includes(rawId);
-          } else {
-            return provider.models.some(
-              (model: any) => model.id === rawId && model.isSelected !== false
-            );
-          }
-        });
-
-        return providerWithModel?.type;
-      } catch (error) {
-        this.logger.aiSdk.error("Failed to get provider type", { error, modelId });
-        return undefined;
-      }
+    } catch (error) {
+      this.logger.aiSdk.warn("Failed to resolve provider type", {
+        error: error instanceof Error ? error.message : String(error),
+        modelId,
+      });
+      return undefined;
     }
   }
 

--- a/src/preload/api/projects.ts
+++ b/src/preload/api/projects.ts
@@ -1,4 +1,4 @@
-import { ipcRenderer } from 'electron';
+import { ipcRenderer, webUtils } from 'electron';
 import type {
   CreateProjectInput,
   UpdateProjectInput,
@@ -22,4 +22,7 @@ export const projectsApi = {
     ipcRenderer.invoke('levante/projects/sessions', projectId),
   addFiles: (projectId: string): Promise<DatabaseResult<string[]>> =>
     ipcRenderer.invoke('levante/projects/addFiles', projectId),
+  addFilesWithPaths: (projectId: string, filePaths: string[]): Promise<DatabaseResult<string[]>> =>
+    ipcRenderer.invoke('levante/projects/addFilesWithPaths', projectId, filePaths),
+  getPathForFile: (file: File): string => webUtils.getPathForFile(file),
 };

--- a/src/preload/preload.ts
+++ b/src/preload/preload.ts
@@ -883,6 +883,8 @@ export interface LevanteAPI {
     delete: (id: string) => Promise<DatabaseResult<boolean>>;
     getSessions: (projectId: string) => Promise<DatabaseResult<ChatSession[]>>;
     addFiles: (projectId: string) => Promise<DatabaseResult<string[]>>;
+    addFilesWithPaths: (projectId: string, filePaths: string[]) => Promise<DatabaseResult<string[]>>;
+    getPathForFile: (file: File) => string;
   };
 
   // Platform API

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -11,7 +11,7 @@ import { OnboardingWizard } from '@/pages/OnboardingWizard'
 import { MCPDeepLinkModal } from '@/components/mcp/deep-link/MCPDeepLinkModal'
 import { AnnouncementModal } from '@/components/announcements/AnnouncementModal'
 import { SkillInstallDeepLinkModal } from '@/components/skills/SkillInstallDeepLinkModal'
-import { useChatStore, initializeChatStore } from '@/stores/chatStore'
+import { useChatStore } from '@/stores/chatStore'
 import { useProjectStore } from '@/stores/projectStore'
 import { usePlatformStore } from '@/stores/platformStore'
 import { ProjectModal } from '@/components/projects/ProjectModal'
@@ -234,7 +234,6 @@ function App() {
       }
 
       await Promise.all([
-        initializeChatStore(),
         modelService.initialize(),
         usePlatformStore.getState().initialize()
       ]);
@@ -319,6 +318,8 @@ function App() {
   const setPendingPrompt = useChatStore((state) => state.setPendingPrompt)
   const setSkipNextHistoricalLoad = useChatStore((state) => state.setSkipNextHistoricalLoad)
   const createSession = useChatStore((state) => state.createSession)
+  const refreshSessions = useChatStore((state) => state.refreshSessions)
+  const refreshProjectSessions = useChatStore((state) => state.refreshProjectSessions)
 
   // Project management
   const projects = useProjectStore((state) => state.projects)
@@ -342,6 +343,16 @@ function App() {
   useEffect(() => {
     loadProjects()
   }, [loadProjects])
+
+  // Load sessions scoped to the current sidebar scope (project or global).
+  // Runs on mount with selectedProject=null (global) and re-runs when scope changes.
+  useEffect(() => {
+    if (selectedProject?.id) {
+      refreshProjectSessions(selectedProject.id)
+    } else {
+      refreshSessions()
+    }
+  }, [selectedProject?.id, refreshSessions, refreshProjectSessions])
 
   const handleProjectSave = async (input: CreateProjectInput | UpdateProjectInput) => {
     if ('id' in input) {

--- a/src/renderer/components/ai-elements/prompt-input-editor.tsx
+++ b/src/renderer/components/ai-elements/prompt-input-editor.tsx
@@ -26,6 +26,7 @@ import { FileMentionNode, type FileMentionPayload } from '@/components/chat/lexi
 import { FileMentionPlugin, replaceTriggerWithFileMention, insertFileMentionAtSelection } from '@/components/chat/lexical/FileMentionPlugin';
 import { FileAutocomplete } from '@/components/chat/FileAutocomplete';
 import { useFileBrowserStore, type DirectoryEntry } from '@/stores/fileBrowserStore';
+import { toPosixPath } from '@/lib/utils';
 import path from 'path-browserify';
 
 // ============================================================================
@@ -364,11 +365,15 @@ function DropPlugin({
         if (!fileData.path || !effectiveCwd) return;
 
         // Validate path is within CWD
-        const rel = path.relative(effectiveCwd, fileData.path);
+        // Normalize to POSIX: on Windows `fileData.path` and `effectiveCwd`
+        // use `\` and path-browserify cannot handle them.
+        const cwdPosix = toPosixPath(effectiveCwd);
+        const filePosix = toPosixPath(fileData.path);
+        const rel = path.relative(cwdPosix, filePosix);
         if (rel.startsWith('..') || path.isAbsolute(rel)) return;
 
         const payload: FileMentionPayload = {
-          fileName: fileData.name || path.basename(fileData.path),
+          fileName: fileData.name || path.basename(filePosix),
           filePath: fileData.path,
           relativePath: rel,
         };
@@ -581,7 +586,9 @@ export function PromptInputEditor({
         return;
       }
 
-      const rel = path.relative(effectiveCwd, entry.path);
+      const cwdPosix = toPosixPath(effectiveCwd);
+      const entryPosix = toPosixPath(entry.path);
+      const rel = path.relative(cwdPosix, entryPosix);
       if (rel.startsWith('..') || path.isAbsolute(rel)) {
         setMentionQuery(null);
         setMentionAnchorRect(null);

--- a/src/renderer/components/file-browser/AddFilesModal.tsx
+++ b/src/renderer/components/file-browser/AddFilesModal.tsx
@@ -1,0 +1,126 @@
+import { useCallback, useState, type DragEvent } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Upload, Loader2 } from 'lucide-react'
+import { toast } from 'sonner'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogFooter,
+} from '@/components/ui/dialog'
+
+interface AddFilesModalProps {
+  open: boolean
+  onClose: () => void
+  projectId: string
+  onFilesAdded: () => void
+}
+
+export function AddFilesModal({ open, onClose, projectId, onFilesAdded }: AddFilesModalProps) {
+  const { t } = useTranslation('chat')
+  const [isDragOver, setIsDragOver] = useState(false)
+  const [isUploading, setIsUploading] = useState(false)
+
+  const handleDragOver = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(true)
+  }, [])
+
+  const handleDragLeave = useCallback((e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(false)
+  }, [])
+
+  const handleDrop = useCallback(async (e: DragEvent<HTMLDivElement>) => {
+    e.preventDefault()
+    e.stopPropagation()
+    setIsDragOver(false)
+
+    const files = Array.from(e.dataTransfer.files ?? [])
+    if (files.length === 0) return
+
+    const paths = files
+      .map((f) => window.levante.projects.getPathForFile(f))
+      .filter((p): p is string => !!p)
+
+    if (paths.length === 0) {
+      toast.error(t('chat_list.file_browser.add_modal.no_valid_paths'))
+      return
+    }
+
+    setIsUploading(true)
+    try {
+      const result = await window.levante.projects.addFilesWithPaths(projectId, paths)
+      if (result.success && result.data && result.data.length > 0) {
+        toast.success(t('chat_list.file_browser.add_modal.success', { count: result.data.length }))
+        onFilesAdded()
+        onClose()
+      } else if (!result.success) {
+        toast.error(result.error ?? t('chat_list.file_browser.add_modal.error_generic'))
+      }
+    } finally {
+      setIsUploading(false)
+    }
+  }, [projectId, onFilesAdded, onClose, t])
+
+  const handleBrowse = async () => {
+    setIsUploading(true)
+    try {
+      const result = await window.levante.projects.addFiles(projectId)
+      if (result.success && result.data && result.data.length > 0) {
+        toast.success(t('chat_list.file_browser.add_modal.success', { count: result.data.length }))
+        onFilesAdded()
+        onClose()
+      }
+    } finally {
+      setIsUploading(false)
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={(v) => { if (!v) onClose() }}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{t('chat_list.file_browser.add_modal.title')}</DialogTitle>
+          <DialogDescription>
+            {t('chat_list.file_browser.add_modal.description')}
+          </DialogDescription>
+        </DialogHeader>
+
+        <div
+          className={[
+            'relative flex aspect-square cursor-pointer flex-col items-center justify-center gap-3 rounded-lg border-2 border-dashed p-8 transition-colors',
+            isDragOver
+              ? 'border-primary bg-primary/5'
+              : 'border-muted-foreground/25 hover:border-muted-foreground/50',
+          ].join(' ')}
+          onDragOver={handleDragOver}
+          onDragLeave={handleDragLeave}
+          onDrop={handleDrop}
+        >
+          {isUploading ? (
+            <Loader2 className="h-10 w-10 animate-spin text-muted-foreground" />
+          ) : (
+            <>
+              <Upload className="h-10 w-10 text-muted-foreground" />
+              <p className="text-center text-sm text-muted-foreground">
+                {t('chat_list.file_browser.add_modal.drop_zone')}
+              </p>
+            </>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button variant="outline" className="w-full" onClick={handleBrowse} disabled={isUploading}>
+            {t('chat_list.file_browser.add_modal.browse')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/components/file-browser/FileBrowserContent.tsx
+++ b/src/renderer/components/file-browser/FileBrowserContent.tsx
@@ -1,9 +1,10 @@
 import { useEffect, useMemo, useState, useRef } from 'react';
-import { RefreshCw, Eye, EyeOff, FolderOpen, Loader2, FilePlus } from 'lucide-react';
+import { FolderOpen, Loader2, Upload } from 'lucide-react';
 import { Button } from '@/components/ui/button';
 import { useFileBrowserStore, type DirectoryEntry } from '@/stores/fileBrowserStore';
 import { useSidePanelStore } from '@/stores/sidePanelStore';
 import { FileTreeNode, getFileIcon } from './FileTreeNode';
+import { AddFilesModal } from './AddFilesModal';
 import { useTranslation } from 'react-i18next';
 
 interface FileBrowserContentProps {
@@ -112,15 +113,15 @@ export function FileBrowserContent({ searchQuery, cwd, projectId }: FileBrowserC
     entries,
     expandedDirs,
     isLoadingDir,
-    showHiddenFiles,
     error,
     initialize,
     toggleDirectory,
     refreshDirectory,
     applyExternalChanges,
-    setShowHidden,
     setError,
   } = useFileBrowserStore();
+
+  const [addFilesModalOpen, setAddFilesModalOpen] = useState(false);
 
   // Backend search state
   const [searchResults, setSearchResults] = useState<FileSearchResult[]>([]);
@@ -225,63 +226,29 @@ export function FileBrowserContent({ searchQuery, cwd, projectId }: FileBrowserC
     void openFileTab(entry.path);
   };
 
-  const handleAddFiles = async () => {
-    if (!projectId) return;
-    const result = await window.levante.projects.addFiles(projectId);
-    if (result.success && result.data && result.data.length > 0) {
-      refreshDirectory(cwd);
-    }
-  };
-
   const rootBasename = getBasename(cwd);
   const rootEntries = entries.get(cwd) ?? [];
   const isSearchMode = searchQuery.trim().length >= 2;
 
   return (
     <div className="flex flex-col">
-      <div className="flex items-center justify-between px-3 py-1.5 text-xs text-muted-foreground border-b">
-        <div className="flex items-center gap-1.5 truncate">
+      <div className="flex items-center gap-2 px-3 py-2 border-b">
+        <div className="flex items-center gap-1.5 truncate text-xs text-muted-foreground min-w-0 flex-1">
           <FolderOpen size={12} className="shrink-0" />
           <span className="truncate font-mono">/{rootBasename}</span>
         </div>
 
-        <div className="flex gap-0.5 shrink-0">
-          {projectId && (
-            <Button
-              size="icon"
-              variant="ghost"
-              className="h-5 w-5"
-              onClick={handleAddFiles}
-              title={t('chat_list.file_browser.add_files')}
-            >
-              <FilePlus size={12} />
-            </Button>
-          )}
-
+        {projectId && (
           <Button
-            size="icon"
-            variant="ghost"
-            className="h-5 w-5"
-            onClick={() => setShowHidden(!showHiddenFiles)}
-            title={
-              showHiddenFiles
-                ? t('chat_list.file_browser.hide_hidden')
-                : t('chat_list.file_browser.show_hidden')
-            }
+            variant="outline"
+            size="sm"
+            className="shrink-0 gap-2"
+            onClick={() => setAddFilesModalOpen(true)}
           >
-            {showHiddenFiles ? <EyeOff size={12} /> : <Eye size={12} />}
+            <Upload size={14} />
+            {t('chat_list.file_browser.add_files')}
           </Button>
-
-          <Button
-            size="icon"
-            variant="ghost"
-            className="h-5 w-5"
-            onClick={() => refreshDirectory(cwd)}
-            title={t('chat_list.file_browser.refresh')}
-          >
-            <RefreshCw size={12} />
-          </Button>
-        </div>
+        )}
       </div>
 
       {error && (
@@ -349,9 +316,9 @@ export function FileBrowserContent({ searchQuery, cwd, projectId }: FileBrowserC
                   variant="outline"
                   size="sm"
                   className="text-xs"
-                  onClick={handleAddFiles}
+                  onClick={() => setAddFilesModalOpen(true)}
                 >
-                  <FilePlus size={14} className="mr-1.5" />
+                  <Upload size={14} className="mr-1.5" />
                   {t('chat_list.file_browser.add_files')}
                 </Button>
               )}
@@ -370,6 +337,15 @@ export function FileBrowserContent({ searchQuery, cwd, projectId }: FileBrowserC
             </div>
           )}
         </>
+      )}
+
+      {projectId && (
+        <AddFilesModal
+          open={addFilesModalOpen}
+          onClose={() => setAddFilesModalOpen(false)}
+          projectId={projectId}
+          onFilesAdded={() => refreshDirectory(cwd)}
+        />
       )}
     </div>
   );

--- a/src/renderer/hooks/useModelSelection.ts
+++ b/src/renderer/hooks/useModelSelection.ts
@@ -12,10 +12,9 @@ import { modelService } from '@/services/modelService';
 import { getRendererLogger } from '@/services/logger';
 import { usePreference } from '@/hooks/usePreferences';
 import { usePlatformStore } from '@/stores/platformStore';
-import { loadSelectableModels, resolveStoredModelForCatalog } from '@/lib/selectableModels';
-import { isQualifiedModelRef } from '../../shared/modelRefs';
+import { useCatalogStore } from '@/stores/catalogStore';
+import { resolveStoredModelForCatalog } from '@/lib/selectableModels';
 import type { Model, GroupedModelsByProvider } from '../../types/models';
-import type { SelectableModelsResult } from '@/lib/selectableModels';
 
 const logger = getRendererLogger();
 
@@ -81,10 +80,6 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
   const { currentSession, onLoadUserName } = options;
 
   const [model, setModel] = useState<string>('');
-  const [availableModels, setAvailableModels] = useState<Model[]>([]);
-  const [groupedModelsByProvider, setGroupedModelsByProvider] = useState<GroupedModelsByProvider | null>(null);
-  const [modelsLoading, setModelsLoading] = useState(true);
-  const [catalog, setCatalog] = useState<SelectableModelsResult | null>(null);
 
   // Platform mode state
   const appMode = usePlatformStore(s => s.appMode);
@@ -99,7 +94,19 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
   const [lastUsedModel, setLastUsedModel] = usePreference('lastUsedModel');
   const [useOtherProviders] = usePreference('useOtherProviders');
 
-  const isHybridMode = isPlatformMode && (useOtherProviders ?? false);
+  // Catalog state from shared store (cached across mounts)
+  const catalog = useCatalogStore(s => s.result);
+  const catalogLoading = useCatalogStore(s => s.loading);
+  const ensureLoaded = useCatalogStore(s => s.ensureLoaded);
+
+  const availableModels = useMemo<Model[]>(
+    () => catalog?.availableModels ?? [],
+    [catalog]
+  );
+  const groupedModelsByProvider = useMemo<GroupedModelsByProvider | null>(
+    () => catalog?.groupedModelsByProvider ?? null,
+    [catalog]
+  );
 
   // Get current model info - search in grouped models if available, otherwise availableModels
   const currentModelInfo = useMemo(() => {
@@ -123,53 +130,37 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
     return filterModelsBySessionType(availableModels, currentSession);
   }, [availableModels, currentSession]);
 
-  // Load available models on component mount
+  // Ensure catalog is loaded for current params; cached across mounts in catalogStore.
   useEffect(() => {
-    // In platform mode, if the catalog is still idle or loading, signal loading to consumers
+    // In platform mode, wait until the platform catalog is resolved before
+    // computing the selectable-models catalog (otherwise we'd load with an
+    // empty platformModels list and then re-load once it arrives).
     if (isPlatformMode && (platformModelsLoadState === 'idle' || platformModelsLoadState === 'loading')) {
-      setModelsLoading(true);
-      return; // will re-run when platformModels / platformModelsLoadState changes
+      return;
     }
 
-    const loadModels = async () => {
-      setModelsLoading(true);
-      try {
-        const result = await loadSelectableModels({
-          appMode,
-          useOtherProviders: useOtherProviders ?? false,
-          platformModels,
-        });
+    ensureLoaded({
+      appMode,
+      useOtherProviders: useOtherProviders ?? false,
+      platformModels,
+    }).catch((error) => {
+      // ensureLoaded already logs; nothing else to do here.
+      logger.models.debug('ensureLoaded threw', {
+        error: error instanceof Error ? error.message : String(error),
+      });
+    });
+  }, [ensureLoaded, appMode, platformModels, platformModelsLoadState, useOtherProviders, isPlatformMode]);
 
-        setAvailableModels(result.availableModels);
-        setGroupedModelsByProvider(result.groupedModelsByProvider);
-        setCatalog(result);
-
-        logger.models.debug('Loaded models via selectableModels', {
-          count: result.availableModels.length,
-          grouped: result.groupedModelsByProvider?.totalModelCount ?? 0,
-          mode: appMode,
-          hybrid: isHybridMode,
-        });
-      } catch (error) {
-        logger.models.error('Failed to load models', {
-          error: error instanceof Error ? error.message : error
-        });
-      } finally {
-        setModelsLoading(false);
-      }
-    };
-
-    loadModels();
-
-    // Also load user name if callback provided
+  // Also load user name if callback provided (kept separate from catalog load)
+  useEffect(() => {
     if (onLoadUserName) {
       onLoadUserName();
     }
-  }, [onLoadUserName, appMode, platformModels, platformModelsLoadState, useOtherProviders, isHybridMode, isPlatformMode]);
+  }, [onLoadUserName]);
 
   // Auto-select model if only one is available OR use lastUsedModel when no model is selected
   useEffect(() => {
-    if (!modelsLoading && !model && !currentSession && catalog) {
+    if (!catalogLoading && !model && !currentSession && catalog) {
       let candidateModel = '';
 
       if (groupedModelsByProvider && groupedModelsByProvider.totalModelCount === 1) {
@@ -195,7 +186,7 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
         setModel(candidateModel);
       }
     }
-  }, [availableModels, groupedModelsByProvider, modelsLoading, model, currentSession, lastUsedModel, catalog]);
+  }, [availableModels, groupedModelsByProvider, catalogLoading, model, currentSession, lastUsedModel, catalog]);
 
   // Sync model with current session when session changes
   useEffect(() => {
@@ -261,8 +252,7 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
               model: newModelId
             });
             await modelService.setActiveProvider(newProviderId);
-            const models = await modelService.getAvailableModels();
-            setAvailableModels(models);
+            useCatalogStore.getState().invalidate('provider-sync');
           }
         } catch (err) {
           logger.models.error('Failed to auto-switch provider', {
@@ -322,12 +312,7 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
             model: newModelId
           });
           await modelService.setActiveProvider(newProviderId);
-
-          const models = await modelService.getAvailableModels();
-          setAvailableModels(models);
-
-          const grouped = await modelService.getAllProvidersWithSelectedModels();
-          setGroupedModelsByProvider(grouped);
+          useCatalogStore.getState().invalidate('provider-sync');
         }
       } catch (err) {
         logger.models.error('Failed to auto-switch provider', {
@@ -347,8 +332,8 @@ export function useModelSelection(options: UseModelSelectionOptions): UseModelSe
 
   // Effective loading / error: in platform mode, reflect catalog state
   const effectiveModelsLoading = isPlatformMode
-    ? modelsLoading || platformModelsLoading
-    : modelsLoading;
+    ? catalogLoading || platformModelsLoading
+    : catalogLoading;
 
   const effectiveModelsError = isPlatformMode ? platformModelsError : null;
   const effectiveRetryModels = isPlatformMode ? platformRetryModels : null;

--- a/src/renderer/lib/__tests__/utils.test.ts
+++ b/src/renderer/lib/__tests__/utils.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest';
+import { toPosixPath } from '../utils';
+
+describe('toPosixPath', () => {
+  it('converts Windows backslashes to forward slashes', () => {
+    expect(toPosixPath('C:\\Users\\saul\\file.xlsx')).toBe('C:/Users/saul/file.xlsx');
+  });
+
+  it('leaves POSIX paths unchanged', () => {
+    expect(toPosixPath('/Users/saul/file.xlsx')).toBe('/Users/saul/file.xlsx');
+  });
+
+  it('handles mixed separators', () => {
+    expect(toPosixPath('C:\\Users/saul\\file.xlsx')).toBe('C:/Users/saul/file.xlsx');
+  });
+});

--- a/src/renderer/lib/utils.ts
+++ b/src/renderer/lib/utils.ts
@@ -17,3 +17,12 @@ export function formatPathTail(filePath: string, segmentCount = 2): string {
 
   return `.../${segments.slice(-segmentCount).join('/')}`
 }
+
+/**
+ * Normalize a filesystem path to POSIX-style forward slashes.
+ * Required before passing Windows paths (with `\`) to `path-browserify`,
+ * which is POSIX-only and would otherwise misinterpret them.
+ */
+export function toPosixPath(p: string): string {
+  return p.replace(/\\/g, '/');
+}

--- a/src/renderer/locales/en/chat.json
+++ b/src/renderer/locales/en/chat.json
@@ -96,14 +96,20 @@
       "tab_chats": "Chats",
       "tab_files": "Files",
       "search_files_placeholder": "Search files...",
-      "show_hidden": "Show hidden files",
-      "hide_hidden": "Hide hidden files",
-      "refresh": "Refresh",
       "add_files": "Add files",
       "empty_directory": "Empty directory",
       "read_dir_error": "Failed to read directory",
       "searching": "Searching...",
-      "no_search_results": "No files found"
+      "no_search_results": "No files found",
+      "add_modal": {
+        "title": "Add files",
+        "description": "Drag and drop files into the project, or browse your computer.",
+        "drop_zone": "Drop files here",
+        "browse": "Browse",
+        "success": "{{count}} file(s) added",
+        "error_generic": "Could not add files",
+        "no_valid_paths": "No valid file paths detected"
+      }
     }
   },
   "project_page": {

--- a/src/renderer/locales/es/chat.json
+++ b/src/renderer/locales/es/chat.json
@@ -96,14 +96,20 @@
       "tab_chats": "Chats",
       "tab_files": "Archivos",
       "search_files_placeholder": "Buscar archivos...",
-      "show_hidden": "Mostrar archivos ocultos",
-      "hide_hidden": "Ocultar archivos ocultos",
-      "refresh": "Actualizar",
       "add_files": "Añadir archivos",
       "empty_directory": "Directorio vacío",
       "read_dir_error": "No se pudo leer el directorio",
       "searching": "Buscando...",
-      "no_search_results": "No se encontraron archivos"
+      "no_search_results": "No se encontraron archivos",
+      "add_modal": {
+        "title": "Añadir archivos",
+        "description": "Arrastra archivos al proyecto o búscalos en tu equipo.",
+        "drop_zone": "Arrastra archivos aquí",
+        "browse": "Buscar",
+        "success": "{{count}} archivo(s) añadidos",
+        "error_generic": "No se pudieron añadir los archivos",
+        "no_valid_paths": "No se detectaron rutas válidas"
+      }
     }
   },
   "project_page": {

--- a/src/renderer/stores/__tests__/fileBrowserStore.test.ts
+++ b/src/renderer/stores/__tests__/fileBrowserStore.test.ts
@@ -38,4 +38,43 @@ describe('fileBrowserStore helpers', () => {
     expect(next.has('/root/src/components')).toBe(false);
     expect(next.has('/root/docs')).toBe(true);
   });
+
+  it('handles Windows paths with backslashes', () => {
+    const loadedDirs = new Set([
+      'C:\\root',
+      'C:\\root\\src',
+      'C:\\root\\src\\components',
+    ]);
+
+    expect(
+      findNearestLoadedAncestor(
+        'C:\\root\\src\\components\\Button.tsx',
+        loadedDirs,
+        'C:\\root'
+      )
+    ).toBe('C:\\root\\src\\components');
+
+    expect(
+      findNearestLoadedAncestor(
+        'C:\\root\\src\\new\\Button.tsx',
+        loadedDirs,
+        'C:\\root'
+      )
+    ).toBe('C:\\root\\src');
+  });
+
+  it('removes the full cached subtree on Windows paths', () => {
+    const entries = new Map<string, DirectoryEntry[]>([
+      ['C:\\root', []],
+      ['C:\\root\\src', []],
+      ['C:\\root\\src\\components', []],
+      ['C:\\root\\docs', []],
+    ]);
+
+    const next = pruneEntriesSubtree(entries, 'C:\\root\\src');
+
+    expect(next.has('C:\\root\\src')).toBe(false);
+    expect(next.has('C:\\root\\src\\components')).toBe(false);
+    expect(next.has('C:\\root\\docs')).toBe(true);
+  });
 });

--- a/src/renderer/stores/catalogStore.ts
+++ b/src/renderer/stores/catalogStore.ts
@@ -1,0 +1,118 @@
+/**
+ * CatalogStore - Unified selectable-models catalog cache
+ *
+ * Wraps `loadSelectableModels` with:
+ * - Cache keyed by (appMode, useOtherProviders, platformModels fingerprint)
+ * - In-flight dedup so concurrent `ensureLoaded` calls share the same load
+ * - Explicit `invalidate(reason)` used by modelStore/platformStore after mutations
+ *
+ * Consumers subscribe to `result` / `loading` / `error` and call `ensureLoaded`
+ * from a single useEffect with their current params. Cache misses trigger a
+ * real load; hits return immediately.
+ */
+
+import { create } from 'zustand';
+import { loadSelectableModels, type SelectableModelsResult } from '@/lib/selectableModels';
+import { getRendererLogger } from '@/services/logger';
+import type { Model } from '../../types/models';
+
+const logger = getRendererLogger();
+
+export type CatalogLoadParams = {
+  appMode: 'platform' | 'standalone' | null;
+  useOtherProviders: boolean;
+  platformModels: Model[];
+};
+
+export type CatalogInvalidateReason =
+  | 'preference-change'
+  | 'provider-sync'
+  | 'platform-models'
+  | 'manual';
+
+interface CatalogState {
+  result: SelectableModelsResult | null;
+  loading: boolean;
+  error: string | null;
+  _inflight: Promise<SelectableModelsResult> | null;
+  _cacheKey: string | null;
+  _lastParams: CatalogLoadParams | null;
+
+  ensureLoaded: (params: CatalogLoadParams) => Promise<SelectableModelsResult>;
+  invalidate: (reason: CatalogInvalidateReason) => void;
+}
+
+function computeCacheKey(params: CatalogLoadParams): string {
+  const { appMode, useOtherProviders, platformModels } = params;
+  const len = platformModels.length;
+  const first = platformModels[0]?.id ?? '';
+  const last = platformModels[len - 1]?.id ?? '';
+  return `${appMode ?? 'null'}|${useOtherProviders ? '1' : '0'}|${len}:${first}:${last}`;
+}
+
+export const useCatalogStore = create<CatalogState>((set, get) => ({
+  result: null,
+  loading: false,
+  error: null,
+  _inflight: null,
+  _cacheKey: null,
+  _lastParams: null,
+
+  ensureLoaded: async (params) => {
+    const nextKey = computeCacheKey(params);
+    const state = get();
+
+    if (state._cacheKey === nextKey && state.result) {
+      return state.result;
+    }
+
+    if (state._inflight && state._cacheKey === nextKey) {
+      return state._inflight;
+    }
+
+    set({
+      loading: true,
+      error: null,
+      _cacheKey: nextKey,
+      _lastParams: params,
+    });
+
+    let loadPromise: Promise<SelectableModelsResult> | null = null;
+
+    const doLoad = async (): Promise<SelectableModelsResult> => {
+      try {
+        const result = await loadSelectableModels(params);
+        if (get()._cacheKey === nextKey) {
+          set({ result, loading: false, error: null });
+        }
+        return result;
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        logger.models.error('Failed to load selectable models (catalogStore)', { error: message });
+        if (get()._cacheKey === nextKey) {
+          set({ loading: false, error: message });
+        }
+        throw error;
+      } finally {
+        if (get()._inflight === loadPromise) {
+          set({ _inflight: null });
+        }
+      }
+    };
+
+    loadPromise = doLoad();
+    set({ _inflight: loadPromise });
+    return loadPromise;
+  },
+
+  invalidate: (reason) => {
+    const { _lastParams } = get();
+    logger.models.debug('Catalog invalidated', { reason, willReload: Boolean(_lastParams) });
+    set({ result: null, _cacheKey: null, error: null });
+    if (_lastParams) {
+      void get().ensureLoaded(_lastParams).catch(() => {
+        // ensureLoaded already logs — swallow to keep invalidate fire-and-forget.
+      });
+    }
+  },
+}));

--- a/src/renderer/stores/chatStore.ts
+++ b/src/renderer/stores/chatStore.ts
@@ -52,6 +52,7 @@ interface ChatStore {
 
   // Session actions
   refreshSessions: () => Promise<void>;
+  refreshProjectSessions: (projectId: string) => Promise<void>;
   createSession: (
     title?: string,
     model?: string,
@@ -177,7 +178,7 @@ export const useChatStore = create<ChatStore>()(
         set({ loading: true, error: null });
 
         try {
-          const result = await window.levante.db.sessions.list({});
+          const result = await window.levante.db.sessions.list({ limit: 100, offset: 0 });
 
           if (result.success && result.data) {
             logger.database.info('Sessions refreshed', {
@@ -201,6 +202,36 @@ export const useChatStore = create<ChatStore>()(
           const error = err instanceof Error ? err.message : 'Unknown error';
           logger.database.error('Error refreshing sessions', { error });
           console.error('[chatStore] refreshSessions failed:', err);
+          set({ error, loading: false });
+        }
+      },
+
+      refreshProjectSessions: async (projectId: string) => {
+        logger.database.debug('Refreshing project sessions', { projectId });
+        set({ loading: true, error: null });
+
+        try {
+          const result = await window.levante.projects.getSessions(projectId);
+
+          if (result.success && result.data) {
+            logger.database.info('Project sessions refreshed', {
+              projectId,
+              count: result.data.length,
+            });
+            set({ sessions: result.data, loading: false });
+          } else {
+            logger.database.error('Failed to refresh project sessions', {
+              projectId,
+              error: result.error,
+            });
+            set({
+              error: result.error || 'Failed to load project sessions',
+              loading: false,
+            });
+          }
+        } catch (err) {
+          const error = err instanceof Error ? err.message : 'Unknown error';
+          logger.database.error('Error refreshing project sessions', { projectId, error });
           set({ error, loading: false });
         }
       },
@@ -868,8 +899,3 @@ export const useChatStore = create<ChatStore>()(
     { name: 'chat-store' }
   )
 );
-
-// Export initialization function
-export const initializeChatStore = () => {
-  return useChatStore.getState().refreshSessions();
-};

--- a/src/renderer/stores/fileBrowserStore.ts
+++ b/src/renderer/stores/fileBrowserStore.ts
@@ -80,14 +80,12 @@ interface FileBrowserState {
 
   isLoadingDir: string | null;
   error: string | null;
-  showHiddenFiles: boolean;
 
   initialize: (cwd: string) => Promise<void>;
   loadDirectory: (dirPath: string) => Promise<void>;
   toggleDirectory: (dirPath: string) => void;
   refreshDirectory: (dirPath: string) => void;
   applyExternalChanges: (changes: FileSystemChange[]) => void;
-  setShowHidden: (show: boolean) => void;
   setError: (error: string | null) => void;
   clearError: () => void;
   reset: () => void;
@@ -100,7 +98,6 @@ export const useFileBrowserStore = create<FileBrowserState>((set, get) => ({
 
   isLoadingDir: null,
   error: null,
-  showHiddenFiles: false,
 
   initialize: async (cwd: string) => {
     if (!cwd?.trim()) {
@@ -138,7 +135,7 @@ export const useFileBrowserStore = create<FileBrowserState>((set, get) => ({
 
     try {
       const result = await window.levante.fs.readDir(dirPath, {
-        showHidden: get().showHiddenFiles,
+        showHidden: true,
         sortBy: 'type',
       });
 
@@ -226,17 +223,6 @@ export const useFileBrowserStore = create<FileBrowserState>((set, get) => ({
     }
   },
 
-  setShowHidden: (show: boolean) => {
-    set({ showHiddenFiles: show });
-
-    const dirs = Array.from(get().entries.keys());
-    set({ entries: new Map() });
-
-    for (const dir of dirs) {
-      void get().loadDirectory(dir);
-    }
-  },
-
   setError: (error: string | null) => {
     set({ error });
   },
@@ -252,7 +238,6 @@ export const useFileBrowserStore = create<FileBrowserState>((set, get) => ({
       expandedDirs: new Set(),
       isLoadingDir: null,
       error: null,
-      showHiddenFiles: false,
     });
   },
 }));

--- a/src/renderer/stores/fileBrowserStore.ts
+++ b/src/renderer/stores/fileBrowserStore.ts
@@ -6,6 +6,7 @@
 
 import path from 'path-browserify';
 import { create } from 'zustand';
+import { toPosixPath } from '../lib/utils';
 
 export interface DirectoryEntry {
   name: string;
@@ -35,11 +36,11 @@ export function pruneEntriesSubtree(
   subtreeRoot: string
 ): Map<string, DirectoryEntry[]> {
   const next = new Map(entries);
-  const normalizedRoot = subtreeRoot.replace(/\\/g, '/').replace(/\/+$/, '');
+  const normalizedRoot = toPosixPath(subtreeRoot).replace(/\/+$/, '');
   const prefix = `${normalizedRoot}/`;
 
   for (const key of next.keys()) {
-    const normalizedKey = key.replace(/\\/g, '/').replace(/\/+$/, '');
+    const normalizedKey = toPosixPath(key).replace(/\/+$/, '');
     if (normalizedKey === normalizedRoot || normalizedKey.startsWith(prefix)) {
       next.delete(key);
     }
@@ -53,14 +54,22 @@ export function findNearestLoadedAncestor(
   loadedDirs: Set<string>,
   workingDirectory: string
 ): string {
-  let current = candidatePath;
+  const wdPosix = toPosixPath(workingDirectory);
+  const loadedPosix = new Set<string>();
+  const posixToOriginal = new Map<string, string>();
+  for (const dir of loadedDirs) {
+    const p = toPosixPath(dir);
+    loadedPosix.add(p);
+    posixToOriginal.set(p, dir);
+  }
+  let current = toPosixPath(candidatePath);
 
   while (true) {
-    if (loadedDirs.has(current)) {
-      return current;
+    if (loadedPosix.has(current)) {
+      return posixToOriginal.get(current) ?? current;
     }
 
-    if (current === workingDirectory) {
+    if (current === wdPosix) {
       return workingDirectory;
     }
 

--- a/src/renderer/stores/modelStore.ts
+++ b/src/renderer/stores/modelStore.ts
@@ -1,6 +1,11 @@
 import { create } from 'zustand';
 import { modelService } from '@/services/modelService';
+import { useCatalogStore } from '@/stores/catalogStore';
 import type { ProviderConfig, Model } from '../../types/models';
+
+function invalidateCatalog(): void {
+  useCatalogStore.getState().invalidate('provider-sync');
+}
 
 interface ModelState {
   // State
@@ -42,6 +47,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
       const providers = modelService.getProviders();
       const activeProvider = await modelService.getActiveProvider();
       set({ providers, activeProvider });
+      invalidateCatalog();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to initialize model service';
       set({ error: errorMessage });
@@ -61,6 +67,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
         providers,
         activeProvider
       });
+      invalidateCatalog();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to switch provider';
       set({ error: errorMessage });
@@ -74,12 +81,13 @@ export const useModelStore = create<ModelState>((set, get) => ({
       await modelService.updateProvider(providerId, updates);
       const providers = modelService.getProviders();
       const activeProvider = await modelService.getActiveProvider();
-      set({ 
-        providers, 
+      set({
+        providers,
         activeProvider,
         success: 'Provider updated successfully'
       });
-      
+      invalidateCatalog();
+
       // Clear success message after 3 seconds
       setTimeout(() => set({ success: null }), 3000);
     } catch (error) {
@@ -95,12 +103,13 @@ export const useModelStore = create<ModelState>((set, get) => ({
       await modelService.syncProviderModels(providerId);
       const providers = modelService.getProviders();
       const activeProvider = await modelService.getActiveProvider();
-      set({ 
-        providers, 
+      set({
+        providers,
         activeProvider,
         success: 'Models synced successfully'
       });
-      
+      invalidateCatalog();
+
       // Clear success message after 3 seconds
       setTimeout(() => set({ success: null }), 3000);
     } catch (error) {
@@ -119,6 +128,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
       const providers = modelService.getProviders();
       const activeProvider = await modelService.getActiveProvider();
       set({ providers, activeProvider });
+      invalidateCatalog();
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Failed to update model selection';
       set({ error: errorMessage });
@@ -134,17 +144,18 @@ export const useModelStore = create<ModelState>((set, get) => ({
       const activeProvider = await modelService.getActiveProvider();
       const isSelectAll = Object.values(selections).every(selected => selected);
       const isDeselectAll = Object.values(selections).every(selected => !selected);
-      
+
       let successMessage = 'Model selections updated';
       if (isSelectAll) successMessage = 'All models selected';
       else if (isDeselectAll) successMessage = 'All models deselected';
-      
-      set({ 
-        providers, 
+
+      set({
+        providers,
         activeProvider,
         success: successMessage
       });
-      
+      invalidateCatalog();
+
       // Clear success message after 2 seconds
       setTimeout(() => set({ success: null }), 2000);
     } catch (error) {
@@ -165,6 +176,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
         activeProvider,
         success: `Model "${model.name}" added successfully`
       });
+      invalidateCatalog();
 
       // Clear success message after 3 seconds
       setTimeout(() => set({ success: null }), 3000);
@@ -187,6 +199,7 @@ export const useModelStore = create<ModelState>((set, get) => ({
         activeProvider,
         success: 'Model removed successfully'
       });
+      invalidateCatalog();
 
       // Clear success message after 3 seconds
       setTimeout(() => set({ success: null }), 3000);

--- a/src/renderer/stores/platformStore.ts
+++ b/src/renderer/stores/platformStore.ts
@@ -14,6 +14,11 @@ import type { AppMode, PlatformUser, PlatformStatus } from '../../types/userProf
 import type { Model } from '../../types/models';
 import { getRendererLogger } from '@/services/logger';
 import { useOAuthStore } from './oauthStore';
+import { useCatalogStore } from './catalogStore';
+
+function invalidateCatalog(): void {
+  useCatalogStore.getState().invalidate('platform-models');
+}
 
 const logger = getRendererLogger();
 
@@ -144,9 +149,11 @@ export const usePlatformStore = create<PlatformState>((set, get) => ({
             models: [],
             modelsLoadState: 'idle',
           });
+          invalidateCatalog();
         }
       } else if (appMode === 'standalone') {
         set({ appMode: 'standalone', isAuthenticated: false });
+        invalidateCatalog();
       }
     } catch (error) {
       logger.core.error('Failed to initialize platform store', {
@@ -216,6 +223,7 @@ export const usePlatformStore = create<PlatformState>((set, get) => ({
         lastModelsLoadedAt: null,
         hasLoadedModelsOnce: false,
       });
+      invalidateCatalog();
     } catch (error) {
       logger.core.error('Platform logout failed', {
         error: error instanceof Error ? error.message : error,
@@ -243,6 +251,7 @@ export const usePlatformStore = create<PlatformState>((set, get) => ({
         lastModelsLoadedAt: null,
         hasLoadedModelsOnce: false,
       });
+      invalidateCatalog();
     } catch (error) {
       logger.core.error('Failed to set standalone mode', {
         error: error instanceof Error ? error.message : error,
@@ -276,6 +285,7 @@ export const usePlatformStore = create<PlatformState>((set, get) => ({
             lastModelsLoadedAt: null,
             hasLoadedModelsOnce: false,
           });
+          invalidateCatalog();
         }
       }
     } catch (error) {
@@ -353,6 +363,7 @@ export const usePlatformStore = create<PlatformState>((set, get) => ({
               lastModelsLoadedAt: Date.now(),
               hasLoadedModelsOnce: true,
             });
+            invalidateCatalog();
 
             logger.core.info('Platform catalog loaded', {
               reason,


### PR DESCRIPTION
## Summary

Branch bundles five commits on top of `develop`: two file-browser fixes, a sidebar project-scope fix, a model catalog refactor, and a small cleanup in `getProviderType`.

---

## 1. `feat(file-browser): replace header icons with Add files modal` (0652c42)

**Why:** The sidebar file-browser header had three inline controls (hidden-files toggle, manual refresh, add-files icon) that were noisy and duplicated behavior.

**Changes**
- Remove the show/hide hidden files toggle — hidden files are always shown.
- Remove the manual refresh icon.
- Replace the inline \"add files\" icon with a dedicated **Add files** button next to the root label that opens a new `AddFilesModal`.
- `AddFilesModal` offers a drop zone + native file picker (`webUtils.getPathForFile`) and posts the selected paths back to the store.
- Adds `projectHandlers.addFilesWithPaths` + preload wiring so the modal can pass explicit paths (needed for the drop-zone case).
- i18n: new `chat.file_browser.add_files_modal.*` keys in `en`/`es`.
- New test coverage in `fileBrowserStore.test.ts`.

## 2. `fix(sidebar): list all project chats when entering project scope` (3448031)

**Why:** The sidebar fetched a global top-50 via `db.sessions.list({})` and then filtered by `project_id` on the client. If a project's chats fell outside that top-50 window, entering the project would show only a subset — while `ProjectPage` (which queries `projects.getSessions` without `LIMIT`) showed all of them.

**Changes**
- `chatStore`:
  - New action `refreshProjectSessions(projectId)` that calls `window.levante.projects.getSessions(projectId)` and replaces `state.sessions`.
  - `refreshSessions()` now passes `{ limit: 100, offset: 0 }` explicitly instead of relying on the backend's silent default of 50.
  - Removed `initializeChatStore` (replaced by the scope-aware effect below).
- `App.tsx`:
  - Removed `initializeChatStore()` from the startup `Promise.all`.
  - Added a `useEffect` keyed on `selectedProject?.id` that dispatches the right refresh (project scope vs global). Single source of truth for what populates the sidebar.

Session mutations (`createSession`, `deleteSession`, `updateSessionTitle`) already update `state.sessions` via `set(...)` directly, so no scope-aware invalidation is needed at those call sites.

## 3. `fix(ai): drop redundant fallback in getProviderType` (ac4ed39)

**Why:** `resolveModelTarget` already handles qualified refs, legacy raw refs, standalone, platform-pure, and platform-hybrid modes. The manual fallback that re-scanned `preferencesService.providers` duplicated that logic and silently masked real errors (corrupted refs, deleted providers).

**Changes**
- Replace the catch-and-rescan branch with a single `try + warn + return undefined`.
- Drop the dynamic `preferencesService` import from the hot path.

Refs: #231

## 4. `refactor(models): move selectable-models catalog to Zustand cache` (d67d500)

**Why:** `useModelSelection` held the unified `SelectableModelsResult` in local state, recomputing on every consumer mount. Fast navigation between chat/settings or between sessions caused flicker and overlapping loads.

**Changes**
- New `catalogStore` (Zustand):
  - `ensureLoaded(params)` caches by `(appMode, useOtherProviders, platformModels fingerprint)`.
  - Dedupes concurrent loads via `_inflight`.
  - Only commits results if the cache key still matches at resolution time (prevents stale writes after provider switches).
  - `invalidate(reason)` clears the cache and auto-reloads with the last known params.
- `useModelSelection` subscribes to the store and derives `availableModels` / `groupedModelsByProvider` via `useMemo`. Local `useState` + load effect removed. `handleModelChange` now invalidates after `modelService.setActiveProvider` instead of mutating two local arrays.
- `modelStore` invalidates on every provider mutation: `initialize`, `setActiveProvider`, `updateProvider`, `syncProviderModels`, `toggleModelSelection`, `setSelectedModels`, add/remove user model.
- `platformStore` invalidates after `ensureModelsLoaded` completes, on logout, on `setStandaloneMode`, on session-invalidated `refreshStatus`, and on unauthenticated/standalone init.

Refs: #231

## 5. `fix(file-browser): normalize Windows paths before path-browserify` (7648f32)

**Why:** `path-browserify` is POSIX-only. Windows paths with backslashes were breaking `findNearestLoadedAncestor`, `pruneEntriesSubtree`, and the drop/mention handlers in `PromptInputEditor`.

**Changes**
- New shared `toPosixPath` helper in `src/renderer/lib/utils.ts` with unit tests.
- Apply it before any `path.*` call; original path strings are preserved for keys and UI so POSIX-style separators don't leak back into Windows state.

---

## Test plan

- [ ] **Sidebar scope:** with >50 total sessions and a project whose chats fall outside the global top-50, open the project from the sidebar and confirm all its chats are listed (parity with ProjectPage, same order by `updated_at DESC`).
- [ ] Create / rename / delete a chat while inside a project scope; confirm the sidebar updates without reverting to the global top-50.
- [ ] Exit the project (\"Todos los chats\") and confirm the global paginated list returns without duplicates or gaps.
- [ ] **File browser:** open the new Add files modal, add files via drop zone and via native picker; confirm both paths register in the project.
- [ ] **Windows:** drop a file with backslash paths onto the chat input and into the file browser; confirm `toPosixPath` handles it and no ancestor-resolution errors appear.
- [ ] **Model catalog:** switch rapidly between chat/settings and between sessions; confirm no flicker and no duplicate catalog fetches (check network / provider logs).
- [ ] Toggle providers on/off, add/remove user models, switch platform ↔ standalone; confirm the catalog invalidates and the model dropdown reflects the change.
- [ ] `pnpm typecheck` passes (verified locally). `pnpm lint` is broken repo-wide due to ESLint v9 missing `eslint.config.js` — pre-existing, not from this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)