### PR TITLE
chore(release): v1.8.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "levante",
-  "version": "1.8.1-beta.3",
+  "version": "1.8.2",
   "description": "A friendly, private desktop chat app with AI and MCP integration",
   "main": ".vite/build/main.js",
   "homepage": "https://github.com/minte-community/levante",

--- a/src/main/services/ai/__tests__/toolMessageSanitizer.test.ts
+++ b/src/main/services/ai/__tests__/toolMessageSanitizer.test.ts
@@ -378,4 +378,62 @@ describe('sanitizeMessagesForModel', () => {
     expect(part.output.content).toEqual([{ type: 'text', text: 'hi' }]);
     expect(part.output.uiResources).toBeUndefined();
   });
+
+  it('preserves coding tool plain-object outputs (bash) untouched', () => {
+    const output = {
+      status: 'success',
+      exitCode: 0,
+      output: 'hello\nworld',
+      truncated: false,
+    };
+
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart({ state: 'output-available', output }),
+      ]),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+    const part = result[0].parts[0] as any;
+
+    expect(part.output).toEqual(output);
+  });
+
+  it('preserves read-tool plain object with content as string', () => {
+    const output = {
+      success: true,
+      content: 'string contents',
+      totalLines: 50,
+    };
+
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart({ state: 'output-available', output }),
+      ]),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+    const part = result[0].parts[0] as any;
+
+    expect(part.output).toEqual(output);
+  });
+
+  it('preserves grep tool empty-match output', () => {
+    const output = {
+      success: true,
+      matches: 0,
+      message: 'No matches found',
+    };
+
+    const messages: UIMessage[] = [
+      makeAssistantMessage([
+        makeToolPart({ state: 'output-available', output }),
+      ]),
+    ];
+
+    const result = sanitizeMessagesForModel(messages);
+    const part = result[0].parts[0] as any;
+
+    expect(part.output).toEqual(output);
+  });
 });

--- a/src/main/services/ai/toolMessageSanitizer.ts
+++ b/src/main/services/ai/toolMessageSanitizer.ts
@@ -137,7 +137,15 @@ export function sanitizeMessagesForModel(messages: UIMessage[]): UIMessage[] {
           return part;
         }
 
-        if (output && typeof output === 'object') {
+        const isLegacyMcpUiOutput =
+          output && typeof output === 'object' && (
+            'uiResources' in output ||
+            'images' in output ||
+            (Array.isArray((output as any).content) &&
+              (output as any).content.some((c: any) => c?.type === 'image'))
+          );
+
+        if (isLegacyMcpUiOutput) {
           const cleanOutput: Record<string, unknown> = {};
 
           if ((output as any).structuredContent) {


### PR DESCRIPTION
## Summary
- Bump version `1.8.1` → `1.8.2` for the new release.
- Includes the follow-up fix from develop: scope the legacy MCP-UI tool output sanitizer so it no longer rewrites modern canonical tool payloads (a16e5c4).

## Commits
- `a16e5c4` fix(ai): scope tool output sanitizer to legacy MCP-UI payloads
- `2820635` chore(release): v1.8.2

## Test plan
- [ ] `pnpm install` succeeds with the bumped version
- [ ] `pnpm build` (typecheck + bundle) passes
- [ ] Smoke test MCP tool calls in a chat — modern tool results render unchanged, legacy MCP-UI payloads still sanitized
- [ ] Installer/package step produces `levante-1.8.2` artifacts

🤖 Generated with [Claude Code](https://claude.com/claude-code)