### PR TITLE
fix(cowork): skip ensuring-python toast when already installed

### DIFF
--- a/src/main/services/runtime/__tests__/coworkPrerequisites.test.ts
+++ b/src/main/services/runtime/__tests__/coworkPrerequisites.test.ts
@@ -82,6 +82,25 @@ describe('ensureCoworkPrerequisites', () => {
     expect(steps).not.toContain('installing-gitbash');
   });
 
+  it('skips ensuring-python when a managed Python is already on disk', async () => {
+    setPlatform('darwin');
+    const findLevanteRuntime = vi.fn((type: string) =>
+      type === 'python' ? '/levante/runtimes/python/3.13.0/python/bin/python3' : null
+    );
+    const ensureRuntime = vi.fn();
+    const rm = makeRuntimeManager({ findLevanteRuntime, ensureRuntime });
+
+    const steps: CoworkPrereqStep[] = [];
+    const result = await ensureCoworkPrerequisites(rm, makeLogger(), {
+      onProgress: (s) => steps.push(s),
+    });
+
+    expect(result.pythonPath).toBe('/levante/runtimes/python/3.13.0/python/bin/python3');
+    expect(ensureRuntime).not.toHaveBeenCalled();
+    expect(steps).not.toContain('ensuring-python');
+    expect(steps).toContain('ready');
+  });
+
   it('on win32 falls through system → managed → install', async () => {
     setPlatform('win32');
     const detectSystemRuntime = vi.fn(async () => null);
@@ -112,7 +131,7 @@ describe('ensureCoworkPrerequisites', () => {
   it('on darwin skips gitbash entirely', async () => {
     setPlatform('darwin');
     const detectSystemRuntime = vi.fn();
-    const findLevanteRuntime = vi.fn();
+    const findLevanteRuntime = vi.fn(() => null);
     const ensureRuntime = vi.fn(async () => '/py/python3');
     const rm = makeRuntimeManager({
       detectSystemRuntime,
@@ -123,7 +142,9 @@ describe('ensureCoworkPrerequisites', () => {
     const result = await ensureCoworkPrerequisites(rm, makeLogger());
 
     expect(detectSystemRuntime).not.toHaveBeenCalled();
-    expect(findLevanteRuntime).not.toHaveBeenCalled();
+    // findLevanteRuntime is consulted for Python (to skip progress events
+    // when it's already cached) but never for gitbash on non-Windows.
+    expect(findLevanteRuntime).not.toHaveBeenCalledWith('gitbash', expect.any(String));
     expect(result.shellPath).toBeNull();
     expect(ensureRuntime).toHaveBeenCalledWith(
       expect.objectContaining({ type: 'python' })

--- a/src/main/services/runtime/coworkPrerequisites.ts
+++ b/src/main/services/runtime/coworkPrerequisites.ts
@@ -94,17 +94,26 @@ export async function ensureCoworkPrerequisites(
 
     // Python: pre-provision on every platform so skill-creator and
     // Python-based MCPs work out of the box on first Cowork entry.
-    onProgress('ensuring-python', { version: DEFAULT_PYTHON_VERSION });
-    let pythonPath: string | null = null;
-    try {
-        pythonPath = await runtimeManager.ensureRuntime({
-            type: 'python',
-            version: DEFAULT_PYTHON_VERSION,
-        });
-    } catch (err) {
-        const message = err instanceof Error ? err.message : String(err);
-        warnings.push(`No se pudo preparar Python: ${message}`);
-        logger.core.warn('Cowork prereq: python provisioning failed', { err: message });
+    //
+    // Only emit `ensuring-python` progress when we're actually going to
+    // download/install. If a Levante-managed Python is already on disk,
+    // reuse it silently so subsequent app launches don't flash a toast.
+    let pythonPath: string | null = runtimeManager.findLevanteRuntime(
+        'python',
+        DEFAULT_PYTHON_VERSION
+    );
+    if (!pythonPath) {
+        onProgress('ensuring-python', { version: DEFAULT_PYTHON_VERSION });
+        try {
+            pythonPath = await runtimeManager.ensureRuntime({
+                type: 'python',
+                version: DEFAULT_PYTHON_VERSION,
+            });
+        } catch (err) {
+            const message = err instanceof Error ? err.message : String(err);
+            warnings.push(`No se pudo preparar Python: ${message}`);
+            logger.core.warn('Cowork prereq: python provisioning failed', { err: message });
+        }
     }
 
     onProgress('ready');


### PR DESCRIPTION
## Summary
- Skip emitting the `ensuring-python` progress event when a Levante-managed Python runtime already exists on disk
- Eliminates the brief toast flash on app restarts when Python was previously cached
- Keeps the original install flow intact for first-time Cowork entry

## Test plan
- [x] `pnpm test` — 6 unit tests pass for `ensureCoworkPrerequisites`
- [x] `pnpm typecheck` — clean (only pre-existing sharp errors)
- [ ] Manual: launch app with `~/levante/runtimes/python/<version>/` present → no toast
- [ ] Manual: first launch (no managed Python) → `ensuring-python` toast appears and resolves to `ready`

🤖 Generated with [Claude Code](https://claude.com/claude-code)